### PR TITLE
Clarify the extension's isolation boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ This means the credential survives container restarts and rebuilds, but is remov
 ## Security and isolation notes
 
 - The wrapper publishes OpenClaw on `127.0.0.1` only.
-- State is stored in the named Docker volume `openclaw-docker-extension-home`.
+- OpenClaw starts through the upstream image entrypoint and runs as the `node` user, while the wrapper image adds a small `socat` bridge so Docker Desktop can forward the service on macOS.
+- State, including the write-only Anthropic key saved by the extension UI, is stored in the named Docker volume `openclaw-docker-extension-home`.
+- The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability, the service retains writable state in its volume, and this repo has not finished a read-only-filesystem or dropped-capability pass.
 - This is a more isolated local packaging path, not a perfect security boundary.
 - This project is not an official Docker or OpenClaw extension.
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -563,6 +563,11 @@ fs.chmodSync(path, 0o600);
           </Typography>
         </Box>
 
+        <Alert severity="info">
+          This is a more isolated local wrapper, not a strong security boundary. The service is
+          exposed on localhost only, and provider auth is stored in the persistent Docker volume.
+        </Alert>
+
         {error && <Alert severity="error">{error}</Alert>}
         {message && <Alert severity="success">{message}</Alert>}
 
@@ -723,6 +728,11 @@ fs.chmodSync(path, 0o600);
                 OpenClaw listens on container loopback by default. On macOS, Docker Desktop does not
                 always forward that listener correctly. This extension uses a local runtime image with
                 a baked-in socat bridge so Docker Desktop can publish a normal host-facing port.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                OpenClaw itself runs as the non-root `node` user after the upstream entrypoint starts.
+                The wrapper still is not a hardened sandbox: it keeps writable state in a named Docker
+                volume, and the local bridge process exists to make localhost access work on macOS.
               </Typography>
               <Divider />
               <Typography variant="body2" color="text.secondary">


### PR DESCRIPTION
## Summary
- add shipped UI copy that says the extension is a more isolated localhost wrapper, not a strong security boundary
- document that OpenClaw runs as `node`, while provider auth persists in the named Docker volume
- call out the remaining hardening gaps so the repo does not overclaim the runtime story

## Verification
- cd ui && npm run build
- npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=more isolated local wrapper" --wait-for-timeout=1000 "http://127.0.0.1:4173/?demo=1" output/playwright/hardening-copy-check.png

Contributes to #10

Issue #3 remains blocked on a real tagged release and verified release-install run, so this run moved to the next unblocked roadmap item.