### PR TITLE
Harden runtime container launch defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Current constraints:
 - Starts and manages an OpenClaw service container from Docker Desktop
 - Uses a bundled `socat` bridge so the Control UI is reachable on macOS
 - Persists OpenClaw state in a named Docker volume
+- Starts the service container with `--cap-drop=ALL` and `--security-opt no-new-privileges`
 - Exposes Docker Desktop UI controls for start, stop, restart, and open-in-browser actions
 - Surfaces runtime diagnostics in a debug panel inside the extension
 
@@ -186,9 +187,10 @@ This means the credential survives container restarts and rebuilds, but is remov
 ## Security and isolation notes
 
 - The wrapper publishes OpenClaw on `127.0.0.1` only.
+- The service container drops all Linux capabilities and sets `no-new-privileges` when the extension starts it.
 - OpenClaw starts through the upstream image entrypoint and runs as the `node` user, while the wrapper image adds a small `socat` bridge so Docker Desktop can forward the service on macOS.
 - State, including the write-only Anthropic key saved by the extension UI, is stored in the named Docker volume `openclaw-docker-extension-home`.
-- The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability, the service retains writable state in its volume, and this repo has not finished a read-only-filesystem or dropped-capability pass.
+- The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability, the service retains writable state in its volume, and this repo has not finished a read-only-filesystem pass.
 - This is a more isolated local packaging path, not a perfect security boundary.
 - This project is not an official Docker or OpenClaw extension.
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -61,6 +61,7 @@ const RUNTIME_PLATFORM = 'linux/arm64';
 const SUPPORTED_DOCKER_ARCH = 'arm64';
 const LEGACY_RUNTIME_IMAGE = 'ghcr.io/openclaw/openclaw:latest';
 const DEFAULT_RUNTIME_IMAGE = import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'openclaw-docker-extension-runtime:dev';
+const RUNTIME_SECURITY_ARGS = ['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges'];
 const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,
   port: 18789,
@@ -328,6 +329,7 @@ export function App() {
           CONTAINER_NAME,
           '--platform',
           RUNTIME_PLATFORM,
+          ...RUNTIME_SECURITY_ARGS,
           '-v',
           `${VOLUME_NAME}:/home/node`,
           '-p',


### PR DESCRIPTION
## Summary
- start the OpenClaw runtime container with `--cap-drop=ALL`
- set `--security-opt no-new-privileges` on runtime launch
- document the new isolation defaults and remaining limits in the README

## Verification
- `cd ui && npm run build`
- `git diff --check`
- `docker run --rm --cap-drop ALL --security-opt no-new-privileges alpine:latest true`

Contributes to #10