### PR TITLE
[codex] Add Ollama local model setup flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,9 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
   - the extension UI state
   - the relevant OpenClaw UI state when the feature crosses that boundary
 - If verification is partial, say exactly what ran and what did not.
+
+## Local Developer Notes
+
+- On this workstation, Docker Desktop CLI symlinks are installed under `$HOME/.docker/bin`.
+- If `docker` resolves to another install or cannot reach the Desktop engine, use `$HOME/.docker/bin/docker` or add `$HOME/.docker/bin` to `PATH` before live Docker validation.
+- Current local-model development assumes host Ollama is already running on `127.0.0.1:11434`; container-to-host checks should use `http://host.docker.internal:11434`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
   - the relevant OpenClaw UI state when the feature crosses that boundary
 - If verification is partial, say exactly what ran and what did not.
 
-## Local Developer Notes
+## Workstation-Specific Local Developer Notes
 
 - On this workstation, Docker Desktop CLI symlinks are installed under `$HOME/.docker/bin`.
 - If `docker` resolves to another install or cannot reach the Desktop engine, use `$HOME/.docker/bin/docker` or add `$HOME/.docker/bin` to `PATH` before live Docker validation.

--- a/runtime/openclaw-bridge.sh
+++ b/runtime/openclaw-bridge.sh
@@ -1,6 +1,37 @@
 #!/bin/sh
 set -eu
 
-docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured >/tmp/openclaw.log 2>&1 &
+tmp_dir="/tmp/openclaw-$(id -u)"
+mkdir -p "$tmp_dir"
+chmod 700 "$tmp_dir"
 
-exec socat TCP-LISTEN:18790,bind=0.0.0.0,reuseaddr,fork TCP:127.0.0.1:18789
+docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured >/tmp/openclaw.log 2>&1 &
+openclaw_pid=$!
+
+socat TCP-LISTEN:18790,bind=0.0.0.0,reuseaddr,fork TCP:127.0.0.1:18789 &
+socat_pid=$!
+
+shutdown() {
+  kill "$openclaw_pid" "$socat_pid" 2>/dev/null || true
+  wait "$openclaw_pid" "$socat_pid" 2>/dev/null || true
+}
+
+trap shutdown INT TERM
+
+while :; do
+  if ! kill -0 "$openclaw_pid" 2>/dev/null; then
+    wait "$openclaw_pid"
+    status=$?
+    kill "$socat_pid" 2>/dev/null || true
+    exit "$status"
+  fi
+
+  if ! kill -0 "$socat_pid" 2>/dev/null; then
+    wait "$socat_pid"
+    status=$?
+    kill "$openclaw_pid" 2>/dev/null || true
+    exit "$status"
+  fi
+
+  sleep 2
+done

