### PR TITLE
Add runtime update-on-open flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ The publish workflow also promotes the runtime image onto a floating channel tag
 
 That gives the extension a predictable GHCR runtime channel for update checks without changing the pinned version-tag install path.
 
+When the runtime image points at a published GHCR channel tag such as `stable` or `beta`, the extension can check for a newer runtime image on open and again before launch. The current MVP update policies are:
+
+- `Check only`: show an update banner and let the user trigger the update manually
+- `Auto-update before launch`: pull the newer runtime image and recreate the service container before `Start`
+
+The update flow preserves the named Docker volume and saved settings. A "what's new" surface is still out of scope for MVP.
+
 Maintainer preflight for a newly published tag:
 
 ```bash
@@ -168,6 +175,7 @@ Current constraints:
 - Persists OpenClaw state in a named Docker volume
 - Starts the service container with `--cap-drop=ALL` and `--security-opt no-new-privileges`
 - Exposes Docker Desktop UI controls for start, stop, restart, and open-in-browser actions
+- Can check published GHCR channel images for runtime updates and optionally apply them before launch
 - Surfaces runtime diagnostics in a debug panel inside the extension
 
 ## Default runtime
@@ -206,6 +214,8 @@ This means the credential survives container restarts and rebuilds, but is remov
 - Gateway token autofill is not fully reliable yet. If the token field is blank in the extension UI, open the Control UI and paste the token manually.
 - The runtime can spend a short warm-up period in `starting` even after the host health check is already passing.
 - Anthropic provider auth currently supports the local `.env` persistence path first. It does not yet manage richer OpenClaw auth-profile workflows in the UI.
+- The update banner only applies to published GHCR channel images. Pinned release tags stay fixed, and local dev images are not auto-updated by the extension.
+- The extension does not yet show release notes or "what's new" content after an update.
 
 ## Roadmap path
 

--- a/openspec/changes/add-runtime-update-on-open/.openspec.yaml
+++ b/openspec/changes/add-runtime-update-on-open/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/add-runtime-update-on-open/design.md
+++ b/openspec/changes/add-runtime-update-on-open/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The current extension is a single-screen React app centered in `ui/src/App.tsx`. It can create, start, stop, restart, and remove one service container, persist config in local storage, and preserve OpenClaw state in the named volume `openclaw-docker-extension-home`. The repo roadmap in issue `#12` treats reproducible install and honest scope as MVP, while issue `#3` is establishing GHCR-published images and a simpler release install path.
+
+Open WebUI uses a focused pattern that matches the user request:
+- only floating or channel-like image references are treated as updateable
+- the extension compares local and remote image digests
+- a cached check runs when the extension is opened and again while the container is active
+- the update path pulls the new image and recreates the container while keeping volumes
+
+OpenClaw upstream releases frequently with dated tags, and upstream already has the notion of stable, beta, and dev channels. That means the Docker Desktop extension should avoid inventing a separate updater system. The extension only needs a lightweight image-channel policy and a safe container recreate flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a configurable update policy that works with published OpenClaw runtime images.
+- Check for updates automatically on extension open and before launch for updateable image channels.
+- Let the user choose whether updates are applied automatically before launch or manually from a banner.
+- Preserve the existing volume, port, and provider-auth behavior during update.
+- Keep the MVP change small enough to layer onto the current single-file UI.
+
+**Non-Goals:**
+- Building a full release-notes or “what’s new” surface.
+- Updating pinned image tags automatically.
+- Replacing the existing start/stop/restart/remove container controls.
+- Introducing background daemons or scheduling beyond extension-open and launch-time checks.
+
+## Decisions
+
+1. Add an explicit update policy to extension settings.
+Rationale: the user asked for a configurable behavior, and the current extension already stores settings locally. A small enum such as `manual`, `check-only`, and `auto-before-launch` is enough for MVP.
+Alternative considered: always auto-update. Rejected because it hides network work and restart behavior from users and makes rollback less predictable.
+
+2. Only perform update checks for published channel-style images.
+Rationale: digest-based checks are useful for floating references such as `:latest`, `:main`, or a future stable/beta/dev channel mapping. Pinned version tags should stay reproducible and unchanged unless the user edits settings.
+Alternative considered: compare every image tag remotely. Rejected because it turns versioned tags into mutable behavior and fights the reproducibility goal in issue `#12`.
+
+3. Reuse the existing container recreate model instead of layering an in-place update.
+Rationale: the container already keeps user state in a named volume, and config changes already imply restart semantics. Pulling the new image, removing the old container, and recreating it is simpler and matches the Open WebUI extension model.
+Alternative considered: stopping and restarting the same container after pull. Rejected because Docker containers are bound to the image they were created from, so a true image update needs recreate semantics.
+
+4. Surface update state in a top-level banner near the status card.
+Rationale: the current UI is simple and status-oriented. A banner above the main controls matches the Open WebUI affordance without forcing a larger navigation or modal system.
+Alternative considered: burying update status inside Settings. Rejected because it would not satisfy the “every time you click on it” expectation.
+
+## Risks / Trade-offs
+
+- [GHCR publishing is not fully in place yet] → Gate the feature behind the published-image path and treat it as dependent on issue `#3`.
+- [Current UI is concentrated in one file] → Keep MVP implementation local to `App.tsx` plus a small helper module rather than forcing a large refactor first.
+- [Registry checks can fail because of auth or rate limits] → Convert those cases into a non-fatal warning banner and let normal launch continue.
+- [Auto-update before launch can increase first-open latency] → Limit automatic apply to the explicit `auto-before-launch` policy and keep a visible “checking/updating” state.
+
+## Migration Plan
+
+1. Extend stored config with an update policy field and default it conservatively for existing installs.
+2. Add image-channel parsing and digest/version check helpers for updateable runtime images.
+3. Add a banner and action flow in the extension UI.
+4. Recreate the service container with the new image when the policy or user action requests it.
+5. Update README language so the behavior is clear and explicitly tied to published images.
+
+## Open Questions
+
+- Should the default published image reference become a stable channel tag once issue `#3` lands, or remain a pinned release tag with update channels opt-in?
+- Should “auto-before-launch” apply only when the container is stopped/missing, or also recreate a currently running container immediately on extension open?
+- Does Docker Desktop expose enough image metadata from the extension API to show both current and available versions cleanly, or should MVP only show image refs/digests?

