### PR TITLE
Verify published tags via anonymous GHCR access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Verify release channel mapping
         run: make test-release-channel
 
+      - name: Verify release tag dry-run
+        run: make test-release-tag-dry-run
+
       - name: Verify release install dry-run wrappers
         run: make test-release-install-dry-run
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,27 @@ jobs:
           esac
 
           echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
-          ./scripts/release-channel.sh "${release_tag}" "${{ github.event_name }}" >> "${GITHUB_OUTPUT}"
+
+          channel_tag=""
+          has_channel_tag=false
+
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            case "${release_tag}" in
+              *-*)
+                channel_tag="beta"
+                ;;
+              *)
+                channel_tag="stable"
+                ;;
+            esac
+            has_channel_tag=true
+          fi
+
+          {
+            echo "release_tag=${release_tag}"
+            echo "channel_tag=${channel_tag}"
+            echo "has_channel_tag=${has_channel_tag}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,6 +106,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (runtime)
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_PLATFORM: linux/arm64
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ steps.runtime-meta.outputs.version }}
           format: 'table'
@@ -137,6 +139,8 @@ jobs:
 
       - name: Run Trivy vulnerability scanner (extension)
         uses: aquasecurity/trivy-action@master
+        env:
+          TRIVY_PLATFORM: linux/arm64
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}:${{ steps.extension-meta.outputs.version }}
           format: 'table'

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
 
 test-release-channel: ; @./scripts/test-release-channel.sh
+test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 
 verify-release-bundle:
@@ -56,4 +57,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel test-release-install-dry-run verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel test-release-tag-dry-run test-release-install-dry-run verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -69,12 +69,6 @@ Maintainer preflight for a newly published tag:
 make verify-release-tag RELEASE_TAG=vX.Y.Z
 ```
 
-That maintainer check uses `gh` for release metadata plus package visibility, so the local `gh` token needs both `repo` and `read:packages` scopes. If the verifier says a scope is missing, run:
-
-```bash
-gh auth refresh -s repo -s read:packages
-```
-
 Local maintainer check before publishing a new tag:
 
 ```bash

--- a/scripts/test-release-tag-dry-run.sh
+++ b/scripts/test-release-tag-dry-run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null 2>&1; then
+    echo "expected output to contain: $needle" >&2
+    echo "actual output:" >&2
+    printf '%s\n' "$haystack" >&2
+    exit 1
+  fi
+}
+
+output="$(make verify-release-tag RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
+assert_contains "$output" "dry run: gh api /repos/jcowhigjr/openclaw-docker-desktop-extension/releases/tags/v1.2.3"
+assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3"
+
+echo "release tag dry-run checks passed"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -7,6 +7,8 @@ repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
+extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}"
+runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-tag RELEASE_TAG=v0.1.0" >&2
@@ -16,16 +18,19 @@ fi
 if [ "$dry_run" = "1" ]; then
   cat <<EOF
 dry run: gh api /repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}
-dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension/versions?per_page=100 --paginate
-dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension
-dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension-runtime/versions?per_page=100 --paginate
-dry run: gh api /users/${ghcr_owner}/packages/container/openclaw-docker-desktop-extension-runtime
+dry run: docker manifest inspect ${extension_image}
+dry run: docker manifest inspect ${runtime_image}
 EOF
   exit 0
 fi
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "GitHub CLI is required for release verification." >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker CLI is required for release verification." >&2
   exit 1
 fi
 
@@ -36,36 +41,7 @@ if ! printf '%s\n' "$auth_status" | grep -F "Active account: true" >/dev/null 2>
   exit 1
 fi
 
