### PR TITLE
Add stable GHCR extension install path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,6 +123,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ steps.release-context.outputs.channel_tag }},enable=${{ steps.release-context.outputs.has_channel_tag }}
             type=sha,prefix=sha-
 
       - name: Build and push extension image

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ RUNTIME_TAG ?= dev
 DEFAULT_RUNTIME_IMAGE ?= $(RUNTIME_IMAGE):$(RUNTIME_TAG)
 GHCR_OWNER ?= jcowhigjr
 RELEASE_TAG ?=
+RELEASE_CHANNEL ?= stable
 REPO_OWNER ?= jcowhigjr
 REPO_NAME ?= openclaw-docker-desktop-extension
 RELEASE_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_TAG)
+CHANNEL_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_CHANNEL)
 SCREENSHOT_URL ?= http://127.0.0.1:4173/?demo=1
 SCREENSHOT_PATH ?= docs/assets/openclaw-extension-dashboard.png
 
@@ -28,6 +30,10 @@ update-extension: build-runtime build-extension
 install-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(RELEASE_EXTENSION_IMAGE)"; else docker extension install -f $(RELEASE_EXTENSION_IMAGE); fi
 
 update-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(RELEASE_EXTENSION_IMAGE)"; else docker extension update $(RELEASE_EXTENSION_IMAGE); fi
+
+install-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is required, for example: make install-channel RELEASE_CHANNEL=stable" && exit 1); IMAGE_TAG="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(CHANNEL_EXTENSION_IMAGE)"; else docker extension install -f $(CHANNEL_EXTENSION_IMAGE); fi
+
+update-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is required, for example: make update-channel RELEASE_CHANNEL=stable" && exit 1); IMAGE_TAG="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(CHANNEL_EXTENSION_IMAGE)"; else docker extension update $(CHANNEL_EXTENSION_IMAGE); fi
 
 verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
@@ -57,4 +63,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension install-release update-release verify-release-tag test-release-channel test-release-tag-dry-run test-release-install-dry-run verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension install-release update-release install-channel update-channel verify-release-tag test-release-channel test-release-tag-dry-run test-release-install-dry-run verify-release-bundle verify-release-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Use these commands depending on where you are in the flow:
 - `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer repair path that publishes the GitHub release if needed, verifies the GHCR tags, then validates Docker Desktop install/uninstall
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image after an anonymous GHCR preflight
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image after the same preflight
+- `make install-channel RELEASE_CHANNEL=stable`: install the current published GHCR channel image with the same preflight
+- `make update-channel RELEASE_CHANNEL=stable`: update an installed GHCR channel image with the same preflight
 - add `DRY_RUN=1` to `install-release`, `update-release`, or `ship-release` to rehearse the documented release path without mutating Docker Desktop
 - `make uninstall`: remove the extension from Docker Desktop
 - `make capture-readme-screenshot`: rebuild the demo UI and refresh the checked-in README screenshot
@@ -49,12 +51,12 @@ Tagged releases now publish both images to GHCR through GitHub Actions and creat
 
 Release builds of the extension UI default the runtime image field to the matching GHCR runtime tag. Local development still defaults to `openclaw-docker-extension-runtime:dev`.
 
-The publish workflow also promotes the runtime image onto a floating channel tag on real tag pushes:
+The publish workflow also promotes both images onto floating channel tags on real tag pushes:
 
 - `stable` for normal release tags such as `v0.2.0`
 - `beta` for prerelease tags such as `v0.2.0-rc.1`
 
-That gives the extension a predictable GHCR runtime channel for update checks without changing the pinned version-tag install path.
+That gives end users a one-line extension install path and gives the extension a predictable GHCR runtime channel for update checks without changing the pinned version-tag install path.
 
 When the runtime image points at a published GHCR channel tag such as `stable` or `beta`, the extension can check for a newer runtime image on open and again before launch. The current MVP update policies are:
 
@@ -125,6 +127,19 @@ The repo-level shortcut checks the published tag first so a missing GHCR release
 make install-release RELEASE_TAG=vX.Y.Z
 ```
 
