### PR TITLE
[codex] Bootstrap localhost Control UI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ Use the canonical localhost Control UI origin for browser-app installs:
 
 The extension launches `http://127.0.0.1:<port>` and, when available, passes the gateway token as a `#token=...` URL fragment. The fragment is used by the browser dashboard bootstrap path and is not part of the HTTP request URL.
 
+The upstream Control UI removes the token fragment from the address bar after reading it. If the gateway token changes, launch the Control UI from the Docker Desktop extension again so it can read the current token before opening the browser.
+
+On Windows, Chrome and Edge expose the same browser-app style install flow through their app or shortcut menus. This repository validates the Docker Desktop extension path on macOS first; keep Windows instructions advisory until a Windows runtime path is tested.
+
 Do not use Portless or another alternate hostname for the default installed-app flow. Alternate origins require extra OpenClaw origin allowlisting and can introduce certificate and bootstrap friction.
 
 ## Security and isolation notes
@@ -279,6 +283,7 @@ Do not use Portless or another alternate hostname for the default installed-app 
 ## Current limitations
 
 - If the gateway token field is blank, open the Control UI and paste the token manually after retrieving it from the service container or volume.
+- If `Open Control UI` reports that localhost is not reachable, start or restart OpenClaw before retrying.
 - The runtime can spend a short warm-up period in `starting` even after the host health check is already passing.
 - Anthropic provider auth currently supports the local `.env` persistence path first. It does not yet manage richer OpenClaw auth-profile workflows in the UI.
 - The update banner only applies to published GHCR channel images. Pinned release tags stay fixed, and local dev images are not auto-updated by the extension.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Then:
 2. Click `Start OpenClaw`.
 3. If you plan to use Anthropic-backed sessions, paste an Anthropic API key into `Provider Auth` and save.
 4. Wait for the service status to show `OpenClaw is ready`.
-5. Click `Open Control UI` and connect with:
-   - Browser URL: `http://127.0.0.1:18789`
-   - WebSocket URL: `ws://127.0.0.1:18789`
+5. Click `Open Control UI`. The extension opens the canonical localhost Control UI and passes the gateway token through the URL fragment for dashboard bootstrap.
 
 If Docker Desktop blocks local extensions, enable local or non-Marketplace extension installs first.
 
@@ -256,6 +254,18 @@ You can install and open the extension before saving a key, but Anthropic-backed
 
 This means the credential survives container restarts and rebuilds, but is removed if you delete the named volume.
 
+## Installed Control UI on macOS
+
+Use the canonical localhost Control UI origin for browser-app installs:
+
+- Open the Docker Desktop extension.
+- Click `Open Control UI`.
+- In Chrome, use `Install page as app` or `Create shortcut` with `Open as window`.
+
+The extension launches `http://127.0.0.1:<port>` and, when available, passes the gateway token as a `#token=...` URL fragment. The fragment is used by the browser dashboard bootstrap path and is not part of the HTTP request URL.
+
+Do not use Portless or another alternate hostname for the default installed-app flow. Alternate origins require extra OpenClaw origin allowlisting and can introduce certificate and bootstrap friction.
+
 ## Security and isolation notes
  
  - The wrapper publishes OpenClaw on `127.0.0.1` only.
@@ -268,7 +278,7 @@ This means the credential survives container restarts and rebuilds, but is remov
 
 ## Current limitations
 
-- Gateway token autofill is not fully reliable yet. If the token field is blank in the extension UI, open the Control UI and paste the token manually.
+- If the gateway token field is blank, open the Control UI and paste the token manually after retrieving it from the service container or volume.
 - The runtime can spend a short warm-up period in `starting` even after the host health check is already passing.
 - Anthropic provider auth currently supports the local `.env` persistence path first. It does not yet manage richer OpenClaw auth-profile workflows in the UI.
 - The update banner only applies to published GHCR channel images. Pinned release tags stay fixed, and local dev images are not auto-updated by the extension.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -184,20 +184,24 @@ export function App() {
     });
   }, []);
 
