### PR TITLE
Fail release installs early when GHCR tag is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,12 @@ update-extension: build-runtime build-extension
 
 install-release:
 	@test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1)
+	@RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" ./scripts/verify-release-image.sh
 	docker extension install -f $(RELEASE_EXTENSION_IMAGE)
 
 update-release:
 	@test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1)
+	@RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" ./scripts/verify-release-image.sh
 	docker extension update $(RELEASE_EXTENSION_IMAGE)
 
 verify-release-tag:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Use these commands depending on where you are in the flow:
 - `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image
 - `make publish-release RELEASE_TAG=vX.Y.Z`: maintainer fallback if a tag exists but the GitHub release needs to be repaired manually
 - `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer repair path that publishes the GitHub release if needed, verifies the GHCR tags, then validates Docker Desktop install/uninstall
-- `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image
-- `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image
+- `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image after an anonymous GHCR preflight
+- `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image after the same preflight
 - `make uninstall`: remove the extension from Docker Desktop
 - `make capture-readme-screenshot`: rebuild the demo UI and refresh the checked-in README screenshot
 
@@ -102,6 +102,12 @@ When a tagged release exists, the end-user install path is:
 
 ```bash
 docker extension install ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:vX.Y.Z
+```
+
+The repo-level shortcut checks the published tag first so a missing GHCR release fails early with a clear next step:
+
+```bash
+make install-release RELEASE_TAG=vX.Y.Z
 ```
 
 To update an existing release install:

--- a/scripts/verify-release-image.sh
+++ b/scripts/verify-release-image.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -eu
+
+release_tag="${1:-${RELEASE_TAG:-}}"
+ghcr_owner="${GHCR_OWNER:-jcowhigjr}"
+image_name="${IMAGE_NAME:-openclaw-docker-desktop-extension}"
+image_ref="ghcr.io/${ghcr_owner}/${image_name}:${release_tag}"
+dry_run="${DRY_RUN:-0}"
+
+if [ -z "$release_tag" ]; then
+  echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" >&2
+  exit 1
+fi
+
+if [ "$dry_run" = "1" ]; then
+  echo "dry run: docker manifest inspect ${image_ref}" >&2
+  exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker CLI is required to verify the published extension image." >&2
+  exit 1
+fi
+
+if docker manifest inspect "$image_ref" >/dev/null 2>&1; then
+  cat <<EOF
+Published extension image is available:
+  ${image_ref}
+EOF
+  exit 0
+fi
+
+cat <<EOF >&2
+Published extension image is not available yet:
+  ${image_ref}
+
+Next step:
+  - If you are testing before the first public tag, use 'make install-dev'.
+  - If this tag should exist, run 'make verify-release-tag RELEASE_TAG=${release_tag}' as a maintainer.
+EOF
+exit 1


### PR DESCRIPTION
## Summary
- add an anonymous GHCR manifest preflight before release install/update
- stop `make install-release` and `make update-release` before Docker Desktop install when the tag is missing
- document the early-failure behavior in the README

## Verification
- `sh -n scripts/verify-release-image.sh scripts/verify-release-install.sh scripts/verify-release-tag.sh`
- `DRY_RUN=1 RELEASE_TAG=v0.1.0 GHCR_OWNER=jcowhigjr IMAGE_NAME=openclaw-docker-desktop-extension ./scripts/verify-release-image.sh`
- `make install-release RELEASE_TAG=v0.1.0`
- `make -n install-release RELEASE_TAG=v0.1.0`

Contributes to #3