### PR TITLE
Harden runtime filesystem without breaking startup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,16 @@ jobs:
           tags: ${{ steps.runtime-meta.outputs.tags }}
           labels: ${{ steps.runtime-meta.outputs.labels }}
 
+      - name: Run Trivy vulnerability scanner (runtime)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ steps.runtime-meta.outputs.version }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
       - name: Docker metadata for extension
         id: extension-meta
         uses: docker/metadata-action@v5
@@ -104,6 +114,16 @@ jobs:
           labels: ${{ steps.extension-meta.outputs.labels }}
           build-args: |
             VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ steps.runtime-meta.outputs.version }}
+
+      - name: Run Trivy vulnerability scanner (extension)
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}:${{ steps.extension-meta.outputs.version }}
+          format: 'table'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
 
       - name: Create or update GitHub release for tag
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ Current constraints:
 - Starts and manages an OpenClaw service container from Docker Desktop
 - Uses a bundled `socat` bridge so the Control UI is reachable on macOS
 - Persists OpenClaw state in a named Docker volume
-- Starts the service container with a read-only root filesystem, `tmpfs` at `/tmp`, `--cap-drop=ALL`, and `--security-opt no-new-privileges`
+- Starts the service container with a read-only root filesystem, `tmpfs` at `/tmp`, `--cap-drop=ALL`, `--security-opt no-new-privileges`, and `--ulimit nofile=1024:1024`
 - Exposes Docker Desktop UI controls for start, stop, restart, and open-in-browser actions
+- Performs automated vulnerability scanning (Trivy) during the GHCR publish workflow
 - Can check published GHCR channel images for runtime updates and optionally apply them before launch
 - Surfaces runtime diagnostics in a debug panel inside the extension
 
@@ -200,10 +201,10 @@ You can install and open the extension before saving a key, but Anthropic-backed
 This means the credential survives container restarts and rebuilds, but is removed if you delete the named volume.
 
 ## Security and isolation notes
-
-- The wrapper publishes OpenClaw on `127.0.0.1` only.
-- The service container uses a read-only root filesystem, mounts `/tmp` as `tmpfs`, drops all Linux capabilities, and sets `no-new-privileges` when the extension starts it.
-- OpenClaw starts through the upstream image entrypoint and runs as the `node` user, while the wrapper image adds a small `socat` bridge so Docker Desktop can forward the service on macOS.
+ 
+ - The wrapper publishes OpenClaw on `127.0.0.1` only.
+ - The service container uses a read-only root filesystem, mounts `/tmp` as `tmpfs`, drops all Linux capabilities, sets `no-new-privileges`, and restricts resource usage with `--ulimit nofile=1024:1024` when the extension starts it.
+ - OpenClaw starts through the upstream image entrypoint and runs as the `node` user, while the wrapper image adds a small `socat` bridge so Docker Desktop can forward the service on macOS.
 - State, including the write-only Anthropic key saved by the extension UI, is stored in the named Docker volume `openclaw-docker-extension-home`.
 - The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability and the service retains writable state in its volume.
 - This is a more isolated local packaging path, not a perfect security boundary.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Current constraints:
 - Starts and manages an OpenClaw service container from Docker Desktop
 - Uses a bundled `socat` bridge so the Control UI is reachable on macOS
 - Persists OpenClaw state in a named Docker volume
-- Starts the service container with `--cap-drop=ALL` and `--security-opt no-new-privileges`
+- Starts the service container with a read-only root filesystem, `tmpfs` at `/tmp`, `--cap-drop=ALL`, and `--security-opt no-new-privileges`
 - Exposes Docker Desktop UI controls for start, stop, restart, and open-in-browser actions
 - Can check published GHCR channel images for runtime updates and optionally apply them before launch
 - Surfaces runtime diagnostics in a debug panel inside the extension
@@ -202,10 +202,10 @@ This means the credential survives container restarts and rebuilds, but is remov
 ## Security and isolation notes
 
 - The wrapper publishes OpenClaw on `127.0.0.1` only.
-- The service container drops all Linux capabilities and sets `no-new-privileges` when the extension starts it.
+- The service container uses a read-only root filesystem, mounts `/tmp` as `tmpfs`, drops all Linux capabilities, and sets `no-new-privileges` when the extension starts it.
 - OpenClaw starts through the upstream image entrypoint and runs as the `node` user, while the wrapper image adds a small `socat` bridge so Docker Desktop can forward the service on macOS.
 - State, including the write-only Anthropic key saved by the extension UI, is stored in the named Docker volume `openclaw-docker-extension-home`.
-- The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability, the service retains writable state in its volume, and this repo has not finished a read-only-filesystem pass.
+- The runtime is still not a hardened sandbox yet: the bridge exists to solve localhost reachability and the service retains writable state in its volume.
 - This is a more isolated local packaging path, not a perfect security boundary.
 - This project is not an official Docker or OpenClaw extension.
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -9,4 +9,6 @@ RUN apt-get update \
 COPY openclaw-bridge.sh /usr/local/bin/openclaw-bridge.sh
 RUN chmod 755 /usr/local/bin/openclaw-bridge.sh
 
+USER node
+
 ENTRYPOINT ["sh", "/usr/local/bin/openclaw-bridge.sh"]

--- a/runtime/openclaw-bridge.sh
+++ b/runtime/openclaw-bridge.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -eu
 
-mkdir -p /tmp
-
-su node -s /bin/sh -c 'docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured >/tmp/openclaw.log 2>&1 &'
+docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured >/tmp/openclaw.log 2>&1 &
 
 exec socat TCP-LISTEN:18790,bind=0.0.0.0,reuseaddr,fork TCP:127.0.0.1:18789

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -80,7 +80,15 @@ const SUPPORTED_DOCKER_ARCH = 'arm64';
 const LEGACY_RUNTIME_IMAGE = 'ghcr.io/openclaw/openclaw:latest';
 const DEFAULT_RUNTIME_IMAGE =
   import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'openclaw-docker-extension-runtime:dev';
-const RUNTIME_SECURITY_ARGS = ['--cap-drop', 'ALL', '--security-opt', 'no-new-privileges'];
+const RUNTIME_SECURITY_ARGS = [
+  '--read-only',
+  '--tmpfs',
+  '/tmp:rw,noexec,nosuid,size=64m',
+  '--cap-drop',
+  'ALL',
+  '--security-opt',
+  'no-new-privileges',
+];
 const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,
   port: 18789,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -88,6 +88,8 @@ const RUNTIME_SECURITY_ARGS = [
   'ALL',
   '--security-opt',
   'no-new-privileges',
+  '--ulimit',
+  'nofile=1024:1024',
 ];
 const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,


### PR DESCRIPTION
Harden runtime filesystem and resource isolation.

This PR completes the security hardening for Issue #10.

### Changes:
- **Rootless Hardening**: Moves the wrapper to run as the upstream `node` user.
- **Filesystem Isolation**: Implements a read-only root filesystem with `tmpfs` for `/tmp`.
- **Resource Protection**: Adds `--ulimit nofile=1024:1024` to prevent resource exhaustion.
- **Automated Security**: Integrates Trivy vulnerability scanning into the GHCR publish workflow.
- **Documentation**: Aligns the README isolation notes with the new runtime defaults.

Closes #10