### PR TITLE
Add release-channel regression coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Build extension image
         run: docker build -t openclaw-docker-extension:test .
 
+      - name: Verify release channel mapping
+        run: make test-release-channel
+
       - name: Verify release bundle wiring
         run: make verify-release-bundle RELEASE_TAG=v0.0.0-ci

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ update-release:
 verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
 
+test-release-channel: ; @./scripts/test-release-channel.sh
+
 verify-release-bundle:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-bundle.sh
 
@@ -59,4 +61,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot

--- a/scripts/test-release-channel.sh
+++ b/scripts/test-release-channel.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -eu
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null 2>&1; then
+    echo "expected output to contain: $needle" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_case() {
+  description="$1"
+  release_tag="$2"
+  event_name="$3"
+  expected_channel="$4"
+  expected_flag="$5"
+
+  output="$(./scripts/release-channel.sh "$release_tag" "$event_name")"
+  assert_contains "$output" "release_tag=${release_tag}"
+  assert_contains "$output" "channel_tag=${expected_channel}"
+  assert_contains "$output" "has_channel_tag=${expected_flag}"
+  echo "passed: ${description}"
+}
+
+assert_case "stable channel on tag push" "v1.2.3" "push" "stable" "true"
+assert_case "beta channel on prerelease tag push" "v1.2.3-rc.1" "push" "beta" "true"
+assert_case "manual repair keeps version-only publish" "v1.2.3" "workflow_dispatch" "" "false"
+assert_case "manual prerelease repair keeps version-only publish" "v1.2.3-rc.1" "workflow_dispatch" "" "false"
+
+echo "release-channel checks passed"


### PR DESCRIPTION
## Summary
- add a dedicated shell test for `scripts/release-channel.sh`
- expose the check through `make test-release-channel`
- run that check in the `Build` workflow before release-bundle verification

## Verification
- `make test-release-channel`
- `make verify-release-bundle RELEASE_TAG=v0.0.0-ci`

## Tracking
- Contributes to #3
- Contributes to #12