+If you want the latest published channel instead of a pinned tag, use the floating GHCR channel image:
+
+```bash
+docker extension install ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable
+```
+
+Or use the repo shortcut with the same preflight and optional dry-run:
+
+```bash
+make install-channel RELEASE_CHANNEL=stable
+make install-channel RELEASE_CHANNEL=stable DRY_RUN=1
+```
+
 To rehearse the same install wrapper without changing Docker Desktop state:
 
 ```bash
@@ -142,6 +157,13 @@ Or use the repo shortcut with the same preflight and optional dry-run:
 ```bash
 make update-release RELEASE_TAG=vX.Y.Z
 make update-release RELEASE_TAG=vX.Y.Z DRY_RUN=1
+```
+
+For the floating channel install path:
+
+```bash
+make update-channel RELEASE_CHANNEL=stable
+make update-channel RELEASE_CHANNEL=stable DRY_RUN=1
 ```
 
 If there is no tagged release yet, use the local build path in the quick start instead.

--- a/scripts/test-release-install-dry-run.sh
+++ b/scripts/test-release-install-dry-run.sh
@@ -17,10 +17,11 @@ assert_contains() {
 assert_case() {
   description="$1"
   target="$2"
-  expected_command="$3"
+  expected_manifest="$3"
+  expected_command="$4"
 
   output="$(make "$target" RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
-  assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+  assert_contains "$output" "$expected_manifest"
   assert_contains "$output" "$expected_command"
   echo "passed: ${description}"
 }
@@ -28,11 +29,25 @@ assert_case() {
 assert_case \
   "install-release dry run prints install command" \
   "install-release" \
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" \
   "dry run: docker extension install -f ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
 
 assert_case \
   "update-release dry run prints update command" \
   "update-release" \
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" \
   "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+
+assert_case \
+  "install-channel dry run prints channel install command" \
+  "install-channel" \
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable" \
+  "dry run: docker extension install -f ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable"
+
+assert_case \
+  "update-channel dry run prints channel update command" \
+  "update-channel" \
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable" \
+  "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable"
 
 echo "release install dry-run checks passed"

--- a/scripts/verify-release-image.sh
+++ b/scripts/verify-release-image.sh
@@ -2,14 +2,14 @@
 
 set -eu
 
-release_tag="${1:-${RELEASE_TAG:-}}"
+image_tag="${1:-${IMAGE_TAG:-${RELEASE_TAG:-}}}"
 ghcr_owner="${GHCR_OWNER:-jcowhigjr}"
 image_name="${IMAGE_NAME:-openclaw-docker-desktop-extension}"
-image_ref="ghcr.io/${ghcr_owner}/${image_name}:${release_tag}"
+image_ref="ghcr.io/${ghcr_owner}/${image_name}:${image_tag}"
 dry_run="${DRY_RUN:-0}"
 
-if [ -z "$release_tag" ]; then
-  echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" >&2
+if [ -z "$image_tag" ]; then
+  echo "IMAGE_TAG or RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" >&2
   exit 1
 fi
 
@@ -37,6 +37,6 @@ Published extension image is not available yet:
 
 Next step:
   - If you are testing before the first public tag, use 'make install-dev'.
-  - If this tag should exist, run 'make verify-release-tag RELEASE_TAG=${release_tag}' as a maintainer.
+  - If this tag should exist, run 'make verify-release-tag RELEASE_TAG=${image_tag}' as a maintainer.
 EOF
 exit 1


### PR DESCRIPTION
## Summary
- publish floating `stable`/`beta` tags for the extension image alongside the runtime image
- add `make install-channel` and `make update-channel` wrappers with anonymous GHCR preflight
- document the one-line channel-based install/update path for MVP users

## Verification
- make test-release-install-dry-run
- make test-release-channel
- make test-release-tag-dry-run

Contributes to #3