--- a/openspec/changes/add-runtime-update-on-open/proposal.md
+++ b/openspec/changes/add-runtime-update-on-open/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current MVP roadmap does not include a user-facing way to keep the bundled OpenClaw runtime current once GHCR publishing exists. Open WebUI shows a better Docker Desktop pattern here: when the configured image uses a moving tag, the extension can detect a newer image and let the user update without dropping local state.
+
+## What Changes
+
+- Add a configurable runtime update policy for published OpenClaw runtime images.
+- Check for newer runtime images when the extension opens and before launch when the configured image uses an updateable channel.
+- Allow the user to automatically apply the newer image before launch, preserving the existing named volume and saved settings.
+- Show a clear update notice with the running image version and the available image version.
+- Explicitly defer “what’s new” or release-note rendering until after the core update path works.
+
+## Capabilities
+
+### New Capabilities
+- `runtime-update-flow`: Detect, present, and optionally apply newer published runtime images before launching OpenClaw.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected code: `ui/src/App.tsx`, `ui/src/dockerDesktopClient.ts`, `README.md`, and any new UI helpers added for update checks.
+- External systems: Docker CLI image inspect/pull flows, GHCR tag or digest lookups for the configured runtime image.
+- Product impact: adds a lightweight “stay current” path that depends on issue `#3` finishing the published-image path.

--- a/openspec/changes/add-runtime-update-on-open/specs/runtime-update-flow/spec.md
+++ b/openspec/changes/add-runtime-update-on-open/specs/runtime-update-flow/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Extension can detect newer published runtime images for updateable channels
+The extension SHALL check for a newer published OpenClaw runtime image when the configured runtime image uses an updateable channel reference rather than a pinned version tag.
+
+#### Scenario: Updateable image is configured
+- **WHEN** the saved runtime image refers to an updateable published channel such as a floating or channel tag
+- **THEN** the extension performs a remote comparison on open and before launch
+
+#### Scenario: Pinned image is configured
+- **WHEN** the saved runtime image refers to a pinned version tag
+- **THEN** the extension does not treat that image as auto-updateable
+
+### Requirement: Extension presents update availability without blocking normal use
+The extension SHALL surface update availability in the main UI and SHALL not treat registry lookup failures as fatal to normal launch.
+
+#### Scenario: Newer image is available
+- **WHEN** the remote published image differs from the local image currently used by the service container
+- **THEN** the extension shows an update notice that identifies the running image and the available image
+
+#### Scenario: Update check fails
+- **WHEN** the extension cannot complete the remote update check because of auth, rate limit, or network failure
+- **THEN** the extension records a non-fatal warning and still allows the user to launch the current image
+
+### Requirement: Extension can apply an update before launch while preserving state
+The extension SHALL support a configurable policy that can automatically apply a newer published runtime image before launch, while preserving the existing named volume and saved settings.
+
+#### Scenario: Auto-before-launch policy is enabled
+- **WHEN** a newer updateable runtime image is available and the user opens the extension or launches OpenClaw
+- **THEN** the extension pulls the newer image, recreates the service container with the existing config, and starts OpenClaw using the preserved volume
+
+#### Scenario: Manual update policy is enabled
+- **WHEN** a newer updateable runtime image is available and automatic apply is disabled
+- **THEN** the extension offers a user-triggered update action and does not replace the running container until the user chooses it

--- a/openspec/changes/add-runtime-update-on-open/tasks.md
+++ b/openspec/changes/add-runtime-update-on-open/tasks.md
@@ -1,0 +1,17 @@
+## 1. Config And Detection
+
+- [x] 1.1 Add an update-policy field to the saved extension config and default existing installs safely.
+- [x] 1.2 Add a helper that classifies runtime images as pinned or updateable channel references.
+- [x] 1.3 Add a helper that compares the local runtime image with the remote published image and returns update state plus non-fatal warnings.
+
+## 2. UI And Launch Flow
+
+- [x] 2.1 Add a top-level update banner that shows current versus available image information and exposes a manual update action.
+- [x] 2.2 Trigger update checks on extension open and before launch for updateable images.
+- [x] 2.3 Implement the auto-before-launch policy by pulling the newer image and recreating the container with the existing volume, port, and saved settings.
+
+## 3. Verification And Docs
+
+- [x] 3.1 Add focused tests for pinned-versus-floating image handling, update-check failure handling, and recreate-on-update behavior.
+- [x] 3.2 Update the README to explain the new update policy, when it runs, and that “what’s new” is still out of scope.
+- [ ] 3.3 Re-verify the extension’s existing start, restart, and provider-auth flows after the update path is added.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -22,7 +22,8 @@
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react-swc": "^3.7.0",
         "typescript": "^5.8.0",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1672,6 +1673,24 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1734,6 +1753,131 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1749,6 +1893,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1756,6 +1910,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/clsx": {
@@ -1821,6 +2002,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -1839,6 +2030,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1892,6 +2090,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2048,6 +2266,23 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2125,6 +2360,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -2322,6 +2574,13 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2341,6 +2600,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -2359,6 +2652,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2374,6 +2681,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -2463,6 +2800,119 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,13 +15,15 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build"
+    "build": "tsc && vite build",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "typescript": "^5.8.0",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^3.2.4"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -66,6 +66,11 @@ type DemoState = {
   runtimeUpdate: RuntimeUpdateCheckResult | null;
 };
 
+function isMissingLocalImageError(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return /No such image|not found|No such object/i.test(text);
+}
+
 const STORAGE_KEY = 'openclaw-docker-extension-config';
 const CONTAINER_NAME = 'openclaw-docker-extension-service';
 const VOLUME_NAME = 'openclaw-docker-extension-home';
