### PR TITLE
Add maintainer release shipping helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ verify-release-install: ; @RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER
 publish-release:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" DRY_RUN="$(DRY_RUN)" ./scripts/publish-release.sh
 
+ship-release:
+	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/ship-release.sh
+
 uninstall:
 	docker extension rm $(IMAGE)
 
@@ -54,4 +57,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag verify-release-bundle verify-release-install publish-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Use these commands depending on where you are in the flow:
 - `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release and both GHCR tags exist
 - `make verify-release-bundle RELEASE_TAG=vX.Y.Z`: maintainer check that a release extension build points at the matching GHCR runtime image
 - `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image
+- `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer path that publishes the GitHub release if needed, verifies the GHCR tags, then validates Docker Desktop install/uninstall
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image
 - `make uninstall`: remove the extension from Docker Desktop
@@ -67,7 +68,13 @@ That check verifies all three requirements for the documented install path:
 - both GHCR image tags exist
 - both GHCR packages are public to anonymous users
 
-If the tag exists but the GitHub release is still missing, publish it first:
+If you want the full maintainer handoff in one command after the tag is published to GHCR:
+
+```bash
+make ship-release RELEASE_TAG=vX.Y.Z
+```
+
+If you want to run the same steps one by one, or the tag exists but the GitHub release is still missing:
 
 ```bash
 make verify-release-bundle RELEASE_TAG=vX.Y.Z

--- a/scripts/ship-release.sh
+++ b/scripts/ship-release.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -eu
+
+release_tag="${1:-${RELEASE_TAG:-}}"
+repo_owner="${REPO_OWNER:-jcowhigjr}"
+repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
+ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+dry_run="${DRY_RUN:-0}"
+
+if [ -z "$release_tag" ]; then
+  echo "RELEASE_TAG is required, for example: make ship-release RELEASE_TAG=v0.1.0" >&2
+  exit 1
+fi
+
+run_step() {
+  step_label="$1"
+  shift
+
+  echo "==> ${step_label}"
+  "$@"
+}
+
+run_step "Publish GitHub release if needed" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" DRY_RUN="$dry_run" \
+  ./scripts/publish-release.sh
+
+run_step "Verify GitHub release and GHCR tags" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" \
+  ./scripts/verify-release-tag.sh
+
+run_step "Validate Docker Desktop install/uninstall" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DRY_RUN="$dry_run" \
+  ./scripts/verify-release-install.sh
+
+cat <<EOF
+Release shipping flow completed for ${release_tag}
+
+End-user install command:
+  docker extension install ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}
+EOF

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -34,6 +34,19 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
+resolve_package_owner_scope() {
+  package_name="$1"
+
+  for owner_scope in users orgs; do
+    if gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}" >/dev/null 2>&1; then
+      echo "$owner_scope"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 require_release() {
   if gh api "/repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}" >/dev/null 2>&1; then
     echo "release exists: ${release_tag}"
@@ -54,8 +67,15 @@ require_release() {
 require_package_tag() {
   package_name="$1"
   image_name="$2"
+  owner_scope="$(resolve_package_owner_scope "$package_name" || true)"
 
-  if gh api "/users/${ghcr_owner}/packages/container/${package_name}/versions?per_page=100" \
+  if [ -z "$owner_scope" ]; then
+    echo "ghcr package details unavailable: ghcr.io/${ghcr_owner}/${image_name}" >&2
+    echo "Next step: confirm the package exists under ${ghcr_owner} and is visible to GitHub Packages." >&2
+    return 1
+  fi
+
+  if gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}/versions?per_page=100" \
     --paginate \
     --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${release_tag}\")) | .id" \
     | grep -q '.'; then
@@ -71,8 +91,15 @@ require_package_tag() {
 require_package_public() {
   package_name="$1"
   image_name="$2"
+  owner_scope="$(resolve_package_owner_scope "$package_name" || true)"
 
-  visibility="$(gh api "/users/${ghcr_owner}/packages/container/${package_name}" --jq '.visibility' 2>/dev/null || true)"
+  if [ -z "$owner_scope" ]; then
+    echo "ghcr package details unavailable: ghcr.io/${ghcr_owner}/${image_name}" >&2
+    echo "Next step: confirm the package exists under ${ghcr_owner} and is visible to GitHub Packages." >&2
+    return 1
+  fi
+
+  visibility="$(gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}" --jq '.visibility' 2>/dev/null || true)"
 
   if [ "$visibility" = "public" ]; then
     echo "ghcr package is public: ghcr.io/${ghcr_owner}/${image_name}"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -6,10 +6,22 @@ release_tag="${1:-${RELEASE_TAG:-}}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+dry_run="${DRY_RUN:-0}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-tag RELEASE_TAG=v0.1.0" >&2
   exit 1
+fi
+
+if [ "$dry_run" = "1" ]; then
+  cat <<EOF
+dry run: gh api /repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}
+dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension/versions?per_page=100 --paginate
+dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension
+dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension-runtime/versions?per_page=100 --paginate
+dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension-runtime
+EOF
+  exit 0
 fi
 
 if ! command -v gh >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add `make ship-release` and `scripts/ship-release.sh` so the maintainer GHCR handoff runs in the documented order
- make `verify-release-tag` support `DRY_RUN=1` so the full ship path is testable before a real publish
- let `verify-release-tag` resolve GHCR packages under either a user or organization owner before checking tags and public visibility
- document the one-command maintainer handoff in the README release path

## Testing
- `sh -n scripts/ship-release.sh scripts/publish-release.sh scripts/verify-release-tag.sh scripts/verify-release-install.sh`
- `make ship-release RELEASE_TAG=v0.1.0-user-verified DRY_RUN=1`
- stubbed `gh` run that exercises the organization-owner GHCR path in `scripts/verify-release-tag.sh`

Contributes to #3
