### PR TITLE
Add release bundle verification helper

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Build extension image
         run: docker build -t openclaw-docker-extension:test .
+
+      - name: Verify release bundle wiring
+        run: make verify-release-bundle RELEASE_TAG=v0.0.0-ci

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ update-release:
 verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
 
+verify-release-bundle:
+	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-bundle.sh
+
 verify-release-install: ; @RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-install.sh
 
 publish-release:
@@ -51,4 +54,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag verify-release-install publish-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag verify-release-bundle verify-release-install publish-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Use these commands depending on where you are in the flow:
 - `make update-extension`: rebuild both local images and refresh an existing local install
 - `make publish-release RELEASE_TAG=vX.Y.Z`: maintainer step to publish the GitHub release for an existing tag
 - `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release and both GHCR tags exist
+- `make verify-release-bundle RELEASE_TAG=vX.Y.Z`: maintainer check that a release extension build points at the matching GHCR runtime image
 - `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image
@@ -52,6 +53,14 @@ Maintainer preflight for a newly published tag:
 make verify-release-tag RELEASE_TAG=vX.Y.Z
 ```
 
+Local maintainer check before publishing a new tag:
+
+```bash
+make verify-release-bundle RELEASE_TAG=vX.Y.Z
+```
+
+That build-time check proves the extension bundle is wired to the matching GHCR runtime tag instead of falling back to the local dev runtime image.
+
 That check verifies all three requirements for the documented install path:
 
 - the GitHub release exists for the tag
@@ -61,6 +70,7 @@ That check verifies all three requirements for the documented install path:
 If the tag exists but the GitHub release is still missing, publish it first:
 
 ```bash
+make verify-release-bundle RELEASE_TAG=vX.Y.Z
 make publish-release RELEASE_TAG=vX.Y.Z
 make verify-release-tag RELEASE_TAG=vX.Y.Z
 ```

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -eu
+
+release_tag="${1:-${RELEASE_TAG:-}}"
+repo_owner="${REPO_OWNER:-jcowhigjr}"
+ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+verify_image="${VERIFY_IMAGE:-openclaw-docker-extension-release-check}"
+verify_tag="${VERIFY_TAG:-${release_tag:-check}}"
+dry_run="${DRY_RUN:-0}"
+
+if [ -z "$release_tag" ]; then
+  echo "RELEASE_TAG is required, for example: make verify-release-bundle RELEASE_TAG=v0.1.0" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker CLI is required for release-bundle verification." >&2
+  exit 1
+fi
+
+expected_runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
+image_ref="${verify_image}:${verify_tag}"
+
+if [ "$dry_run" = "1" ]; then
+  echo "dry run: docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=${expected_runtime_image} --tag ${image_ref} ."
+  echo "dry run: docker create ${image_ref}"
+  echo "dry run: docker cp <container>:/ui <tmpdir>/ui"
+  echo "dry run: grep -R -F ${expected_runtime_image} <tmpdir>/ui"
+  exit 0
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker Desktop must be running before verifying a release bundle." >&2
+  echo "Next step: start Docker Desktop and rerun make verify-release-bundle RELEASE_TAG=${release_tag}" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+container_id=""
+
+cleanup() {
+  if [ -n "$container_id" ]; then
+    docker rm -f "$container_id" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT INT TERM
+
+docker build \
+  --build-arg "VITE_DEFAULT_RUNTIME_IMAGE=${expected_runtime_image}" \
+  --tag "$image_ref" \
+  .
+
+container_id="$(docker create "$image_ref")"
+docker cp "${container_id}:/ui" "${tmpdir}/ui" >/dev/null
+
+if ! grep -R -F "$expected_runtime_image" "${tmpdir}/ui" >/dev/null 2>&1; then
+  echo "Release bundle verification failed: ${image_ref} does not contain ${expected_runtime_image}" >&2
+  echo "Next step: confirm the Docker build arg is wired through the UI build and extension image." >&2
+  exit 1
+fi
+
+cat <<EOF
+Release bundle verification passed:
+  extension image: ${image_ref}
+  bundled runtime default: ${expected_runtime_image}
+
+Next maintainer steps:
+  make publish-release RELEASE_TAG=${release_tag}
+  make verify-release-tag RELEASE_TAG=${release_tag}
+EOF


### PR DESCRIPTION
## Summary
- add a maintainer verifier that builds the extension and proves the bundled runtime default matches the requested GHCR release tag
- wire the verifier into `make` and the build workflow so release-path regressions fail earlier
- document the new pre-publish check in the README release flow

## Testing
- `make verify-release-bundle RELEASE_TAG=v0.1.0-test`

Contributes to #3