-require_auth_scope() {
-  required_scope="$1"
-
-  if printf '%s\n' "$auth_status" | grep -F "'${required_scope}'" >/dev/null 2>&1; then
-    return 0
-  fi
-
-  echo "gh token is missing the required scope: ${required_scope}" >&2
-  echo "Next step: run 'gh auth refresh -s ${required_scope}' and rerun make verify-release-tag RELEASE_TAG=${release_tag}." >&2
-  exit 1
-}
-
-resolve_package_owner_scope() {
-  package_name="$1"
-
-  require_auth_scope "read:packages"
-
-  for owner_scope in users orgs; do
-    if gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}" >/dev/null 2>&1; then
-      echo "$owner_scope"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
 require_release() {
-  require_auth_scope "repo"
-
   if gh api "/repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}" >/dev/null 2>&1; then
     echo "release exists: ${release_tag}"
     return 0
@@ -82,64 +58,22 @@ require_release() {
   return 1
 }
 
-require_package_tag() {
-  package_name="$1"
-  image_name="$2"
-  owner_scope="$(resolve_package_owner_scope "$package_name" || true)"
+require_anonymous_manifest() {
+  image_ref="$1"
 
-  if [ -z "$owner_scope" ]; then
-    echo "ghcr package details unavailable: ghcr.io/${ghcr_owner}/${image_name}" >&2
-    echo "Next step: confirm the package exists under ${ghcr_owner} and is visible to GitHub Packages." >&2
-    return 1
-  fi
-
-  if gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}/versions?per_page=100" \
-    --paginate \
-    --jq ".[] | select(any(.metadata.container.tags[]?; . == \"${release_tag}\")) | .id" \
-    | grep -q '.'; then
-    echo "ghcr tag exists: ghcr.io/${ghcr_owner}/${image_name}:${release_tag}"
+  if docker manifest inspect "$image_ref" >/dev/null 2>&1; then
+    echo "ghcr tag is publicly readable: ${image_ref}"
     return 0
   fi
 
-  echo "ghcr tag missing: ghcr.io/${ghcr_owner}/${image_name}:${release_tag}" >&2
-  echo "Next step: confirm the publish workflow completed and the package is public." >&2
-  return 1
-}
-
-require_package_public() {
-  package_name="$1"
-  image_name="$2"
-  owner_scope="$(resolve_package_owner_scope "$package_name" || true)"
-
-  if [ -z "$owner_scope" ]; then
-    echo "ghcr package details unavailable: ghcr.io/${ghcr_owner}/${image_name}" >&2
-    echo "Next step: confirm the package exists under ${ghcr_owner} and is visible to GitHub Packages." >&2
-    return 1
-  fi
-
-  visibility="$(gh api "/${owner_scope}/${ghcr_owner}/packages/container/${package_name}" --jq '.visibility' 2>/dev/null || true)"
-
-  if [ "$visibility" = "public" ]; then
-    echo "ghcr package is public: ghcr.io/${ghcr_owner}/${image_name}"
-    return 0
-  fi
-
-  if [ -z "$visibility" ]; then
-    echo "ghcr package details unavailable: ghcr.io/${ghcr_owner}/${image_name}" >&2
-    echo "Next step: confirm the package exists under ${ghcr_owner} and is visible to GitHub Packages." >&2
-    return 1
-  fi
-
-  echo "ghcr package is not public (${visibility}): ghcr.io/${ghcr_owner}/${image_name}" >&2
-  echo "Next step: change the package visibility to public so end users can install it without authentication." >&2
+  echo "ghcr tag is missing or not publicly readable: ${image_ref}" >&2
+  echo "Next step: confirm the publish workflow completed and the GHCR package is public." >&2
   return 1
 }
 
 require_release
-require_package_tag "openclaw-docker-desktop-extension" "openclaw-docker-desktop-extension"
-require_package_public "openclaw-docker-desktop-extension" "openclaw-docker-desktop-extension"
-require_package_tag "openclaw-docker-desktop-extension-runtime" "openclaw-docker-desktop-extension-runtime"
-require_package_public "openclaw-docker-desktop-extension-runtime" "openclaw-docker-desktop-extension-runtime"
+require_anonymous_manifest "${extension_image}"
+require_anonymous_manifest "${runtime_image}"
 
 cat <<EOF
 Release install path is ready for this tag:


### PR DESCRIPTION
## Summary
- verify release tags against anonymous `docker manifest inspect` reads instead of GitHub Packages API scopes
- add CI coverage for the verifier dry-run output
- remove the stale README note that claimed `read:packages` was required for the maintainer preflight

## Verification
- git diff --check
- make test-release-tag-dry-run
- make test-release-install-dry-run
- make test-release-channel
- make verify-release-bundle RELEASE_TAG=v0.0.0-ci DRY_RUN=1
- make verify-release-tag RELEASE_TAG=v0.1.0-user-verified
- make publish-release RELEASE_TAG=v0.1.0-user-verified
- make verify-release-tag RELEASE_TAG=v0.1.0-user-verified
- make verify-release-install RELEASE_TAG=v0.1.0-user-verified

Contributes to #3