### PR TITLE
Tighten Docker build metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN npm run build
 FROM alpine:3.20
 LABEL org.opencontainers.image.title="OpenClaw for Docker Desktop" \
     org.opencontainers.image.description="Run OpenClaw from Docker Desktop with a macOS-safe port bridge and one-click controls." \
-    org.opencontainers.image.vendor="OpenAI Codex" \
+    org.opencontainers.image.vendor="jcowhigjr/openclaw-docker-desktop-extension" \
+    org.opencontainers.image.source="https://github.com/jcowhigjr/openclaw-docker-desktop-extension" \
+    org.opencontainers.image.licenses="MIT" \
     com.docker.desktop.extension.api.version="0.4.2" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/static/icon.png" \
     com.docker.extension.categories="ai,developer-tools"

--- a/runtime/.dockerignore
+++ b/runtime/.dockerignore
@@ -1,0 +1,5 @@
+# Keep the runtime image context limited to the wrapper files copied by runtime/Dockerfile.
+**
+
+!Dockerfile
+!openclaw-bridge.sh

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,5 +1,11 @@
 FROM ghcr.io/openclaw/openclaw:latest
 
+LABEL org.opencontainers.image.title="OpenClaw Docker Desktop Extension Runtime" \
+    org.opencontainers.image.description="OpenClaw runtime wrapper with a localhost bridge for the Docker Desktop extension." \
+    org.opencontainers.image.vendor="jcowhigjr/openclaw-docker-desktop-extension" \
+    org.opencontainers.image.source="https://github.com/jcowhigjr/openclaw-docker-desktop-extension" \
+    org.opencontainers.image.licenses="MIT"
+
 USER root
 
 RUN apt-get update \


### PR DESCRIPTION
## Summary\n- replace stale OCI vendor metadata on the extension image\n- add source/license OCI labels to extension and runtime images\n- add runtime/.dockerignore for the separate runtime build context\n\nCloses #9.\n\n## Test Plan\n- docker build -t openclaw-docker-extension-runtime:issue-9 -f runtime/Dockerfile runtime\n- docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest --tag=openclaw-docker-extension:issue-9 .\n- docker image inspect openclaw-docker-extension:issue-9 --format '{{json .Config.Labels}}'\n- docker image inspect openclaw-docker-extension-runtime:issue-9 --format '{{json .Config.Labels}}'\n- npm test\n- npm run build\n- git diff --check