### PR TITLE
Refresh roadmap after integration wave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,13 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
 ## Current Roadmap
 
 - Treat issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) as the source of truth for roadmap and decision gates.
-- Issue [#7](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/7) is already closed; treat onboarding work as completed.
-- Issue [#5](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/5) is already closed; treat architecture handling as completed for MVP.
-- Active MVP priority:
-  1. [#3](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/3) pre-built GHCR images
-- Anything beyond those open MVP issues is unknown until issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) says otherwise.
-- Do not pick up "nice-to-have" work ahead of MVP issues unless explicitly requested.
+- MVP foundations are complete enough for external review: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, repo metadata, `.env` documentation, and build validation.
+- Active pre-submission priorities:
+  1. [#11](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/11) public landing page / shareable project surface.
+  2. [#13](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/13) explicit execution-mode UX and restart flow for exec approvals.
+  3. [#14](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/14) offline-first local model exploration, only after the local Ollama path has enough validation to justify more scope.
+- Treat [#2](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/2) as historical context for #13, not a separate implementation track.
+- Do not start new feature branches from stale priority notes. Re-check #12, open issues, and the latest merged PRs first.
 
 ## Decision Gates
 
@@ -58,6 +59,8 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
   - verify the linked issue state
   - close or update related issues
   - update milestones when priorities change
+- Planning freshness hook: after any PR that closes or materially changes a roadmap item, check whether README Roadmap path, AGENTS Current Roadmap, and issue #12 need a one-comment status update. Keep this to a small patch or comment; do not create a planning subsystem.
+- External review loop: before merging user-facing PRs, expect the maintainer may paste the PR into Gemini CLI for a review comment and Claude for a more critical review. Treat those reviews as input to verify, not orders to follow blindly.
 
 ## Repo Hygiene
 

--- a/README.md
+++ b/README.md
@@ -296,13 +296,15 @@ Do not use Portless or another alternate hostname for the default installed-app 
 
 The roadmap source of truth is [issue #12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12). Keep this section aligned with that issue.
 
-The repo should move in this order:
+Current status: the MVP foundation is complete enough for external review. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, and the README now documents the current provider-auth and `.env` behavior.
 
-1. Publish pre-built GHCR images and finish the end-user install/update path.
-2. Tighten the isolation and trust-boundary story around the wrapper runtime.
-3. Add architecture detection or graceful failure for unsupported hosts.
+The repo should now move in this order:
 
-The developer-only local update path remains `make update-extension`. The release-image path is the one that should eventually replace manual rebuilds for end users.
+1. Prepare a public project surface: GitHub Pages landing page, current screenshot/GIF, quick-start links, and clear limitations.
+2. Resolve the remaining exec-approval UX gap by making restart-required behavior explicit and recoverable from the extension.
+3. Keep offline-first/local-model work bounded to host Ollama validation unless real user traction justifies a bundled local runtime.
+
+The developer-only local update path remains `make update-extension`. The release-image path is the preferred end-user path; local builds remain useful for development and validation.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Update README roadmap path to reflect current external-review readiness.
- Update AGENTS current roadmap so future agents do not follow stale #3/#8/#40/#9 priorities.
- Add a lightweight planning freshness hook and document the Gemini/Claude external review loop.
- Close #2 as superseded by #13 and post a fresh #12 roadmap status comment.

Contributes to #12.

## Validation
- git diff --check
- Verified open issue list now routes through #11, #13, #14, and #12