### PR TITLE
Tighten Docker publish context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the extension publish context limited to the files the Dockerfile copies.
+**
+
+!.dockerignore
+!Dockerfile
+!docker-compose.yaml
+!metadata.json
+!openclaw.svg
+!ui/
+!ui/index.html
+!ui/package-lock.json
+!ui/package.json
+!ui/src/
+!ui/src/**
+!ui/tsconfig.json
+!ui/tsconfig.node.json
+!ui/vite-env.d.ts
+!ui/vite.config.ts
+
+# Exclude generated or local-only UI artifacts from the allowed tree above.
+ui/build/
+ui/node_modules/


### PR DESCRIPTION
## Summary
- add a strict allowlist `.dockerignore` for the extension image build context
- exclude repo-only assets like `.git`, docs, scripts, runtime files, and `ui/node_modules` from GHCR publish builds
- keep the context aligned with the exact files copied by the Dockerfile

## Verification
- `docker build --progress=plain -t openclaw-docker-extension:test .`
  - resulting build context: `110.97kB`

Contributes to #3