### PR TITLE
Schedule runtime image refresh

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -3,12 +3,20 @@ name: Publish runtime image
 on:
   push:
     branches: [main]
-    paths: ['runtime/**']
+    paths:
+      - 'runtime/**'
+      - '.github/workflows/publish-runtime.yml'
+  schedule:
+    # Rebuild the wrapper against ghcr.io/openclaw/openclaw:latest even when this repo is unchanged.
+    - cron: '17 9 * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
+
+env:
+  RUNTIME_IMAGE: ghcr.io/${{ github.repository_owner }}/openclaw-docker-extension-runtime
 
 jobs:
   build-and-push:
@@ -25,7 +33,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/openclaw-docker-extension-runtime
+          images: ${{ env.RUNTIME_IMAGE }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=sha-,format=short
@@ -37,3 +45,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Verify published runtime image
+        run: docker buildx imagetools inspect "${RUNTIME_IMAGE}:latest"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ The publish workflow also promotes both images onto floating channel tags on rea
 
 That gives end users a one-line extension install path and gives the extension a predictable GHCR runtime channel for update checks without changing the pinned version-tag install path.
 
-When the runtime image points at a published GHCR channel tag such as `stable` or `beta`, the extension can check for a newer runtime image on open and again before launch. The current MVP update policies are:
+When the runtime image points at a published GHCR channel tag such as `stable` or `beta`, the extension can check for a newer runtime image on open and again before launch.
+
+The standalone runtime publish workflow also refreshes `ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest` on a daily schedule and can still be run manually with `workflow_dispatch`. That scheduled rebuild is how the wrapper picks up new `ghcr.io/openclaw/openclaw:latest` content when this repo has no file changes, so upstream OpenClaw updates become available after the next scheduled runtime rebuild and GHCR push, not instantly at the moment upstream publishes them.
+
+The current MVP update policies are:
 
 - `Check only`: show an update banner and let the user trigger the update manually
 - `Auto-update before launch`: pull the newer runtime image and recreate the service container before `Start`


### PR DESCRIPTION
### Motivation
- Ensure the runtime wrapper image is rebuilt periodically so the extension picks up upstream `ghcr.io/openclaw/openclaw:latest` changes even when this repository has no file changes.
- Preserve manual refresh capability while providing an automated daily refresh to reduce drift between upstream OpenClaw and the published runtime image.
- Add a lightweight verification step to fail fast if the pushed floating runtime tag cannot be inspected.

### Description
- Add a `schedule:` trigger to `.github/workflows/publish-runtime.yml` with a daily cron while keeping `workflow_dispatch` for manual runs.
- Introduce an `env` variable `RUNTIME_IMAGE` and use it for the metadata/push steps, and add a post-push verification step that runs `docker buildx imagetools inspect "${RUNTIME_IMAGE}:latest"`.
- Expand the workflow `push` paths to include `.github/workflows/publish-runtime.yml` so updating the workflow will also retrigger builds, and update `README.md` to document that upstream OpenClaw updates arrive after the scheduled runtime rebuild and GHCR push.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues (succeeded).
- Parsed the modified workflow YAML with Ruby (`ruby -e 'require "yaml"; YAML.load_file(...)'`) which succeeded (YAML is valid).
- Attempted a local `docker build -t openclaw-docker-extension-runtime:test -f runtime/Dockerfile runtime`, but the Docker CLI is not available in this environment so the build could not be executed (not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd2f3796cc8321bb56cc397b9b7ceb)