### PR TITLE
Add dry-run rehearsal for release install helpers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Verify release channel mapping
         run: make test-release-channel
 
+      - name: Verify release install dry-run wrappers
+        run: make test-release-install-dry-run
+
       - name: Verify release bundle wiring
         run: make verify-release-bundle RELEASE_TAG=v0.0.0-ci

--- a/Makefile
+++ b/Makefile
@@ -25,20 +25,15 @@ install-dev: build-runtime build-extension
 update-extension: build-runtime build-extension
 	docker extension update $(IMAGE):$(TAG)
 
-install-release:
-	@test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1)
-	@RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" ./scripts/verify-release-image.sh
-	docker extension install -f $(RELEASE_EXTENSION_IMAGE)
+install-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(RELEASE_EXTENSION_IMAGE)"; else docker extension install -f $(RELEASE_EXTENSION_IMAGE); fi
 
-update-release:
-	@test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1)
-	@RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" ./scripts/verify-release-image.sh
-	docker extension update $(RELEASE_EXTENSION_IMAGE)
+update-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(RELEASE_EXTENSION_IMAGE)"; else docker extension update $(RELEASE_EXTENSION_IMAGE); fi
 
 verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
 
 test-release-channel: ; @./scripts/test-release-channel.sh
+test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 
 verify-release-bundle:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-bundle.sh
@@ -61,4 +56,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel test-release-install-dry-run verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Use these commands depending on where you are in the flow:
 - `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer repair path that publishes the GitHub release if needed, verifies the GHCR tags, then validates Docker Desktop install/uninstall
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image after an anonymous GHCR preflight
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image after the same preflight
+- add `DRY_RUN=1` to `install-release`, `update-release`, or `ship-release` to rehearse the documented release path without mutating Docker Desktop
 - `make uninstall`: remove the extension from Docker Desktop
 - `make capture-readme-screenshot`: rebuild the demo UI and refresh the checked-in README screenshot
 
@@ -130,10 +131,23 @@ The repo-level shortcut checks the published tag first so a missing GHCR release
 make install-release RELEASE_TAG=vX.Y.Z
 ```
 
+To rehearse the same install wrapper without changing Docker Desktop state:
+
+```bash
+make install-release RELEASE_TAG=vX.Y.Z DRY_RUN=1
+```
+
 To update an existing release install:
 
 ```bash
 docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:vX.Y.Z
+```
+
+Or use the repo shortcut with the same preflight and optional dry-run:
+
+```bash
+make update-release RELEASE_TAG=vX.Y.Z
+make update-release RELEASE_TAG=vX.Y.Z DRY_RUN=1
 ```
 
 If there is no tagged release yet, use the local build path in the quick start instead.

--- a/scripts/test-release-install-dry-run.sh
+++ b/scripts/test-release-install-dry-run.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null 2>&1; then
+    echo "expected output to contain: $needle" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_case() {
+  description="$1"
+  target="$2"
+  expected_command="$3"
+
+  output="$(make "$target" RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
+  assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+  assert_contains "$output" "$expected_command"
+  echo "passed: ${description}"
+}
+
+assert_case \
+  "install-release dry run prints install command" \
+  "install-release" \
+  "dry run: docker extension install -f ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+
+assert_case \
+  "update-release dry run prints update command" \
+  "update-release" \
+  "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+
+echo "release install dry-run checks passed"


### PR DESCRIPTION
## Summary
- add `DRY_RUN=1` support to the documented `make install-release` and `make update-release` wrappers
- add a shell regression test plus CI coverage for the dry-run install/update path
- document the rehearsal commands in the README

## Verification
- `git diff --check`
- `make test-release-install-dry-run`
- `make test-release-channel`
- `make verify-release-bundle RELEASE_TAG=v0.0.0-ci DRY_RUN=1`

Contributes to #3