### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jcowhigjr/openclaw-docker-desktop-extension/security/code-scanning/1](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the token is least-privileged by default.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for `actions/checkout` and the shown build/test steps, and does not change current functional behavior.

Change location:
- File: `.github/workflows/build.yml`
- Insert the `permissions` block between the existing `on:` trigger block and `jobs:`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