@@ -418,12 +423,21 @@ export function App() {
 
       setCheckingUpdate(true);
       try {
-        const localInspect = (await ddClient.docker.cli.exec('image', [
-          'inspect',
-          image,
-        ])) as CliExecResult;
-        appendCliResult(`docker image inspect ${image}`, localInspect);
-        const localImage = parseLocalImageInspect(asText(localInspect.stdout));
+        let localImage: ReturnType<typeof parseLocalImageInspect> = { digests: [] };
+        try {
+          const localInspect = (await ddClient.docker.cli.exec('image', [
+            'inspect',
+            image,
+          ])) as CliExecResult;
+          appendCliResult(`docker image inspect ${image}`, localInspect);
+          localImage = parseLocalImageInspect(asText(localInspect.stdout));
+        } catch (err) {
+          if (!isMissingLocalImageError(err)) {
+            throw err;
+          }
+          appendDebug(`runtime image ${image} is not cached locally yet`);
+        }
+
         const remoteDigest = await inspectRemoteDigest(image);
 
         if (!remoteDigest) {
@@ -584,20 +598,29 @@ export function App() {
     setError('');
     setMessage('');
     setPhase('starting');
-    setStatusText('Checking OpenClaw runtime...');
+    setStatusText('Creating OpenClaw container...');
 
     try {
-      const updateResult = await checkForRuntimeUpdate({ force: true });
+      let updateResult: RuntimeUpdateCheckResult | null = null;
+      if (config.updatePolicy === 'auto-before-launch') {
+        setStatusText('Checking OpenClaw runtime...');
+        updateResult = await checkForRuntimeUpdate({ force: true });
+      } else if (isRuntimeImageUpdateable(config.image)) {
+        void checkForRuntimeUpdate({ force: true });
+      }
+
       if (shouldAutoApplyRuntimeUpdate(config.updatePolicy, updateResult)) {
         appendDebug('auto-before-launch policy found a newer runtime image');
         await applyRuntimeUpdateInternal('auto-before-launch');
       } else {
-        setStatusText('Creating OpenClaw container...');
         await ensureContainerRunning(config);
         setMessage(
           'OpenClaw setup started. The first launch can take a minute while socat is installed.',
         );
         await runAndPoll();
+        if (isRuntimeImageUpdateable(config.image)) {
+          void checkForRuntimeUpdate({ force: true });
+        }
       }
     } catch (err) {
       setPhase('error');

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -12,6 +12,7 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  MenuItem,
   Stack,
   TextField,
   Typography,
@@ -19,6 +20,16 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getDDClient } from './dockerDesktopClient';
+import {
+  describeRuntimeImageVersion,
+  isRuntimeImageUpdateable,
+  parseLocalImageInspect,
+  parseRemoteDigestFromBuildxOutput,
+  parseRemoteDigestFromManifest,
+  shouldAutoApplyRuntimeUpdate,
+  type RuntimeUpdateCheckResult,
+  type UpdatePolicy,
+} from './runtimeUpdate';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 
@@ -26,6 +37,7 @@ type ExtensionConfig = {
   image: string;
   port: number;
   autoStart: boolean;
+  updatePolicy: UpdatePolicy;
 };
 
 type ContainerSnapshot = {
@@ -51,6 +63,7 @@ type DemoState = {
   token: string;
   message: string;
   debugLog: string;
+  runtimeUpdate: RuntimeUpdateCheckResult | null;
 };
 
 const STORAGE_KEY = 'openclaw-docker-extension-config';
@@ -60,17 +73,20 @@ const BRIDGE_PORT = 18790;
 const RUNTIME_PLATFORM = 'linux/arm64';
 const SUPPORTED_DOCKER_ARCH = 'arm64';
 const LEGACY_RUNTIME_IMAGE = 'ghcr.io/openclaw/openclaw:latest';
-const DEFAULT_RUNTIME_IMAGE = import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'openclaw-docker-extension-runtime:dev';
+const DEFAULT_RUNTIME_IMAGE =
+  import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'openclaw-docker-extension-runtime:dev';
 const RUNTIME_SECURITY_ARGS = ['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges'];
 const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,
   port: 18789,
   autoStart: true,
+  updatePolicy: 'check-only',
 };
 const LABELS = {
   'com.docker.extension.openclaw': 'true',
   'com.docker.extension.openclaw.role': 'service',
 };
+
 function loadConfig(): ExtensionConfig {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -80,10 +96,17 @@ function loadConfig(): ExtensionConfig {
 
     const parsed = JSON.parse(raw) as Partial<ExtensionConfig>;
     const image = typeof parsed.image === 'string' ? parsed.image.trim() : '';
+    const updatePolicy =
+      parsed.updatePolicy === 'auto-before-launch' ? 'auto-before-launch' : 'check-only';
     return {
-      image: image ? (image === LEGACY_RUNTIME_IMAGE ? DEFAULT_RUNTIME_IMAGE : image) : DEFAULT_CONFIG.image,
-      port: typeof parsed.port === 'number' && Number.isFinite(parsed.port) ? parsed.port : DEFAULT_CONFIG.port,
+      image:
+        image && image !== LEGACY_RUNTIME_IMAGE ? image : DEFAULT_CONFIG.image,
+      port:
+        typeof parsed.port === 'number' && Number.isFinite(parsed.port)
+          ? parsed.port
+          : DEFAULT_CONFIG.port,
       autoStart: parsed.autoStart ?? DEFAULT_CONFIG.autoStart,
+      updatePolicy,
     };
   } catch {
     return DEFAULT_CONFIG;
@@ -111,9 +134,10 @@ function loadDemoState(): DemoState | null {
 
   return {
     config: {
-      image: DEFAULT_RUNTIME_IMAGE,
+      image: 'ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:stable',
       port: 18789,
       autoStart: false,
+      updatePolicy: 'check-only',
     },
     phase: 'running',
     statusText: 'OpenClaw is ready',
@@ -125,6 +149,17 @@ function loadDemoState(): DemoState | null {
       'healthz check: ok',
       'token loaded from /home/node/.openclaw/openclaw.json',
     ].join('\n'),
+    runtimeUpdate: {
+      image: 'ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:stable',
+      supported: true,
+      updateAvailable: true,
+      checkedAt: Date.now(),
+      localVersion: 'v2026.3.31',
+      localDigest:
+        'sha256:1111111111111111111111111111111111111111111111111111111111111111',
+      remoteDigest:
+        'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+    },
   };
 }
 
@@ -134,13 +169,19 @@ export function App() {
   const ddClient = useMemo(() => (isDemo ? null : getDDClient()), [isDemo]);
   const [config, setConfig] = useState<ExtensionConfig>(() => demoState?.config ?? loadConfig());
   const [phase, setPhase] = useState<ContainerPhase>(demoState?.phase ?? 'missing');
-  const [statusText, setStatusText] = useState(demoState?.statusText ?? 'No OpenClaw container yet');
+  const [statusText, setStatusText] = useState(
+    demoState?.statusText ?? 'No OpenClaw container yet',
+  );
   const [token, setToken] = useState(demoState?.token ?? '');
   const [anthropicApiKey, setAnthropicApiKey] = useState('');
   const [busy, setBusy] = useState(false);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [message, setMessage] = useState(demoState?.message ?? '');
   const [error, setError] = useState('');
   const [debugLog, setDebugLog] = useState(demoState?.debugLog ?? '');
+  const [runtimeUpdate, setRuntimeUpdate] = useState<RuntimeUpdateCheckResult | null>(
+    demoState?.runtimeUpdate ?? null,
+  );
 
   const persistConfig = useCallback((next: ExtensionConfig) => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -153,6 +194,25 @@ export function App() {
   const asText = useCallback((value: unknown) => {
     return typeof value === 'string' ? value : '';
   }, []);
+
+  const appendDebug = useCallback((entry: string) => {
+    setDebugLog((current) => {
+      const next = current ? `${current}\n${entry}` : entry;
+      return next.slice(-12000);
+    });
+  }, []);
+
+  const appendCliResult = useCallback(
+    (label: string, result: CliExecResult) => {
+      const stdout = asText(result.stdout).trim();
+      const stderr = asText(result.stderr).trim();
+      appendDebug(`${label} stdout: ${stdout || '<empty>'}`);
+      if (stderr) {
+        appendDebug(`${label} stderr: ${stderr}`);
+      }
+    },
+    [appendDebug, asText],
+  );
 
   const findContainer = useCallback(async (): Promise<ContainerSnapshot | null> => {
     if (!ddClient) {
@@ -168,8 +228,6 @@ export function App() {
       Id: string;
       State: string;
       Status: string;
-      Names?: string[];
-      Name?: string;
     }>;
 
     if (containers.length > 0) {
@@ -189,31 +247,27 @@ export function App() {
     return { id: byName[0].Id, state: byName[0].State, status: byName[0].Status };
   }, [ddClient]);
 
-  const appendDebug = useCallback((entry: string) => {
-    setDebugLog((current) => {
-      const next = current ? `${current}\n${entry}` : entry;
-      return next.slice(-12000);
-    });
-  }, []);
+  const readToken = useCallback(
+    async (containerId: string) => {
+      if (!ddClient) {
+        return;
+      }
 
-  const readToken = useCallback(async (containerId: string) => {
-    if (!ddClient) {
-      return;
-    }
-
-    try {
-      const result = (await ddClient.docker.cli.exec('exec', [
-        containerId,
-        'node',
-        '-e',
-        'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
-      ])) as CliExecResult;
-      setToken(asText((result as CliExecResult).stdout).trim());
-    } catch (err) {
-      appendDebug(`token read failed: ${err instanceof Error ? err.message : String(err)}`);
-      setToken('');
-    }
-  }, [appendDebug, asText, ddClient]);
+      try {
+        const result = (await ddClient.docker.cli.exec('exec', [
+          containerId,
+          'node',
+          '-e',
+          'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
+        ])) as CliExecResult;
+        setToken(asText(result.stdout).trim());
+      } catch (err) {
+        appendDebug(`token read failed: ${err instanceof Error ? err.message : String(err)}`);
+        setToken('');
+      }
+    },
+    [appendDebug, asText, ddClient],
+  );
 
   const checkReady = useCallback(async () => {
     try {
@@ -234,7 +288,10 @@ export function App() {
       return '';
     }
 
-    const result = (await ddClient.docker.cli.exec('version', ['--format', '{{.Server.Arch}}'])) as CliExecResult;
+    const result = (await ddClient.docker.cli.exec('version', [
+      '--format',
+      '{{.Server.Arch}}',
+    ])) as CliExecResult;
     return asText(result.stdout).trim();
   }, [asText, ddClient]);
 
@@ -242,7 +299,9 @@ export function App() {
     try {
       const serverArch = await readDockerServerArch();
       if (!serverArch) {
-        appendDebug('docker server architecture was empty; continuing with linux/arm64 runtime platform');
+        appendDebug(
+          'docker server architecture was empty; continuing with linux/arm64 runtime platform',
+        );
         return;
       }
 
@@ -256,7 +315,9 @@ export function App() {
       if (err instanceof Error && err.message.startsWith('Unsupported Docker architecture:')) {
         throw err;
       }
-      appendDebug(`docker server architecture check failed: ${err instanceof Error ? err.message : String(err)}`);
+      appendDebug(
+        `docker server architecture check failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }, [appendDebug, readDockerServerArch]);
 
@@ -304,6 +365,216 @@ export function App() {
     }
   }, [appendDebug, refresh]);
 
+  const inspectRemoteDigest = useCallback(
+    async (image: string): Promise<string | null> => {
+      if (!ddClient) {
+        return null;
+      }
+
+      try {
+        const buildxResult = (await ddClient.docker.cli.exec('buildx', [
+          'imagetools',
+          'inspect',
+          image,
+        ])) as CliExecResult;
+        appendCliResult(`docker buildx imagetools inspect ${image}`, buildxResult);
+        const digest = parseRemoteDigestFromBuildxOutput(asText(buildxResult.stdout));
+        if (digest) {
+          return digest;
+        }
+      } catch (err) {
+        appendDebug(
+          `buildx inspect failed for ${image}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const manifestResult = (await ddClient.docker.cli.exec('manifest', [
+        'inspect',
+        image,
+      ])) as CliExecResult;
+      appendCliResult(`docker manifest inspect ${image}`, manifestResult);
+      return parseRemoteDigestFromManifest(asText(manifestResult.stdout));
+    },
+    [appendCliResult, appendDebug, asText, ddClient],
+  );
+
+  const checkForRuntimeUpdate = useCallback(
+    async ({ force = false }: { force?: boolean } = {}): Promise<RuntimeUpdateCheckResult | null> => {
+      if (!ddClient) {
+        return null;
+      }
+
+      const image = config.image.trim();
+      if (!isRuntimeImageUpdateable(image)) {
+        const unsupported = {
+          image,
+          supported: false,
+          updateAvailable: false,
+          checkedAt: Date.now(),
+        } satisfies RuntimeUpdateCheckResult;
+        setRuntimeUpdate(unsupported);
+        return unsupported;
+      }
+
+      setCheckingUpdate(true);
+      try {
+        const localInspect = (await ddClient.docker.cli.exec('image', [
+          'inspect',
+          image,
+        ])) as CliExecResult;
+        appendCliResult(`docker image inspect ${image}`, localInspect);
+        const localImage = parseLocalImageInspect(asText(localInspect.stdout));
+        const remoteDigest = await inspectRemoteDigest(image);
+
+        if (!remoteDigest) {
+          const result = {
+            image,
+            supported: true,
+            updateAvailable: false,
+            checkedAt: Date.now(),
+            localVersion: localImage.version,
+            localDigest: localImage.digests[0],
+            error: 'Remote image digest was unavailable. Skipping update notice.',
+          } satisfies RuntimeUpdateCheckResult;
+          setRuntimeUpdate(result);
+          return result;
+        }
+
+        if (localImage.digests.length === 0) {
+          const result = {
+            image,
+            supported: true,
+            updateAvailable: false,
+            checkedAt: Date.now(),
+            remoteDigest,
+            error: force
+              ? 'Runtime image is not cached locally yet. OpenClaw will pull it on first launch.'
+              : undefined,
+          } satisfies RuntimeUpdateCheckResult;
+          setRuntimeUpdate(result);
+          return result;
+        }
+
+        const result = {
+          image,
+          supported: true,
+          updateAvailable: !localImage.digests.includes(remoteDigest),
+          checkedAt: Date.now(),
+          localVersion: localImage.version,
+          localDigest: localImage.digests[0],
+          remoteDigest,
+        } satisfies RuntimeUpdateCheckResult;
+        setRuntimeUpdate(result);
+        return result;
+      } catch (err) {
+        const result = {
+          image,
+          supported: true,
+          updateAvailable: false,
+          checkedAt: Date.now(),
+          error: `Failed to check for runtime updates: ${err instanceof Error ? err.message : String(err)}`,
+        } satisfies RuntimeUpdateCheckResult;
+        appendDebug(result.error);
+        setRuntimeUpdate(result);
+        return result;
+      } finally {
+        setCheckingUpdate(false);
+      }
+    },
+    [appendCliResult, appendDebug, asText, config.image, ddClient, inspectRemoteDigest],
+  );
+
+  const ensureContainerRunning = useCallback(
+    async (
+      nextConfig: ExtensionConfig,
+      options: {
+        recreate?: boolean;
+      } = {},
+    ) => {
+      if (!ddClient) {
+        return;
+      }
+
+      await requireSupportedPlatform();
+      const existing = await findContainer();
+      if (existing && !options.recreate) {
+        appendDebug(`found existing container ${existing.id} (${existing.state})`);
+        if (existing.state === 'running') {
+          setStatusText('OpenClaw is already running.');
+          await runAndPoll();
+          return;
+        }
+        await ddClient.docker.cli.exec('start', [existing.id]);
+        setStatusText('Starting existing OpenClaw container...');
+        return;
+      }
+
+      if (existing) {
+        appendDebug(`removing existing container ${existing.id} before runtime update`);
+        await ddClient.docker.cli.exec('rm', ['-f', existing.id]);
+      }
+
+      appendDebug(`creating container ${CONTAINER_NAME} from ${nextConfig.image}`);
+      const result = (await ddClient.docker.cli.exec('run', [
+        '-d',
+        '--name',
+        CONTAINER_NAME,
+        '--platform',
+        RUNTIME_PLATFORM,
+        ...RUNTIME_SECURITY_ARGS,
+        '-v',
+        `${VOLUME_NAME}:/home/node`,
+        '-p',
+        `127.0.0.1:${nextConfig.port}:${BRIDGE_PORT}`,
+        '--label',
+        `com.docker.extension.openclaw=${LABELS['com.docker.extension.openclaw']}`,
+        '--label',
+        `com.docker.extension.openclaw.role=${LABELS['com.docker.extension.openclaw.role']}`,
+        nextConfig.image,
+      ])) as CliExecResult;
+      appendCliResult('docker run', result);
+
+      await new Promise((resolve) => window.setTimeout(resolve, 1500));
+      const created = await findContainer();
+      if (!created) {
+        const ps = (await ddClient.docker.cli.exec('ps', ['-a'])) as CliExecResult;
+        appendDebug(`docker ps -a:\n${asText(ps.stdout).trim()}`);
+        throw new Error(
+          asText(result.stderr).trim() ||
+            asText(result.stdout).trim() ||
+            'Docker reported success, but no OpenClaw service container was created.',
+        );
+      }
+    },
+    [appendCliResult, appendDebug, asText, ddClient, findContainer, requireSupportedPlatform, runAndPoll],
+  );
+
+  const applyRuntimeUpdateInternal = useCallback(
+    async (trigger: 'manual' | 'auto-before-launch') => {
+      if (!ddClient) {
+        return;
+      }
+
+      const image = config.image.trim();
+      appendDebug(`pulling runtime update for ${image} (${trigger})`);
+      const pullResult = (await ddClient.docker.cli.exec('pull', [image])) as CliExecResult;
+      appendCliResult(`docker pull ${image}`, pullResult);
+
+      setStatusText(
+        trigger === 'manual' ? 'Updating OpenClaw runtime...' : 'Updating OpenClaw before launch...',
+      );
+      await ensureContainerRunning(config, { recreate: true });
+      setMessage(
+        trigger === 'manual'
+          ? 'OpenClaw runtime updated and restarted.'
+          : 'OpenClaw updated before launch.',
+      );
+      await runAndPoll();
+      await checkForRuntimeUpdate({ force: true });
+    },
+    [appendCliResult, appendDebug, checkForRuntimeUpdate, config, ddClient, ensureContainerRunning, runAndPoll],
+  );
+
   const createOrStart = useCallback(async () => {
     if (!ddClient) {
       return;
@@ -313,55 +584,21 @@ export function App() {
     setError('');
     setMessage('');
     setPhase('starting');
-    setStatusText('Creating OpenClaw container...');
+    setStatusText('Checking OpenClaw runtime...');
+
     try {
-      await requireSupportedPlatform();
-      const existing = await findContainer();
-      if (existing) {
-        appendDebug(`found existing container ${existing.id} (${existing.state})`);
-        await ddClient.docker.cli.exec('start', [existing.id]);
-        setStatusText('Starting existing OpenClaw container...');
+      const updateResult = await checkForRuntimeUpdate({ force: true });
+      if (shouldAutoApplyRuntimeUpdate(config.updatePolicy, updateResult)) {
+        appendDebug('auto-before-launch policy found a newer runtime image');
+        await applyRuntimeUpdateInternal('auto-before-launch');
       } else {
-        appendDebug(`creating container ${CONTAINER_NAME} from ${config.image}`);
-        const result = (await ddClient.docker.cli.exec('run', [
-          '-d',
-          '--name',
-          CONTAINER_NAME,
-          '--platform',
-          RUNTIME_PLATFORM,
-          ...RUNTIME_SECURITY_ARGS,
-          '-v',
-          `${VOLUME_NAME}:/home/node`,
-          '-p',
-          `127.0.0.1:${config.port}:${BRIDGE_PORT}`,
-          '--label',
-          `com.docker.extension.openclaw=${LABELS['com.docker.extension.openclaw']}`,
-          '--label',
-          `com.docker.extension.openclaw.role=${LABELS['com.docker.extension.openclaw.role']}`,
-          config.image,
-        ])) as CliExecResult;
-        const stdout = asText(result.stdout).trim();
-        const stderr = asText(result.stderr).trim();
-        appendDebug(`docker run stdout: ${stdout || '<empty>'}`);
-        if (stderr) {
-          appendDebug(`docker run stderr: ${stderr}`);
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 1500));
-        const created = await findContainer();
-        if (!created) {
-          const ps = (await ddClient.docker.cli.exec('ps', ['-a'])) as CliExecResult;
-          appendDebug(`docker ps -a:\n${asText(ps.stdout).trim()}`);
-          throw new Error(
-            stderr ||
-              stdout ||
-              'Docker reported success, but no OpenClaw service container was created.',
-          );
-        }
+        setStatusText('Creating OpenClaw container...');
+        await ensureContainerRunning(config);
+        setMessage(
+          'OpenClaw setup started. The first launch can take a minute while socat is installed.',
+        );
+        await runAndPoll();
       }
-
-      setMessage('OpenClaw setup started. The first launch can take a minute while socat is installed.');
-      await runAndPoll();
     } catch (err) {
       setPhase('error');
       const text = err instanceof Error ? err.message : String(err);
@@ -370,7 +607,35 @@ export function App() {
     } finally {
       setBusy(false);
     }
-  }, [appendDebug, asText, config.image, config.port, ddClient, findContainer, runAndPoll]);
+  }, [
+    appendDebug,
+    applyRuntimeUpdateInternal,
+    checkForRuntimeUpdate,
+    config,
+    ddClient,
+    ensureContainerRunning,
+    runAndPoll,
+  ]);
+
+  const updateNow = useCallback(async () => {
+    if (!ddClient) {
+      return;
+    }
+
+    setBusy(true);
+    setError('');
+    setMessage('');
+    setPhase('starting');
+    try {
+      await applyRuntimeUpdateInternal('manual');
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`runtime update failed: ${text}`);
+      setError(text);
+    } finally {
+      setBusy(false);
+    }
+  }, [appendDebug, applyRuntimeUpdateInternal, ddClient]);
 
   const stop = useCallback(async () => {
     if (!ddClient) {
@@ -483,20 +748,24 @@ export function App() {
       }
 
       if (container.state !== 'running') {
-        appendDebug(`container ${container.id} is in state "${container.state}", starting it before writing Anthropic API key`);
+        appendDebug(
+          `container ${container.id} is in state "${container.state}", starting it before writing Anthropic API key`,
+        );
         await ddClient.docker.cli.exec('start', [container.id]);
       }
 
       appendDebug('writing Anthropic API key to /home/node/.openclaw/.env');
-      await ddClient.docker.cli.exec('exec', [
-        '-e',
-        'OPENCLAW_ANTHROPIC_API_KEY',
-        '-u',
-        'node',
-        container.id,
-        'node',
-        '-e',
-        `
+      await ddClient.docker.cli.exec(
+        'exec',
+        [
+          '-e',
+          'OPENCLAW_ANTHROPIC_API_KEY',
+          '-u',
+          'node',
+          container.id,
+          'node',
+          '-e',
+          `
 const fs = require("fs");
 const dir = "/home/node/.openclaw";
 const path = "/home/node/.openclaw/.env";
@@ -513,12 +782,14 @@ const filtered = lines.filter((line) => line && !line.startsWith("ANTHROPIC_API_
 filtered.push("ANTHROPIC_API_KEY=" + key);
 fs.writeFileSync(path, filtered.join("\\n") + "\\n", { mode: 0o600 });
 fs.chmodSync(path, 0o600);
-        `.trim(),
-      ], {
-        env: {
-          OPENCLAW_ANTHROPIC_API_KEY: key,
+          `.trim(),
+        ],
+        {
+          env: {
+            OPENCLAW_ANTHROPIC_API_KEY: key,
+          },
         },
-      });
+      );
 
       appendDebug('restarting service after Anthropic key update');
       setAnthropicApiKey('');
@@ -547,10 +818,34 @@ fs.chmodSync(path, 0o600);
       return;
     }
 
+    void checkForRuntimeUpdate();
+  }, [checkForRuntimeUpdate, config.image, config.updatePolicy, isDemo]);
+
+  useEffect(() => {
+    if (isDemo) {
+      return;
+    }
+
     if (config.autoStart && phase === 'missing' && !busy) {
       void createOrStart();
     }
   }, [busy, config.autoStart, createOrStart, isDemo, phase]);
+
+  const runtimeUpdateSummary =
+    runtimeUpdate && runtimeUpdate.supported
+      ? {
+          current: describeRuntimeImageVersion(
+            runtimeUpdate.image,
+            runtimeUpdate.localVersion,
+            runtimeUpdate.localDigest,
+          ),
+          available: describeRuntimeImageVersion(
+            runtimeUpdate.image,
+            undefined,
+            runtimeUpdate.remoteDigest,
+          ),
+        }
+      : null;
 
   return (
     <Box sx={{ p: 3, maxWidth: 1100, mx: 'auto' }}>
@@ -569,6 +864,33 @@ fs.chmodSync(path, 0o600);
           This is a more isolated local wrapper, not a strong security boundary. The service is
           exposed on localhost only, and provider auth is stored in the persistent Docker volume.
         </Alert>
+
+        {checkingUpdate && isRuntimeImageUpdateable(config.image) && (
+          <Alert severity="info">Checking for a newer published OpenClaw runtime image...</Alert>
+        )}
+
+        {runtimeUpdate?.updateAvailable && runtimeUpdateSummary && (
+          <Alert
+            severity="warning"
+            action={
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() => void updateNow()}
+                disabled={busy || isDemo}
+              >
+                Update now
+              </Button>
+            }
+          >
+            Update available: {runtimeUpdateSummary.available} (running {runtimeUpdateSummary.current}
+            ).
+          </Alert>
+        )}
+
+        {!runtimeUpdate?.updateAvailable && runtimeUpdate?.error && (
+          <Alert severity="info">{runtimeUpdate.error}</Alert>
+        )}
 
         {error && <Alert severity="error">{error}</Alert>}
         {message && <Alert severity="success">{message}</Alert>}
@@ -690,8 +1012,10 @@ fs.chmodSync(path, 0o600);
                 label="OpenClaw Image"
                 value={config.image}
                 fullWidth
-                onChange={(event) => setConfig((current) => ({ ...current, image: event.target.value }))}
-                helperText="This should point to the local runtime image that bundles the macOS socat bridge."
+                onChange={(event) =>
+                  setConfig((current) => ({ ...current, image: event.target.value }))
+                }
+                helperText="Published GHCR channel tags such as stable or beta can be checked for runtime updates. Local dev images stay manual."
               />
               <TextField
                 label="Host Port"
@@ -705,6 +1029,21 @@ fs.chmodSync(path, 0o600);
                 }
                 helperText="The extension publishes this port on localhost and bridges it to OpenClaw internally."
               />
+              <TextField
+                select
+                label="Runtime Update Policy"
+                value={config.updatePolicy}
+                onChange={(event) =>
+                  setConfig((current) => ({
+                    ...current,
+                    updatePolicy: event.target.value as UpdatePolicy,
+                  }))
+                }
+                helperText="Check-only shows an update banner. Auto-before-launch pulls the newer published runtime image before Start."
+              >
+                <MenuItem value="check-only">Check only</MenuItem>
+                <MenuItem value="auto-before-launch">Auto-update before launch</MenuItem>
+              </TextField>
               <Button
                 variant="outlined"
                 onClick={() => {
@@ -730,6 +1069,12 @@ fs.chmodSync(path, 0o600);
                 OpenClaw listens on container loopback by default. On macOS, Docker Desktop does not
                 always forward that listener correctly. This extension uses a local runtime image with
                 a baked-in socat bridge so Docker Desktop can publish a normal host-facing port.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                For published GHCR channel images, the extension can also compare the cached local
+                runtime image with the current remote digest and optionally pull and recreate the
+                service container before launch. Release-note or &quot;what&apos;s new&quot; UX is still out of
+                scope for MVP.
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 OpenClaw itself runs as the non-root `node` user after the upstream entrypoint starts.

--- a/ui/src/runtimeUpdate.test.ts
+++ b/ui/src/runtimeUpdate.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeRuntimeImageVersion,
+  isRuntimeImageUpdateable,
+  parseLocalImageInspect,
+  parseRemoteDigestFromBuildxOutput,
+  parseRemoteDigestFromManifest,
+  shouldAutoApplyRuntimeUpdate,
+} from './runtimeUpdate';
+
+describe('runtimeUpdate helpers', () => {
+  it('classifies updateable runtime tags', () => {
+    expect(isRuntimeImageUpdateable('ghcr.io/example/openclaw-runtime:stable')).toBe(true);
+    expect(isRuntimeImageUpdateable('ghcr.io/example/openclaw-runtime:beta')).toBe(true);
+    expect(isRuntimeImageUpdateable('ghcr.io/example/openclaw-runtime:v2026.4.11')).toBe(false);
+    expect(isRuntimeImageUpdateable('openclaw-docker-extension-runtime:dev')).toBe(false);
+  });
+
+  it('parses local inspect digests and version labels', () => {
+    const result = parseLocalImageInspect(
+      JSON.stringify([
+        {
+          RepoDigests: [
+            'ghcr.io/example/openclaw-runtime@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          ],
+          Config: {
+            Labels: {
+              'org.opencontainers.image.version': 'v2026.4.11',
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(result.digests).toEqual([
+      'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ]);
+    expect(result.version).toBe('v2026.4.11');
+  });
+
+  it('parses remote digests from buildx and manifest output', () => {
+    expect(
+      parseRemoteDigestFromBuildxOutput(
+        'Name: ghcr.io/example/openclaw-runtime:stable\nDigest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n',
+      ),
+    ).toBe('sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+    expect(
+      parseRemoteDigestFromManifest(
+        JSON.stringify({
+          Digest: 'sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+        }),
+      ),
+    ).toBe('sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc');
+  });
+
+  it('decides when auto-before-launch should recreate with an updated image', () => {
+    expect(
+      shouldAutoApplyRuntimeUpdate('auto-before-launch', {
+        image: 'ghcr.io/example/openclaw-runtime:stable',
+        supported: true,
+        updateAvailable: true,
+        checkedAt: Date.now(),
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldAutoApplyRuntimeUpdate('check-only', {
+        image: 'ghcr.io/example/openclaw-runtime:stable',
+        supported: true,
+        updateAvailable: true,
+        checkedAt: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it('builds human-readable runtime version labels', () => {
+    expect(
+      describeRuntimeImageVersion(
+        'ghcr.io/example/openclaw-runtime:stable',
+        'v2026.4.11',
+        'sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      ),
+    ).toBe('v2026.4.11');
+
+    expect(
+      describeRuntimeImageVersion(
+        'ghcr.io/example/openclaw-runtime:stable',
+        undefined,
+        'sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      ),
+    ).toBe('stable@eeeeeeeeeeee');
+  });
+});

--- a/ui/src/runtimeUpdate.ts
+++ b/ui/src/runtimeUpdate.ts
@@ -1,0 +1,151 @@
+export type UpdatePolicy = 'check-only' | 'auto-before-launch';
+
+export type RuntimeUpdateCheckResult = {
+  image: string;
+  supported: boolean;
+  updateAvailable: boolean;
+  checkedAt: number;
+  localDigest?: string;
+  remoteDigest?: string;
+  localVersion?: string;
+  error?: string;
+};
+
+const UPDATEABLE_RUNTIME_TAGS = new Set(['latest', 'main', 'stable', 'beta', 'dev']);
+const SHA256_DIGEST_REGEX = /\bsha256:[a-f0-9]{64}\b/i;
+
+type DockerImageInspectEntry = {
+  RepoDigests?: string[];
+  Config?: {
+    Labels?: Record<string, string>;
+  };
+};
+
+export function getImageTag(image: string): string | null {
+  const trimmed = image.trim();
+  if (!trimmed || trimmed.includes('@')) {
+    return null;
+  }
+
+  const lastSlash = trimmed.lastIndexOf('/');
+  const lastColon = trimmed.lastIndexOf(':');
+  if (lastColon <= lastSlash) {
+    return null;
+  }
+
+  return trimmed.slice(lastColon + 1).trim().toLowerCase() || null;
+}
+
+export function isRuntimeImageUpdateable(image: string): boolean {
+  const trimmed = image.trim().toLowerCase();
+  if (!trimmed.startsWith('ghcr.io/')) {
+    return false;
+  }
+
+  const tag = getImageTag(image);
+  return tag !== null && UPDATEABLE_RUNTIME_TAGS.has(tag);
+}
+
+export function shouldAutoApplyRuntimeUpdate(
+  policy: UpdatePolicy,
+  result: RuntimeUpdateCheckResult | null,
+): boolean {
+  return policy === 'auto-before-launch' && Boolean(result?.updateAvailable);
+}
+
+export function shortenDigest(digest?: string): string | null {
+  if (!digest) {
+    return null;
+  }
+
+  const normalized = digest.trim().toLowerCase();
+  if (!SHA256_DIGEST_REGEX.test(normalized)) {
+    return null;
+  }
+
+  return normalized.replace('sha256:', '').slice(0, 12);
+}
+
+export function describeRuntimeImageVersion(
+  image: string,
+  version?: string,
+  digest?: string,
+): string {
+  if (version && version.trim()) {
+    return version.trim();
+  }
+
+  const tag = getImageTag(image);
+  const shortDigest = shortenDigest(digest);
+  if (tag && shortDigest) {
+    return `${tag}@${shortDigest}`;
+  }
+  if (tag) {
+    return tag;
+  }
+  if (shortDigest) {
+    return shortDigest;
+  }
+  return image;
+}
+
+export function extractDigestFromRepoDigest(repoDigest: string): string | null {
+  if (!repoDigest || typeof repoDigest !== 'string') {
+    return null;
+  }
+
+  const atIndex = repoDigest.lastIndexOf('@');
+  if (atIndex < 0) {
+    return null;
+  }
+
+  const digest = repoDigest.slice(atIndex + 1).trim().toLowerCase();
+  return SHA256_DIGEST_REGEX.test(digest) ? digest : null;
+}
+
+export function parseLocalImageInspect(stdout: string): {
+  digests: string[];
+  version?: string;
+} {
+  if (!stdout.trim()) {
+    return { digests: [] };
+  }
+
+  const payload = JSON.parse(stdout) as DockerImageInspectEntry[];
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return { digests: [] };
+  }
+
+  const digests = Array.from(
+    new Set(
+      payload
+        .flatMap((entry) => entry.RepoDigests ?? [])
+        .map((value) => extractDigestFromRepoDigest(value))
+        .filter((value): value is string => Boolean(value)),
+    ),
+  );
+
+  const labels = payload[0]?.Config?.Labels ?? {};
+  const version = labels['org.opencontainers.image.version']?.trim() || undefined;
+
+  return { digests, version };
+}
+
+export function parseRemoteDigestFromBuildxOutput(stdout: string): string | null {
+  if (!stdout) {
+    return null;
+  }
+
+  const match = stdout.match(/^\s*Digest:\s*(sha256:[a-f0-9]{64})\s*$/im);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function parseRemoteDigestFromManifest(stdout: string): string | null {
+  if (!stdout.trim()) {
+    return null;
+  }
+
+  const payload = JSON.parse(stdout) as Record<string, unknown>;
+  const digest = typeof payload.Digest === 'string' ? payload.Digest.trim().toLowerCase() : '';
+  return SHA256_DIGEST_REGEX.test(digest) ? digest : null;
+}


### PR DESCRIPTION
## Summary
- add an OpenSpec change and implementation for configurable runtime update-on-open behavior
- add runtime image update helpers plus focused Vitest coverage
- document the new runtime update policy in the README
- fix first-run channel image handling and make `check-only` startup non-blocking

## Verification
- `npm test`
- `npm run build`
- `make build-runtime`
- `make build-extension`

## Tracking
- Contributes to #12
- Contributes to #33
- Depends on #3 for the published-image path
