### PR TITLE
Update roadmap priorities after issue #10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
 - Issue [#7](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/7) is already closed; treat onboarding work as completed.
 - Active priority order:
   1. [#3](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/3) pre-built GHCR images
-  2. [#10](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/10) security and isolation story
-  3. [#5](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/5) architecture support and graceful failure
+  2. [#5](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/5) architecture support and graceful failure
+- Anything beyond those open MVP issues is unknown until issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) says otherwise.
 - Do not pick up "nice-to-have" work ahead of MVP issues unless explicitly requested.
 
 ## Decision Gates


### PR DESCRIPTION
Contributes to #12\n\n## Summary\n- remove closed issue #10 from the active priority list in AGENTS.md\n- keep #3 first and #5 second\n- mark anything beyond those open MVP issues as unknown until roadmap issue #12 changes\n\n## Verification\n- git diff --check\n- make verify-release-tag RELEASE_TAG=v0.1.0-user-verified (expected failure: GitHub release missing for the real tag)