### PR TITLE
Fix release dry-run rehearsal flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ If you want the full maintainer handoff in one command after the tag is publishe
 make ship-release RELEASE_TAG=vX.Y.Z
 ```
 
+To rehearse the same maintainer flow without touching GitHub or Docker Desktop state:
+
+```bash
+make ship-release RELEASE_TAG=vX.Y.Z DRY_RUN=1
+```
+
 If you want to run the same steps one by one, or the tag exists but the GitHub release is still missing:
 
 ```bash

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -22,6 +22,15 @@ if ! gh auth status >/dev/null 2>&1; then
   exit 1
 fi
 
+release_args="release create ${release_tag} --repo ${repo_owner}/${repo_name} --title ${release_tag} --generate-notes"
+
+if [ "$dry_run" = "1" ]; then
+  echo "dry run: gh api /repos/${repo_owner}/${repo_name}/git/ref/tags/${release_tag}"
+  echo "dry run: gh api /repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}"
+  echo "dry run: gh ${release_args}"
+  exit 0
+fi
+
 if ! gh api "/repos/${repo_owner}/${repo_name}/git/ref/tags/${release_tag}" >/dev/null 2>&1; then
   echo "git tag is missing: ${release_tag}" >&2
   echo "Next step: create and push the tag before publishing a GitHub release." >&2
@@ -31,13 +40,6 @@ fi
 if gh api "/repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}" >/dev/null 2>&1; then
   echo "GitHub release already exists: ${release_tag}"
   echo "Next step: run make verify-release-tag RELEASE_TAG=${release_tag}" >&2
-  exit 0
-fi
-
-release_args="release create ${release_tag} --repo ${repo_owner}/${repo_name} --title ${release_tag} --generate-notes"
-
-if [ "$dry_run" = "1" ]; then
-  echo "dry run: gh ${release_args}"
   exit 0
 fi
 

--- a/scripts/ship-release.sh
+++ b/scripts/ship-release.sh
@@ -26,7 +26,7 @@ run_step "Publish GitHub release if needed" \
   ./scripts/publish-release.sh
 
 run_step "Verify GitHub release and GHCR tags" \
-  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DRY_RUN="$dry_run" \
   ./scripts/verify-release-tag.sh
 
 run_step "Validate Docker Desktop install/uninstall" \


### PR DESCRIPTION
## Summary
- honor `DRY_RUN=1` across every step in `make ship-release`
- let `publish-release.sh` rehearse tag and release checks before requiring a real tag
- document the one-command rehearsal path in the README

## Verification
- `make ship-release RELEASE_TAG=v0.0.0-test DRY_RUN=1`
- `git diff --check`

Contributes to #3