+  const fetchGatewayToken = useCallback(async (containerId: string) => {
+    const result = (await ddClient.docker.cli.exec('exec', [
+      containerId,
+      'node',
+      '-e',
+      'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
+    ])) as CliExecResult;
+    return asText(result.stdout).trim();
+  }, [asText, ddClient]);
+
   const readToken = useCallback(async (containerId: string) => {
     try {
-      const result = (await ddClient.docker.cli.exec('exec', [
-        containerId,
-        'node',
-        '-e',
-        'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
-      ])) as CliExecResult;
-      setToken(asText((result as CliExecResult).stdout).trim());
+      setToken(await fetchGatewayToken(containerId));
     } catch (err) {
       appendDebug(`token read failed: ${err instanceof Error ? err.message : String(err)}`);
       setToken('');
     }
-  }, [appendDebug, asText, ddClient]);
+  }, [appendDebug, fetchGatewayToken]);
 
   const checkReady = useCallback(async () => {
     try {
@@ -378,13 +382,31 @@ export function App() {
   }, [appendDebug, ddClient, findContainer, refresh]);
 
   const openBrowser = useCallback(async () => {
-    await Promise.resolve(ddClient.host.openExternal(buildControlUiLaunchUrl(openUrl, token)));
+    const ready = await checkReady();
+    if (!ready) {
+      setError('OpenClaw Control is not reachable on localhost yet. Start or restart OpenClaw and try again.');
+      return;
+    }
+
+    let launchToken = token;
+    try {
+      const container = await findContainer();
+      if (container?.state === 'running') {
+        launchToken = await fetchGatewayToken(container.id);
+        setToken(launchToken);
+      }
+    } catch (err) {
+      appendDebug(`launch token refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+      launchToken = '';
+    }
+
+    await Promise.resolve(ddClient.host.openExternal(buildControlUiLaunchUrl(openUrl, launchToken)));
     setMessage(
-      token
+      launchToken
         ? 'Opened OpenClaw Control with gateway token bootstrap.'
         : 'Opened OpenClaw Control. Paste the gateway token if the dashboard asks for one.',
     );
-  }, [ddClient, openUrl, token]);
+  }, [appendDebug, checkReady, ddClient, fetchGatewayToken, findContainer, openUrl, token]);
 
   const copyToken = useCallback(async () => {
     if (!token) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,7 @@ import {
   parseOllamaTags,
   type OllamaModel,
 } from './ollamaSetup';
+import { buildControlUiLaunchUrl } from './controlUiLaunch';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 
@@ -377,8 +378,13 @@ export function App() {
   }, [appendDebug, ddClient, findContainer, refresh]);
 
   const openBrowser = useCallback(async () => {
-    await Promise.resolve(ddClient.host.openExternal(openUrl));
-  }, [ddClient, openUrl]);
+    await Promise.resolve(ddClient.host.openExternal(buildControlUiLaunchUrl(openUrl, token)));
+    setMessage(
+      token
+        ? 'Opened OpenClaw Control with gateway token bootstrap.'
+        : 'Opened OpenClaw Control. Paste the gateway token if the dashboard asks for one.',
+    );
+  }, [ddClient, openUrl, token]);
 
   const copyToken = useCallback(async () => {
     if (!token) {
@@ -699,7 +705,7 @@ export function App() {
                   value={token}
                   fullWidth
                   InputProps={{ readOnly: true }}
-                  helperText="Paste this into OpenClaw Control if the dashboard asks for a token."
+                  helperText="Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again."
                 />
                 <Button
                   variant="outlined"

--- a/ui/src/controlUiLaunch.test.ts
+++ b/ui/src/controlUiLaunch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildControlUiLaunchUrl } from './controlUiLaunch';
+
+describe('control UI launch helpers', () => {
+  it('returns the canonical localhost URL when no token is available', () => {
+    expect(buildControlUiLaunchUrl('http://127.0.0.1:18789', '')).toBe('http://127.0.0.1:18789');
+  });
+
+  it('adds the gateway token as a URL fragment for dashboard bootstrap', () => {
+    expect(buildControlUiLaunchUrl('http://127.0.0.1:18789', 'abc 123')).toBe(
+      'http://127.0.0.1:18789/#token=abc+123',
+    );
+  });
+
+  it('preserves existing non-token fragment parameters', () => {
+    expect(buildControlUiLaunchUrl('http://127.0.0.1:18789/#session=main', 'token-value')).toBe(
+      'http://127.0.0.1:18789/#session=main&token=token-value',
+    );
+  });
+});

--- a/ui/src/controlUiLaunch.ts
+++ b/ui/src/controlUiLaunch.ts
@@ -1,0 +1,13 @@
+export function buildControlUiLaunchUrl(baseUrl: string, token: string): string {
+  const trimmedBaseUrl = baseUrl.trim();
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return trimmedBaseUrl;
+  }
+
+  const url = new URL(trimmedBaseUrl);
+  const fragment = new URLSearchParams(url.hash.startsWith('#') ? url.hash.slice(1) : url.hash);
+  fragment.set('token', trimmedToken);
+  url.hash = fragment.toString();
+  return url.toString();
+}


### PR DESCRIPTION
# Summary

Contributes to #40 by tightening the canonical localhost Control UI launch path.

# What changed

- Opens the canonical localhost Control UI with the gateway token in the URL fragment (`#token=...`) when the extension has read the token.
- Keeps the visible Browser URL field clean and unchanged.
- Updates the token helper text so manual copy is fallback-only.
- Adds README guidance for installing the localhost Control UI as a browser app on macOS.
- Explicitly documents that Portless/alternate-host flows are out of scope for the default installed-app path.

# Validation

- `npm test`
- `npm run build`
- `git diff --check`
- `make update-extension`
- `curl -fsS http://127.0.0.1:18789/healthz`
- `openclaw dashboard --no-open` inside the service container confirms upstream dashboard semantics use fragment key `token`.
- Runtime config inspection confirmed a gateway token exists without printing the token value.