--- a/scripts/test-runtime-bridge.sh
+++ b/scripts/test-runtime-bridge.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+script="runtime/openclaw-bridge.sh"
+
+if ! grep -F 'tmp_dir="/tmp/openclaw-$(id -u)"' "$script" >/dev/null; then
+  echo "runtime bridge must create the OpenClaw fallback temp dir for the node user" >&2
+  exit 1
+fi
+
+if ! grep -F 'openclaw_pid=$!' "$script" >/dev/null; then
+  echo "runtime bridge must track the OpenClaw child process" >&2
+  exit 1
+fi
+
+if ! grep -F 'socat_pid=$!' "$script" >/dev/null; then
+  echo "runtime bridge must track the socat child process" >&2
+  exit 1
+fi
+
+if grep -F 'exec socat' "$script" >/dev/null; then
+  echo "runtime bridge must not exec socat and orphan OpenClaw failures" >&2
+  exit 1
+fi
+
+echo "runtime bridge checks passed"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,7 +21,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getDDClient } from './dockerDesktopClient';
 import {
-  buildOllamaAuthProfilesStore,
+  buildOllamaAuthProfilesWriteScript,
+  buildOllamaConfigWriteScript,
+  buildOllamaTagsFetchScript,
   chooseRecommendedOllamaModel,
   normalizeOllamaModelName,
   parseOllamaTags,
@@ -128,6 +130,7 @@ export function App() {
   const [configuredOllamaModel, setConfiguredOllamaModel] = useState('');
   const [ollamaChecking, setOllamaChecking] = useState(false);
   const [ollamaStatus, setOllamaStatus] = useState('');
+  const [ollamaAlertSeverity, setOllamaAlertSeverity] = useState<'success' | 'info' | 'error'>('info');
   const selectedOllamaChanged = Boolean(selectedOllamaModel) && selectedOllamaModel !== configuredOllamaModel;
 
   const persistConfig = useCallback((next: ExtensionConfig) => {
@@ -389,13 +392,18 @@ export function App() {
     setOllamaChecking(true);
     setError('');
     setOllamaStatus('');
+    setOllamaAlertSeverity('info');
     try {
-      const result = (await ddClient.docker.cli.exec('run', [
-        '--rm',
-        'alpine:latest',
-        'wget',
-        '-qO-',
-        'http://host.docker.internal:11434/api/tags',
+      const container = await findContainer();
+      if (!container || container.state !== 'running') {
+        throw new Error('Start OpenClaw before detecting local Ollama models.');
+      }
+
+      const result = (await ddClient.docker.cli.exec('exec', [
+        container.id,
+        'node',
+        '-e',
+        buildOllamaTagsFetchScript(),
       ])) as CliExecResult;
       const stderr = asText(result.stderr).trim();
       if (stderr) {
@@ -404,7 +412,7 @@ export function App() {
 
       const models = parseOllamaTags(asText(result.stdout));
       const currentModelResult = (await ddClient.docker.cli.exec('exec', [
-        CONTAINER_NAME,
+        container.id,
         'node',
         'openclaw.mjs',
         'config',
@@ -415,6 +423,7 @@ export function App() {
       setOllamaModels(models);
       setConfiguredOllamaModel(currentModel);
       setSelectedOllamaModel((current) => current || currentModel || chooseRecommendedOllamaModel(models));
+      setOllamaAlertSeverity(models.length > 0 ? 'success' : 'info');
       setOllamaStatus(
         models.length > 0
           ? `Detected ${models.length} host Ollama model${models.length === 1 ? '' : 's'}${currentModel ? `; configured model is ${currentModel}.` : '.'}`
@@ -424,6 +433,7 @@ export function App() {
       const text = err instanceof Error ? err.message : String(err);
       appendDebug(`ollama detect failed: ${text}`);
       setOllamaModels([]);
+      setOllamaAlertSeverity('error');
       setOllamaStatus(`Could not reach host Ollama from OpenClaw: ${text}`);
     } finally {
       setOllamaChecking(false);
@@ -446,26 +456,9 @@ export function App() {
         throw new Error('Start OpenClaw before applying local model setup.');
       }
 
-      const setConfigValue = async (path: string, value: string, strictJson = false) => {
-        const args = [container.id, 'node', 'openclaw.mjs', 'config', 'set', path, value];
-        if (strictJson) {
-          args.push('--strict-json');
-        }
-        await ddClient.docker.cli.exec('exec', args);
-      };
-
       appendDebug(`configuring OpenClaw Ollama provider for ${model}`);
-      await setConfigValue('models.providers.ollama.api', 'ollama');
-      await setConfigValue('models.providers.ollama.apiKey', 'ollama-local');
-      await setConfigValue('models.providers.ollama.baseUrl', 'http://host.docker.internal:11434');
-      await setConfigValue('models.providers.ollama.models[0].id', model);
-      await setConfigValue('models.providers.ollama.models[0].name', model);
-      await setConfigValue('models.providers.ollama.models[0].reasoning', 'false', true);
-      await setConfigValue('agents.defaults.model.primary', `ollama/${model}`);
-      await setConfigValue('agents.defaults.timeoutSeconds', '300', true);
-      const authProfilesJson = JSON.stringify(buildOllamaAuthProfilesStore());
-      const writeAuthProfilesCode = `const fs=require("fs"); const path=require("path"); const file="/home/node/.openclaw/agents/main/agent/auth-profiles.json"; fs.mkdirSync(path.dirname(file), {recursive:true}); const data=${authProfilesJson}; fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\\n");`;
-      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', writeAuthProfilesCode]);
+      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', buildOllamaConfigWriteScript(model)]);
+      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', buildOllamaAuthProfilesWriteScript()]);
       await ddClient.docker.cli.exec('exec', [
         container.id,
         'node',
@@ -804,7 +797,7 @@ export function App() {
                 ))}
               </TextField>
               {ollamaStatus && (
-                <Alert severity={ollamaModels.length > 0 ? 'success' : 'info'}>{ollamaStatus}</Alert>
+                <Alert severity={ollamaAlertSeverity}>{ollamaStatus}</Alert>
               )}
             </Stack>
           </CardContent>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getDDClient } from './dockerDesktopClient';
 import {
+  buildOllamaAuthProfilesStore,
   chooseRecommendedOllamaModel,
   normalizeOllamaModelName,
   parseOllamaTags,
@@ -462,6 +463,23 @@ export function App() {
       await setConfigValue('models.providers.ollama.models[0].reasoning', 'false', true);
       await setConfigValue('agents.defaults.model.primary', `ollama/${model}`);
       await setConfigValue('agents.defaults.timeoutSeconds', '300', true);
+      const authProfilesJson = JSON.stringify(buildOllamaAuthProfilesStore());
+      const writeAuthProfilesCode = `const fs=require("fs"); const path=require("path"); const file="/home/node/.openclaw/agents/main/agent/auth-profiles.json"; fs.mkdirSync(path.dirname(file), {recursive:true}); const data=${authProfilesJson}; fs.writeFileSync(file, JSON.stringify(data, null, 2) + "\\n");`;
+      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', writeAuthProfilesCode]);
+      await ddClient.docker.cli.exec('exec', [
+        container.id,
+        'node',
+        'openclaw.mjs',
+        'models',
+        'auth',
+        'order',
+        'set',
+        '--agent',
+        'main',
+        '--provider',
+        'ollama',
+        'ollama:manual',
+      ]);
       appendDebug(`OpenClaw default model set to ollama/${model}`);
       setOllamaStatus(`Configured OpenClaw to use Ollama model ${model}. Restarting OpenClaw...`);
       await restart();

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -20,6 +20,12 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getDDClient } from './dockerDesktopClient';
+import {
+  chooseRecommendedOllamaModel,
+  normalizeOllamaModelName,
+  parseOllamaTags,
+  type OllamaModel,
+} from './ollamaSetup';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 
@@ -116,6 +122,12 @@ export function App() {
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [updateChecking, setUpdateChecking] = useState(false);
   const [updateError, setUpdateError] = useState('');
+  const [ollamaModels, setOllamaModels] = useState<OllamaModel[]>([]);
+  const [selectedOllamaModel, setSelectedOllamaModel] = useState('');
+  const [configuredOllamaModel, setConfiguredOllamaModel] = useState('');
+  const [ollamaChecking, setOllamaChecking] = useState(false);
+  const [ollamaStatus, setOllamaStatus] = useState('');
+  const selectedOllamaChanged = Boolean(selectedOllamaModel) && selectedOllamaModel !== configuredOllamaModel;
 
   const persistConfig = useCallback((next: ExtensionConfig) => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -371,6 +383,99 @@ export function App() {
     await navigator.clipboard.writeText(token);
     setMessage('Gateway token copied to clipboard.');
   }, [token]);
+
+  const detectOllamaModels = useCallback(async () => {
+    setOllamaChecking(true);
+    setError('');
+    setOllamaStatus('');
+    try {
+      const result = (await ddClient.docker.cli.exec('run', [
+        '--rm',
+        'alpine:latest',
+        'wget',
+        '-qO-',
+        'http://host.docker.internal:11434/api/tags',
+      ])) as CliExecResult;
+      const stderr = asText(result.stderr).trim();
+      if (stderr) {
+        appendDebug(`ollama detect stderr: ${stderr}`);
+      }
+
+      const models = parseOllamaTags(asText(result.stdout));
+      const currentModelResult = (await ddClient.docker.cli.exec('exec', [
+        CONTAINER_NAME,
+        'node',
+        'openclaw.mjs',
+        'config',
+        'get',
+        'agents.defaults.model.primary',
+      ])) as CliExecResult;
+      const currentModel = normalizeOllamaModelName(asText(currentModelResult.stdout));
+      setOllamaModels(models);
+      setConfiguredOllamaModel(currentModel);
+      setSelectedOllamaModel((current) => current || currentModel || chooseRecommendedOllamaModel(models));
+      setOllamaStatus(
+        models.length > 0
+          ? `Detected ${models.length} host Ollama model${models.length === 1 ? '' : 's'}${currentModel ? `; configured model is ${currentModel}.` : '.'}`
+          : 'Host Ollama responded, but no models were installed.',
+      );
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`ollama detect failed: ${text}`);
+      setOllamaModels([]);
+      setOllamaStatus(`Could not reach host Ollama from OpenClaw: ${text}`);
+    } finally {
+      setOllamaChecking(false);
+    }
+  }, [appendDebug, asText, ddClient, findContainer]);
+
+  const applyOllamaSetup = useCallback(async () => {
+    const model = selectedOllamaModel.trim();
+    if (!model) {
+      setOllamaStatus('Choose an installed Ollama model first.');
+      return;
+    }
+
+    setBusy(true);
+    setError('');
+    setMessage('');
+    try {
+      const container = await findContainer();
+      if (!container || container.state !== 'running') {
+        throw new Error('Start OpenClaw before applying local model setup.');
+      }
+
+      const setConfigValue = async (path: string, value: string, strictJson = false) => {
+        const args = [container.id, 'node', 'openclaw.mjs', 'config', 'set', path, value];
+        if (strictJson) {
+          args.push('--strict-json');
+        }
+        await ddClient.docker.cli.exec('exec', args);
+      };
+
+      appendDebug(`configuring OpenClaw Ollama provider for ${model}`);
+      await setConfigValue('models.providers.ollama.api', 'ollama');
+      await setConfigValue('models.providers.ollama.apiKey', 'ollama-local');
+      await setConfigValue('models.providers.ollama.baseUrl', 'http://host.docker.internal:11434');
+      await setConfigValue('models.providers.ollama.models[0].id', model);
+      await setConfigValue('models.providers.ollama.models[0].name', model);
+      await setConfigValue('models.providers.ollama.models[0].reasoning', 'false', true);
+      await setConfigValue('agents.defaults.model.primary', `ollama/${model}`);
+      await setConfigValue('agents.defaults.timeoutSeconds', '300', true);
+      appendDebug(`OpenClaw default model set to ollama/${model}`);
+      setOllamaStatus(`Configured OpenClaw to use Ollama model ${model}. Restarting OpenClaw...`);
+      await restart();
+      setConfiguredOllamaModel(model);
+      setOllamaStatus(`Restart complete. OpenClaw is using ${model}.`);
+      setMessage(`OpenClaw local model setup applied for ${model}.`);
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`ollama setup failed: ${text}`);
+      setError(text);
+    } finally {
+      setBusy(false);
+    }
+  }, [appendDebug, ddClient, findContainer, restart, selectedOllamaModel]);
 
   const checkForUpdate = useCallback(async () => {
     if (!config.image.startsWith('ghcr.io/')) {
@@ -630,6 +735,59 @@ export function App() {
               >
                 Save Settings
               </Button>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Stack spacing={2}>
+              <Typography variant="h5">Local Model Setup</Typography>
+              <Typography variant="body2" color="text.secondary">
+                Use an already installed host Ollama model. The extension verifies Ollama from inside
+                the OpenClaw container and writes only the OpenClaw provider config in the named volume.
+              </Typography>
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                <Button
+                  variant="outlined"
+                  startIcon={ollamaChecking ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  onClick={() => void detectOllamaModels()}
+                  disabled={busy || ollamaChecking || phase !== 'running'}
+                >
+                  {ollamaChecking ? 'Checking...' : 'Detect Ollama Models'}
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={() => void applyOllamaSetup()}
+                  disabled={busy || phase !== 'running' || !selectedOllamaChanged}
+                >
+                  {selectedOllamaChanged ? 'Apply and Restart' : 'Already Applied'}
+                </Button>
+              </Stack>
+              <TextField
+                select
+                SelectProps={{ native: true }}
+                label="Ollama Model"
+                value={selectedOllamaModel}
+                onChange={(event) => setSelectedOllamaModel(event.target.value)}
+                fullWidth
+                helperText={
+                  configuredOllamaModel
+                    ? `Configured model: ${configuredOllamaModel}`
+                    : 'Models are read from host Ollama through host.docker.internal:11434.'
+                }
+                disabled={ollamaModels.length === 0}
+              >
+                {ollamaModels.length === 0 && <option value="">No models detected yet</option>}
+                {ollamaModels.map((model) => (
+                  <option key={model.name} value={model.name}>
+                    {model.name}
+                  </option>
+                ))}
+              </TextField>
+              {ollamaStatus && (
+                <Alert severity={ollamaModels.length > 0 ? 'success' : 'info'}>{ollamaStatus}</Alert>
+              )}
             </Stack>
           </CardContent>
         </Card>

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildOllamaAuthConfigProfile,
   buildOllamaAuthOrder,
   buildOllamaAuthProfilesStore,
   buildOllamaAuthProfilesWriteScript,
@@ -66,6 +67,10 @@ describe('ollamaSetup helpers', () => {
   });
 
   it('builds the per-agent Ollama auth store profile', () => {
+    expect(buildOllamaAuthConfigProfile()).toEqual({
+      provider: 'ollama',
+      mode: 'api_key',
+    });
     expect(buildOllamaAuthProfilesStore()).toEqual({
       version: 1,
       profiles: {
@@ -158,9 +163,8 @@ describe('ollamaSetup helpers', () => {
       mode: 'api_key',
     });
     expect(merged.auth.profiles['ollama:manual']).toEqual({
-      type: 'api_key',
       provider: 'ollama',
-      key: 'ollama-local',
+      mode: 'api_key',
     });
     expect(merged.auth.order.anthropic).toEqual(['anthropic:default']);
     expect(merged.auth.order.ollama).toEqual(['ollama:manual']);

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOllamaProviderPatch,
+  chooseRecommendedOllamaModel,
+  mergeOllamaProviderConfig,
+  normalizeOllamaModelName,
+  parseOllamaTags,
+} from './ollamaSetup';
+
+describe('ollamaSetup helpers', () => {
+  it('parses installed Ollama models from the host tags API', () => {
+    const models = parseOllamaTags(
+      JSON.stringify({
+        models: [
+          { name: 'qwen3.5:latest', size: 6594474711 },
+          { model: 'gemma4-fast:latest', size: 9608350718 },
+          { name: '', size: 1 },
+        ],
+      }),
+    );
+
+    expect(models).toEqual([
+      { name: 'qwen3.5:latest', size: 6594474711 },
+      { name: 'gemma4-fast:latest', size: 9608350718 },
+    ]);
+  });
+
+  it('builds a native Ollama provider patch for OpenClaw', () => {
+    expect(buildOllamaProviderPatch('qwen3.5:latest')).toEqual({
+      agents: {
+        defaults: {
+          model: {
+            primary: 'ollama/qwen3.5:latest',
+          },
+          timeoutSeconds: 300,
+        },
+      },
+      models: {
+        providers: {
+          ollama: {
+            api: 'ollama',
+            apiKey: 'ollama-local',
+            baseUrl: 'http://host.docker.internal:11434',
+            models: [
+              {
+                id: 'qwen3.5:latest',
+                name: 'qwen3.5:latest',
+                reasoning: false,
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  it('prefers a practical installed local model over the first Ollama result', () => {
+    expect(
+      chooseRecommendedOllamaModel([
+        { name: 'batiai/qwen3.6-35b:iq4' },
+        { name: 'qwen3.5:latest' },
+        { name: 'gemma4:latest' },
+      ]),
+    ).toBe('gemma4:latest');
+
+    expect(
+      chooseRecommendedOllamaModel([
+        { name: 'batiai/qwen3.6-35b:iq4' },
+        { name: 'qwen3.5:latest' },
+      ]),
+    ).toBe('qwen3.5:latest');
+  });
+
+  it('normalizes configured Ollama model ids for selection comparison', () => {
+    expect(normalizeOllamaModelName('ollama/gemma4:latest')).toBe('gemma4:latest');
+    expect(normalizeOllamaModelName('gemma4:latest')).toBe('gemma4:latest');
+    expect(normalizeOllamaModelName('  ollama/qwen3.5:latest  ')).toBe('qwen3.5:latest');
+  });
+
+  it('merges Ollama provider config without clobbering existing gateway auth or other providers', () => {
+    const merged = mergeOllamaProviderConfig(
+      {
+        gateway: {
+          auth: {
+            mode: 'token',
+            token: 'preserved-token',
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              api: 'anthropic',
+              apiKey: 'existing-secret-ref',
+            },
+          },
+        },
+      },
+      'qwen3.5:latest',
+    ) as any;
+
+    expect(merged.gateway.auth.token).toBe('preserved-token');
+    expect(merged.agents.defaults.model.primary).toBe('ollama/qwen3.5:latest');
+    expect(merged.agents.defaults.timeoutSeconds).toBe(300);
+    expect(merged.models.providers.anthropic.api).toBe('anthropic');
+    expect(merged.models.providers.ollama).toEqual({
+      api: 'ollama',
+      apiKey: 'ollama-local',
+      baseUrl: 'http://host.docker.internal:11434',
+      models: [
+        {
+          id: 'qwen3.5:latest',
+          name: 'qwen3.5:latest',
+          reasoning: false,
+        },
+      ],
+    });
+  });
+});

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
   buildOllamaAuthOrder,
   buildOllamaAuthProfilesStore,
+  buildOllamaAuthProfilesWriteScript,
+  buildOllamaConfigWriteScript,
   buildOllamaProviderPatch,
+  buildOllamaTagsFetchScript,
   chooseRecommendedOllamaModel,
   mergeOllamaProviderConfig,
   normalizeOllamaModelName,
@@ -26,6 +29,11 @@ describe('ollamaSetup helpers', () => {
       { name: 'qwen3.5:latest', size: 6594474711 },
       { name: 'gemma4-fast:latest', size: 9608350718 },
     ]);
+  });
+
+  it('treats invalid Ollama tags output as no detected models', () => {
+    expect(parseOllamaTags('<html>not json</html>')).toEqual([]);
+    expect(parseOllamaTags('ollama request timed out')).toEqual([]);
   });
 
   it('builds a native Ollama provider patch for OpenClaw', () => {
@@ -69,6 +77,22 @@ describe('ollamaSetup helpers', () => {
       },
     });
     expect(buildOllamaAuthOrder()).toEqual(['ollama:manual']);
+  });
+
+  it('builds Docker SDK-safe Node scripts for Ollama setup', () => {
+    const scripts = [
+      buildOllamaTagsFetchScript(),
+      buildOllamaConfigWriteScript('gemma4:latest'),
+      buildOllamaAuthProfilesWriteScript(),
+    ];
+
+    for (const script of scripts) {
+      expect(script).not.toContain('=>');
+      expect(script).not.toContain('`');
+    }
+
+    expect(buildOllamaConfigWriteScript('gemma4:latest')).toContain('gemma4:latest');
+    expect(buildOllamaAuthProfilesWriteScript()).toContain('auth-profiles.json');
   });
 
   it('prefers a practical installed local model over the first Ollama result', () => {

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildOllamaAuthOrder,
+  buildOllamaAuthProfilesStore,
   buildOllamaProviderPatch,
   chooseRecommendedOllamaModel,
   mergeOllamaProviderConfig,
@@ -55,6 +57,20 @@ describe('ollamaSetup helpers', () => {
     });
   });
 
+  it('builds the per-agent Ollama auth store profile', () => {
+    expect(buildOllamaAuthProfilesStore()).toEqual({
+      version: 1,
+      profiles: {
+        'ollama:manual': {
+          type: 'api_key',
+          provider: 'ollama',
+          key: 'ollama-local',
+        },
+      },
+    });
+    expect(buildOllamaAuthOrder()).toEqual(['ollama:manual']);
+  });
+
   it('prefers a practical installed local model over the first Ollama result', () => {
     expect(
       chooseRecommendedOllamaModel([
@@ -87,6 +103,17 @@ describe('ollamaSetup helpers', () => {
             token: 'preserved-token',
           },
         },
+        auth: {
+          profiles: {
+            'anthropic:default': {
+              provider: 'anthropic',
+              mode: 'api_key',
+            },
+          },
+          order: {
+            anthropic: ['anthropic:default'],
+          },
+        },
         models: {
           providers: {
             anthropic: {
@@ -102,6 +129,17 @@ describe('ollamaSetup helpers', () => {
     expect(merged.gateway.auth.token).toBe('preserved-token');
     expect(merged.agents.defaults.model.primary).toBe('ollama/qwen3.5:latest');
     expect(merged.agents.defaults.timeoutSeconds).toBe(300);
+    expect(merged.auth.profiles['anthropic:default']).toEqual({
+      provider: 'anthropic',
+      mode: 'api_key',
+    });
+    expect(merged.auth.profiles['ollama:manual']).toEqual({
+      type: 'api_key',
+      provider: 'ollama',
+      key: 'ollama-local',
+    });
+    expect(merged.auth.order.anthropic).toEqual(['anthropic:default']);
+    expect(merged.auth.order.ollama).toEqual(['ollama:manual']);
     expect(merged.models.providers.anthropic.api).toBe('anthropic');
     expect(merged.models.providers.ollama).toEqual({
       api: 'ollama',

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -7,6 +7,7 @@ export type JsonObject = Record<string, unknown>;
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://host.docker.internal:11434';
 const DEFAULT_OLLAMA_API_KEY = 'ollama-local';
+const OLLAMA_AUTH_PROFILE_ID = 'ollama:manual';
 const RECOMMENDED_MODEL_ORDER = [
   'gemma4:latest',
   'gemma4',
@@ -86,6 +87,23 @@ export function buildOllamaProviderPatch(model: string): JsonObject {
   };
 }
 
+export function buildOllamaAuthProfilesStore(): JsonObject {
+  return {
+    version: 1,
+    profiles: {
+      [OLLAMA_AUTH_PROFILE_ID]: {
+        type: 'api_key',
+        provider: 'ollama',
+        key: DEFAULT_OLLAMA_API_KEY,
+      },
+    },
+  };
+}
+
+export function buildOllamaAuthOrder(): string[] {
+  return [OLLAMA_AUTH_PROFILE_ID];
+}
+
 export function chooseRecommendedOllamaModel(models: OllamaModel[]): string {
   const installed = new Set(models.map((model) => model.name));
   for (const candidate of RECOMMENDED_MODEL_ORDER) {
@@ -108,17 +126,39 @@ function isJsonObject(value: unknown): value is JsonObject {
 
 export function mergeOllamaProviderConfig(existing: JsonObject, model: string): JsonObject {
   const patch = buildOllamaProviderPatch(model);
+  const patchAuth = {
+    profiles: buildOllamaAuthProfilesStore().profiles as JsonObject,
+    order: {
+      ollama: buildOllamaAuthOrder(),
+    },
+  };
   const existingAgents = isJsonObject(existing.agents) ? existing.agents : {};
   const existingAgentDefaults = isJsonObject(existingAgents.defaults) ? existingAgents.defaults : {};
+  const existingAuth = isJsonObject(existing.auth) ? existing.auth : {};
+  const existingAuthProfiles = isJsonObject(existingAuth.profiles) ? existingAuth.profiles : {};
+  const existingAuthOrder = isJsonObject(existingAuth.order) ? existingAuth.order : {};
   const patchAgents = patch.agents as JsonObject;
   const patchAgentDefaults = patchAgents.defaults as JsonObject;
   const existingModels = isJsonObject(existing.models) ? existing.models : {};
   const existingProviders = isJsonObject(existingModels.providers) ? existingModels.providers : {};
   const patchModels = patch.models as JsonObject;
   const patchProviders = patchModels.providers as JsonObject;
+  const patchAuthProfiles = patchAuth.profiles;
+  const patchAuthOrder = patchAuth.order;
 
   return {
     ...existing,
+    auth: {
+      ...existingAuth,
+      profiles: {
+        ...existingAuthProfiles,
+        ...patchAuthProfiles,
+      },
+      order: {
+        ...existingAuthOrder,
+        ...patchAuthOrder,
+      },
+    },
     agents: {
       ...existingAgents,
       defaults: {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -108,6 +108,13 @@ export function buildOllamaAuthProfilesStore(): JsonObject {
   };
 }
 
+export function buildOllamaAuthConfigProfile(): JsonObject {
+  return {
+    provider: 'ollama',
+    mode: 'api_key',
+  };
+}
+
 export function buildOllamaAuthOrder(): string[] {
   return [OLLAMA_AUTH_PROFILE_ID];
 }
@@ -151,7 +158,7 @@ export function buildOllamaConfigWriteScript(model: string): string {
     'config.models.providers.ollama={api:"ollama",apiKey:"ollama-local",baseUrl:"http://host.docker.internal:11434",models:[{id:model,name:model,reasoning:false}]};',
     'config.auth=config.auth||{};',
     'config.auth.profiles=config.auth.profiles||{};',
-    'config.auth.profiles["ollama:manual"]={provider:"ollama",mode:"api_key"};',
+    'config.auth.profiles["ollama:manual"]=' + JSON.stringify(buildOllamaAuthConfigProfile()) + ';',
     'config.auth.order=config.auth.order||{};',
     'config.auth.order.ollama=["ollama:manual"];',
     'if(fs.existsSync(configPath)){fs.copyFileSync(configPath,configPath+".bak");}',
@@ -193,7 +200,9 @@ function isJsonObject(value: unknown): value is JsonObject {
 export function mergeOllamaProviderConfig(existing: JsonObject, model: string): JsonObject {
   const patch = buildOllamaProviderPatch(model);
   const patchAuth = {
-    profiles: buildOllamaAuthProfilesStore().profiles as JsonObject,
+    profiles: {
+      [OLLAMA_AUTH_PROFILE_ID]: buildOllamaAuthConfigProfile(),
+    },
     order: {
       ollama: buildOllamaAuthOrder(),
     },

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -1,0 +1,137 @@
+export type OllamaModel = {
+  name: string;
+  size?: number;
+};
+
+export type JsonObject = Record<string, unknown>;
+
+const DEFAULT_OLLAMA_BASE_URL = 'http://host.docker.internal:11434';
+const DEFAULT_OLLAMA_API_KEY = 'ollama-local';
+const RECOMMENDED_MODEL_ORDER = [
+  'gemma4:latest',
+  'gemma4',
+  'llama3.2:latest',
+  'llama3.2',
+  'qwen3.5:latest',
+  'qwen3.5',
+];
+
+type OllamaTagsResponse = {
+  models?: Array<{
+    name?: unknown;
+    model?: unknown;
+    size?: unknown;
+  }>;
+};
+
+export function parseOllamaTags(stdout: string): OllamaModel[] {
+  if (!stdout.trim()) {
+    return [];
+  }
+
+  const payload = JSON.parse(stdout) as OllamaTagsResponse;
+  if (!Array.isArray(payload.models)) {
+    return [];
+  }
+
+  const models: OllamaModel[] = [];
+  for (const entry of payload.models) {
+    const rawName = typeof entry.name === 'string' ? entry.name : entry.model;
+    const name = typeof rawName === 'string' ? rawName.trim() : '';
+    if (!name) {
+      continue;
+    }
+
+    const model: OllamaModel = { name };
+    if (typeof entry.size === 'number' && Number.isFinite(entry.size)) {
+      model.size = entry.size;
+    }
+    models.push(model);
+  }
+
+  return models;
+}
+
+export function buildOllamaProviderPatch(model: string): JsonObject {
+  const selectedModel = model.trim();
+  if (!selectedModel) {
+    throw new Error('Choose an Ollama model before applying local setup.');
+  }
+
+  return {
+    agents: {
+      defaults: {
+        model: {
+          primary: `ollama/${selectedModel}`,
+        },
+        timeoutSeconds: 300,
+      },
+    },
+    models: {
+      providers: {
+        ollama: {
+          api: 'ollama',
+          apiKey: DEFAULT_OLLAMA_API_KEY,
+          baseUrl: DEFAULT_OLLAMA_BASE_URL,
+          models: [
+            {
+              id: selectedModel,
+              name: selectedModel,
+              reasoning: false,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+export function chooseRecommendedOllamaModel(models: OllamaModel[]): string {
+  const installed = new Set(models.map((model) => model.name));
+  for (const candidate of RECOMMENDED_MODEL_ORDER) {
+    if (installed.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return models[0]?.name ?? '';
+}
+
+export function normalizeOllamaModelName(model: string): string {
+  const trimmed = model.trim();
+  return trimmed.startsWith('ollama/') ? trimmed.slice('ollama/'.length) : trimmed;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function mergeOllamaProviderConfig(existing: JsonObject, model: string): JsonObject {
+  const patch = buildOllamaProviderPatch(model);
+  const existingAgents = isJsonObject(existing.agents) ? existing.agents : {};
+  const existingAgentDefaults = isJsonObject(existingAgents.defaults) ? existingAgents.defaults : {};
+  const patchAgents = patch.agents as JsonObject;
+  const patchAgentDefaults = patchAgents.defaults as JsonObject;
+  const existingModels = isJsonObject(existing.models) ? existing.models : {};
+  const existingProviders = isJsonObject(existingModels.providers) ? existingModels.providers : {};
+  const patchModels = patch.models as JsonObject;
+  const patchProviders = patchModels.providers as JsonObject;
+
+  return {
+    ...existing,
+    agents: {
+      ...existingAgents,
+      defaults: {
+        ...existingAgentDefaults,
+        ...patchAgentDefaults,
+      },
+    },
+    models: {
+      ...existingModels,
+      providers: {
+        ...existingProviders,
+        ...patchProviders,
+      },
+    },
+  };
+}

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -8,6 +8,8 @@ export type JsonObject = Record<string, unknown>;
 const DEFAULT_OLLAMA_BASE_URL = 'http://host.docker.internal:11434';
 const DEFAULT_OLLAMA_API_KEY = 'ollama-local';
 const OLLAMA_AUTH_PROFILE_ID = 'ollama:manual';
+const OPENCLAW_CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+const OPENCLAW_AUTH_PROFILES_PATH = '/home/node/.openclaw/agents/main/agent/auth-profiles.json';
 const RECOMMENDED_MODEL_ORDER = [
   'gemma4:latest',
   'gemma4',
@@ -30,7 +32,13 @@ export function parseOllamaTags(stdout: string): OllamaModel[] {
     return [];
   }
 
-  const payload = JSON.parse(stdout) as OllamaTagsResponse;
+  let payload: OllamaTagsResponse;
+  try {
+    payload = JSON.parse(stdout) as OllamaTagsResponse;
+  } catch {
+    return [];
+  }
+
   if (!Array.isArray(payload.models)) {
     return [];
   }
@@ -102,6 +110,64 @@ export function buildOllamaAuthProfilesStore(): JsonObject {
 
 export function buildOllamaAuthOrder(): string[] {
   return [OLLAMA_AUTH_PROFILE_ID];
+}
+
+export function buildOllamaTagsFetchScript(): string {
+  return [
+    'const http=require("http");',
+    'const req=http.get("http://host.docker.internal:11434/api/tags",function(res){',
+    'var data="";',
+    'res.setEncoding("utf8");',
+    'res.on("data",function(chunk){data=data+chunk;});',
+    'res.on("end",function(){',
+    'if(res.statusCode!==200){console.error("ollama returned "+res.statusCode);process.exit(1);}',
+    'process.stdout.write(data);',
+    '});',
+    '});',
+    'req.on("error",function(err){console.error(err.message);process.exit(1);});',
+    'req.setTimeout(5000,function(){req.destroy(new Error("ollama request timed out"));});',
+  ].join(' ');
+}
+
+export function buildOllamaConfigWriteScript(model: string): string {
+  const selectedModel = model.trim();
+  if (!selectedModel) {
+    throw new Error('Choose an Ollama model before applying local setup.');
+  }
+
+  return [
+    'const fs=require("fs");',
+    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
+    'const model=' + JSON.stringify(selectedModel) + ';',
+    'var config={};',
+    'if(fs.existsSync(configPath)){config=JSON.parse(fs.readFileSync(configPath,"utf8"));}',
+    'config.agents=config.agents||{};',
+    'config.agents.defaults=config.agents.defaults||{};',
+    'config.agents.defaults.model=config.agents.defaults.model||{};',
+    'config.agents.defaults.model.primary="ollama/"+model;',
+    'config.agents.defaults.timeoutSeconds=300;',
+    'config.models=config.models||{};',
+    'config.models.providers=config.models.providers||{};',
+    'config.models.providers.ollama={api:"ollama",apiKey:"ollama-local",baseUrl:"http://host.docker.internal:11434",models:[{id:model,name:model,reasoning:false}]};',
+    'config.auth=config.auth||{};',
+    'config.auth.profiles=config.auth.profiles||{};',
+    'config.auth.profiles["ollama:manual"]={provider:"ollama",mode:"api_key"};',
+    'config.auth.order=config.auth.order||{};',
+    'config.auth.order.ollama=["ollama:manual"];',
+    'if(fs.existsSync(configPath)){fs.copyFileSync(configPath,configPath+".bak");}',
+    'fs.writeFileSync(configPath,JSON.stringify(config,null,2)+"\\n");',
+  ].join(' ');
+}
+
+export function buildOllamaAuthProfilesWriteScript(): string {
+  return [
+    'const fs=require("fs");',
+    'const path=require("path");',
+    'const file=' + JSON.stringify(OPENCLAW_AUTH_PROFILES_PATH) + ';',
+    'const data=' + JSON.stringify(buildOllamaAuthProfilesStore()) + ';',
+    'fs.mkdirSync(path.dirname(file),{recursive:true});',
+    'fs.writeFileSync(file,JSON.stringify(data,null,2)+"\\n");',
+  ].join(' ');
 }
 
 export function chooseRecommendedOllamaModel(models: OllamaModel[]): string {


### PR DESCRIPTION
# Summary

Adds a first-pass Ollama local model setup flow for the OpenClaw Docker Desktop extension.

# What changed

- Detects installed host Ollama models from the container side.
- Writes the OpenClaw Ollama provider config into the persistent volume.
- Writes the per-agent Ollama auth profile store so OpenClaw can resolve `ollama:manual`.
- Selects a practical default model and avoids re-applying unchanged config.
- Fixes the runtime bridge so OpenClaw fails loudly if the child process dies.

# Validation

- `npm test`
- `npm run build`
- `sh scripts/test-runtime-bridge.sh`
- Live container checks against OpenClaw health and Ollama reachability.
- Verified `models auth list --agent main` shows `ollama:manual [ollama/api_key]`.
- Manual Docker Desktop extension flow succeeded: apply/restart completed and OpenClaw replied through `ollama/gemma4:latest`.
