### PR TITLE
Repair manual tag publish path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing v* tag to publish or repair
+        required: true
+        type: string
   push:
     tags:
       - 'v*'
@@ -18,8 +23,31 @@ jobs:
       contents: write
       packages: write
     steps:
+      - name: Resolve release tag
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${INPUT_RELEASE_TAG}"
+          else
+            release_tag="${GITHUB_REF_NAME}"
+          fi
+
+          case "${release_tag}" in
+            v*)
+              ;;
+            *)
+              echo "release_tag must start with v, got: ${release_tag}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -40,9 +68,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest
 
       - name: Build and push runtime image
         uses: docker/build-push-action@v6
@@ -60,9 +88,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest
 
       - name: Build and push extension image
         uses: docker/build-push-action@v6
@@ -77,7 +105,7 @@ jobs:
             VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ steps.runtime-meta.outputs.version }}
 
       - name: Create or update GitHub release for tag
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,6 @@ jobs:
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
             type=sha,prefix=sha-
-            type=raw,value=latest
 
       - name: Build and push runtime image
         uses: docker/build-push-action@v6
@@ -90,7 +89,6 @@ jobs:
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
             type=sha,prefix=sha-
-            type=raw,value=latest
 
       - name: Build and push extension image
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ make publish-release RELEASE_TAG=vX.Y.Z
 make verify-release-tag RELEASE_TAG=vX.Y.Z
 ```
 
+If the GitHub Actions publish job needs to be re-run for an existing tag, use the `Publish` workflow's manual dispatch and pass `release_tag=vX.Y.Z` so it rebuilds the matching GHCR artifacts instead of publishing the default branch state.
+
 Before treating the release image as verified for end users, run the Docker Desktop install/uninstall validation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ make verify-release-tag RELEASE_TAG=vX.Y.Z
 
 If the GitHub Actions publish job needs to be re-run for an existing tag, use the `Publish` workflow's manual dispatch and pass `release_tag=vX.Y.Z` so it rebuilds the matching GHCR artifacts instead of publishing the default branch state.
 
+That repair path only refreshes the requested versioned tags. It does not move a floating `latest` tag to an older release.
+
 Before treating the release image as verified for end users, run the Docker Desktop install/uninstall validation:
 
 ```bash


### PR DESCRIPTION
## Summary
- make the Publish workflow accept a required manual `release_tag` input
- check out the tagged ref and publish the matching GHCR tags during workflow dispatch
- keep manual repair runs versioned-only so an older tag cannot move `latest`
- document the manual tag repair path in the README

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "yaml-ok"'`
- `git diff --check`

Contributes to #3
