### PR TITLE
Improve gateway token retry UX

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -30,8 +30,10 @@ import {
   type OllamaModel,
 } from './ollamaSetup';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
+import { readGatewayTokenWithRetry } from './tokenRetry';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
+type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
 
 type ExtensionConfig = {
   image: string;
@@ -119,6 +121,7 @@ export function App() {
   const [phase, setPhase] = useState<ContainerPhase>('missing');
   const [statusText, setStatusText] = useState('No OpenClaw container yet');
   const [token, setToken] = useState('');
+  const [tokenStatus, setTokenStatus] = useState<TokenStatus>('unknown');
   const [busy, setBusy] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
@@ -195,11 +198,18 @@ export function App() {
   }, [asText, ddClient]);
 
   const readToken = useCallback(async (containerId: string) => {
+    setTokenStatus('checking');
     try {
-      setToken(await fetchGatewayToken(containerId));
+      const nextToken = await readGatewayTokenWithRetry(
+        () => fetchGatewayToken(containerId),
+        { attempts: 5, delayMs: 1000 },
+      );
+      setToken(nextToken);
+      setTokenStatus(nextToken ? 'ready' : 'empty');
     } catch (err) {
       appendDebug(`token read failed: ${err instanceof Error ? err.message : String(err)}`);
       setToken('');
+      setTokenStatus('error');
     }
   }, [appendDebug, fetchGatewayToken]);
 
@@ -224,6 +234,7 @@ export function App() {
         setPhase('missing');
         setStatusText('No OpenClaw container yet');
         setToken('');
+        setTokenStatus('unknown');
         return { phase: 'missing', ready: false };
       }
 
@@ -238,6 +249,7 @@ export function App() {
       setPhase(container.state === 'exited' ? 'stopped' : 'error');
       setStatusText(container.status);
       setToken('');
+      setTokenStatus('unknown');
       return { phase: container.state === 'exited' ? 'stopped' : 'error', ready: false };
     } catch (err) {
       setPhase('error');
@@ -371,6 +383,7 @@ export function App() {
         await ddClient.docker.cli.exec('rm', ['-f', container.id]);
       }
       setToken('');
+      setTokenStatus('unknown');
       await refresh();
     } catch (err) {
       const text = err instanceof Error ? err.message : String(err);
@@ -394,10 +407,12 @@ export function App() {
       if (container?.state === 'running') {
         launchToken = await fetchGatewayToken(container.id);
         setToken(launchToken);
+        setTokenStatus(launchToken ? 'ready' : 'empty');
       }
     } catch (err) {
       appendDebug(`launch token refresh failed: ${err instanceof Error ? err.message : String(err)}`);
       launchToken = '';
+      setTokenStatus('error');
     }
 
     await Promise.resolve(ddClient.host.openExternal(buildControlUiLaunchUrl(openUrl, launchToken)));
@@ -617,6 +632,22 @@ export function App() {
     };
   }, [phase, checkForUpdate]);
 
+  const tokenHelperText = (() => {
+    if (token) {
+      return 'Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again.';
+    }
+    if (tokenStatus === 'checking') {
+      return 'Waiting for OpenClaw to write the gateway token. This should resolve shortly after startup.';
+    }
+    if (tokenStatus === 'empty') {
+      return 'Gateway token is still blank after retries. Open Control UI can still launch; paste the token manually if asked.';
+    }
+    if (tokenStatus === 'error') {
+      return 'Could not read the gateway token. Open Control UI can still launch; use manual fallback if asked.';
+    }
+    return 'Gateway token appears here after the OpenClaw service is ready.';
+  })();
+
   return (
     <Box sx={{ p: 3, maxWidth: 1100, mx: 'auto' }}>
       <Stack spacing={3}>
@@ -727,7 +758,7 @@ export function App() {
                   value={token}
                   fullWidth
                   InputProps={{ readOnly: true }}
-                  helperText="Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again."
+                  helperText={tokenHelperText}
                 />
                 <Button
                   variant="outlined"

--- a/ui/src/tokenRetry.test.ts
+++ b/ui/src/tokenRetry.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { readGatewayTokenWithRetry } from './tokenRetry';
+
+describe('gateway token retry helper', () => {
+  it('retries empty token reads before returning the detected token', async () => {
+    const reads = ['', '   ', 'token-value'];
+    const attempts: string[] = [];
+
+    const token = await readGatewayTokenWithRetry(async () => {
+      const next = reads.shift() ?? '';
+      attempts.push(next);
+      return next;
+    }, { attempts: 3, delayMs: 0 });
+
+    expect(token).toBe('token-value');
+    expect(attempts).toEqual(['', '   ', 'token-value']);
+  });
+
+  it('returns an empty token after all retry attempts are exhausted', async () => {
+    let attempts = 0;
+
+    const token = await readGatewayTokenWithRetry(async () => {
+      attempts += 1;
+      return '';
+    }, { attempts: 3, delayMs: 0 });
+
+    expect(token).toBe('');
+    expect(attempts).toBe(3);
+  });
+});

--- a/ui/src/tokenRetry.ts
+++ b/ui/src/tokenRetry.ts
@@ -1,0 +1,24 @@
+export type GatewayTokenRetryOptions = {
+  attempts: number;
+  delayMs: number;
+};
+
+export async function readGatewayTokenWithRetry(
+  readToken: () => Promise<string>,
+  options: GatewayTokenRetryOptions,
+): Promise<string> {
+  const attempts = Math.max(1, options.attempts);
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const token = (await readToken()).trim();
+    if (token) {
+      return token;
+    }
+
+    if (attempt < attempts - 1 && options.delayMs > 0) {
+      await new Promise((resolve) => window.setTimeout(resolve, options.delayMs));
+    }
+  }
+
+  return '';
+}


### PR DESCRIPTION
## Summary\n- retry empty gateway token reads briefly after OpenClaw becomes healthy\n- expose checking, empty, and error helper text for the Gateway Token field\n- keep token copy explicit and manual rather than auto-copying\n\nCloses #8.\n\n## Test Plan\n- npm test\n- npm run build\n- git diff --check\n- make update-extension built images successfully; Docker extension update completed with docker extension update --force openclaw-docker-extension:dev\n- curl -fsS http://127.0.0.1:18789/healthz\n- docker exec token presence check without printing token