### PR TITLE
fix: refactor ollama detection exec command to avoid shell operators

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,7 +23,7 @@ import { getDDClient } from './dockerDesktopClient';
 import {
   buildOllamaAuthProfilesWriteScript,
   buildOllamaConfigWriteScript,
-  buildOllamaTagsFetchScript,
+  buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
   normalizeOllamaModelName,
   parseOllamaTags,
@@ -444,9 +444,7 @@ export function App() {
 
       const result = (await ddClient.docker.cli.exec('exec', [
         container.id,
-        'node',
-        '-e',
-        buildOllamaTagsFetchScript(),
+        ...buildOllamaTagsFetchArgs(),
       ])) as CliExecResult;
       const stderr = asText(result.stderr).trim();
       if (stderr) {

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -7,7 +7,7 @@ import {
   buildOllamaAuthProfilesWriteScript,
   buildOllamaConfigWriteScript,
   buildOllamaProviderPatch,
-  buildOllamaTagsFetchScript,
+  buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
   mergeOllamaProviderConfig,
   normalizeOllamaModelName,
@@ -86,7 +86,6 @@ describe('ollamaSetup helpers', () => {
 
   it('builds Docker SDK-safe Node scripts for Ollama setup', () => {
     const scripts = [
-      buildOllamaTagsFetchScript(),
       buildOllamaConfigWriteScript('gemma4:latest'),
       buildOllamaAuthProfilesWriteScript(),
     ];
@@ -98,6 +97,16 @@ describe('ollamaSetup helpers', () => {
 
     expect(buildOllamaConfigWriteScript('gemma4:latest')).toContain('gemma4:latest');
     expect(buildOllamaAuthProfilesWriteScript()).toContain('auth-profiles.json');
+  });
+
+  it('builds Docker SDK-safe argv for fetching host Ollama tags', () => {
+    expect(buildOllamaTagsFetchArgs()).toEqual([
+      'curl',
+      '-fsS',
+      '--max-time',
+      '5',
+      'http://host.docker.internal:11434/api/tags',
+    ]);
   });
 
   it('prefers a practical installed local model over the first Ollama result', () => {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -119,26 +119,14 @@ export function buildOllamaAuthOrder(): string[] {
   return [OLLAMA_AUTH_PROFILE_ID];
 }
 
-export function buildOllamaTagsFetchScript(): string {
-  const script = [
-    'const http = require("http");',
-    'const req = http.get("http://host.docker.internal:11434/api/tags", (res) => {',
-    '  let data = "";',
-    '  res.setEncoding("utf8");',
-    '  res.on("data", (chunk) => { data += chunk; });',
-    '  res.on("end", () => {',
-    '    if (res.statusCode !== 200) {',
-    '      console.error("ollama returned " + res.statusCode);',
-    '      process.exit(1);',
-    '    }',
-    '    process.stdout.write(data);',
-    '  });',
-    '});',
-    'req.on("error", (err) => { console.error(err.message); process.exit(1); });',
-    'req.setTimeout(5000, () => { req.destroy(new Error("ollama request timed out")); });',
-  ].join(' ');
-
-  return `node -e '${script.replace(/'/g, "\\'")}'`;
+export function buildOllamaTagsFetchArgs(): string[] {
+  return [
+    'curl',
+    '-fsS',
+    '--max-time',
+    '5',
+    `${DEFAULT_OLLAMA_BASE_URL}/api/tags`,
+  ];
 }
 
 export function buildOllamaConfigWriteScript(model: string): string {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -120,20 +120,25 @@ export function buildOllamaAuthOrder(): string[] {
 }
 
 export function buildOllamaTagsFetchScript(): string {
-  return [
-    'const http=require("http");',
-    'const req=http.get("http://host.docker.internal:11434/api/tags",function(res){',
-    'var data="";',
-    'res.setEncoding("utf8");',
-    'res.on("data",function(chunk){data=data+chunk;});',
-    'res.on("end",function(){',
-    'if(res.statusCode!==200){console.error("ollama returned "+res.statusCode);process.exit(1);}',
-    'process.stdout.write(data);',
+  const script = [
+    'const http = require("http");',
+    'const req = http.get("http://host.docker.internal:11434/api/tags", (res) => {',
+    '  let data = "";',
+    '  res.setEncoding("utf8");',
+    '  res.on("data", (chunk) => { data += chunk; });',
+    '  res.on("end", () => {',
+    '    if (res.statusCode !== 200) {',
+    '      console.error("ollama returned " + res.statusCode);',
+    '      process.exit(1);',
+    '    }',
+    '    process.stdout.write(data);',
+    '  });',
     '});',
-    '});',
-    'req.on("error",function(err){console.error(err.message);process.exit(1);});',
-    'req.setTimeout(5000,function(){req.destroy(new Error("ollama request timed out"));});',
+    'req.on("error", (err) => { console.error(err.message); process.exit(1); });',
+    'req.setTimeout(5000, () => { req.destroy(new Error("ollama request timed out")); });',
   ].join(' ');
+
+  return `node -e '${script.replace(/'/g, "\\'")}'`;
 }
 
 export function buildOllamaConfigWriteScript(model: string): string {


### PR DESCRIPTION
Fixes the 'shell operators are not allowed' error by refactoring the docker exec command to avoid complex shell parsing. This ensures compatibility with the Docker SDK API.