### PR TITLE
Publish runtime GHCR stable/beta channel tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,8 @@ jobs:
       contents: write
       packages: write
     steps:
-      - name: Resolve release tag
+      - name: Resolve release metadata
+        id: release-context
         env:
           INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
@@ -43,6 +44,7 @@ jobs:
           esac
 
           echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
+          ./scripts/release-channel.sh "${release_tag}" "${{ github.event_name }}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +71,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ steps.release-context.outputs.channel_tag }},enable=${{ steps.release-context.outputs.has_channel_tag }}
             type=sha,prefix=sha-
 
       - name: Build and push runtime image

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Tagged releases now publish both images to GHCR through GitHub Actions and creat
 
 Release builds of the extension UI default the runtime image field to the matching GHCR runtime tag. Local development still defaults to `openclaw-docker-extension-runtime:dev`.
 
+The publish workflow also promotes the runtime image onto a floating channel tag on real tag pushes:
+
+- `stable` for normal release tags such as `v0.2.0`
+- `beta` for prerelease tags such as `v0.2.0-rc.1`
+
+That gives the extension a predictable GHCR runtime channel for update checks without changing the pinned version-tag install path.
+
 Maintainer preflight for a newly published tag:
 
 ```bash
@@ -90,7 +97,7 @@ make verify-release-tag RELEASE_TAG=vX.Y.Z
 
 If the GitHub Actions publish job needs to be re-run for an existing tag, use the `Publish` workflow's manual dispatch and pass `release_tag=vX.Y.Z` so it rebuilds the matching GHCR artifacts instead of publishing the default branch state.
 
-That repair path only refreshes the requested versioned tags. It does not move a floating `latest` tag to an older release.
+That repair path only refreshes the requested versioned tags. It does not move the floating `stable` or `beta` runtime channel tags to an older release.
 
 Before treating the release image as verified for end users, run the Docker Desktop install/uninstall validation:
 

--- a/scripts/release-channel.sh
+++ b/scripts/release-channel.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+release_tag="${1:-${RELEASE_TAG:-}}"
+event_name="${2:-${GITHUB_EVENT_NAME:-${EVENT_NAME:-}}}"
+
+if [ -z "$release_tag" ]; then
+  echo "RELEASE_TAG is required, for example: ./scripts/release-channel.sh v0.1.0 push" >&2
+  exit 1
+fi
+
+if [ -z "$event_name" ]; then
+  echo "event name is required, for example: ./scripts/release-channel.sh v0.1.0 push" >&2
+  exit 1
+fi
+
+channel_tag=""
+has_channel_tag=false
+
+if [ "$event_name" != "workflow_dispatch" ]; then
+  case "$release_tag" in
+    *-*)
+      channel_tag="beta"
+      ;;
+    *)
+      channel_tag="stable"
+      ;;
+  esac
+  has_channel_tag=true
+fi
+
+cat <<EOF
+release_tag=${release_tag}
+channel_tag=${channel_tag}
+has_channel_tag=${has_channel_tag}
+EOF


### PR DESCRIPTION
## Summary
- publish the runtime image to a floating `stable` tag for normal `vX.Y.Z` releases
- publish the runtime image to a floating `beta` tag for prerelease tags like `vX.Y.Z-rc.1`
- keep manual `Publish` workflow repairs pinned to version tags so reruns do not move runtime channels backwards
- document the runtime channel behavior in the README

## Verification
- `./scripts/release-channel.sh v0.2.0 push`
- `./scripts/release-channel.sh v0.2.0-rc.1 push`
- `./scripts/release-channel.sh v0.2.0 workflow_dispatch`
- `ruby -e "require 'yaml'; data = YAML.load_file('.github/workflows/publish.yml'); raise 'missing publish job' unless data['jobs']['publish']; puts 'publish workflow parses';"`
- `git diff --check`

## Tracking
- Contributes to #3
- Contributes to #12
