### PR TITLE
feat: add execution mode restart flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ Current extension-managed auth is intentionally narrow:
 - `Local Model Setup` writes OpenClaw config and a per-agent Ollama auth profile for an already installed host Ollama model.
 - Other provider credentials should be configured through OpenClaw's own auth/onboarding flows or by writing supported keys such as `ANTHROPIC_API_KEY=...` into `/home/node/.openclaw/.env`, then restarting OpenClaw.
 
+## Execution mode
+
+OpenClaw exec approval settings can be cached by the running gateway. If the approvals file changes on disk but the gateway is not restarted, webchat command behavior may still reflect the older in-memory policy.
+
+The extension exposes an `Execution Mode` control to make that restart requirement explicit:
+
+- `Safer`: configures gateway exec to use allowlisted commands and approval prompts, with denied fallback when no approval UI is reachable.
+- `Full access`: configures gateway exec to run without approval prompts inside the OpenClaw service container.
+
+Changing the mode writes both `/home/node/.openclaw/openclaw.json` and `/home/node/.openclaw/exec-approvals.json`, then restarts OpenClaw automatically so the new policy is loaded. `Full access` is opt-in because it reduces command approval protections.
+
 ## Installed Control UI on macOS
 
 Use the canonical localhost Control UI origin for browser-app installs:

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,9 @@ import {
   Chip,
   CircularProgress,
   Divider,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
   Stack,
   TextField,
   Typography,
@@ -31,6 +34,12 @@ import {
 } from './ollamaSetup';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { readGatewayTokenWithRetry } from './tokenRetry';
+import {
+  buildExecModeReadScript,
+  buildExecModeWriteScript,
+  parseExecModeReadOutput,
+  type ExecutionMode,
+} from './execMode';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
@@ -135,7 +144,13 @@ export function App() {
   const [ollamaChecking, setOllamaChecking] = useState(false);
   const [ollamaStatus, setOllamaStatus] = useState('');
   const [ollamaAlertSeverity, setOllamaAlertSeverity] = useState<'success' | 'info' | 'error'>('info');
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>('safer');
+  const [appliedExecutionMode, setAppliedExecutionMode] = useState<ExecutionMode>('safer');
+  const [executionModeChecking, setExecutionModeChecking] = useState(false);
+  const [executionModeStatus, setExecutionModeStatus] = useState('');
+  const [executionModeAlertSeverity, setExecutionModeAlertSeverity] = useState<'success' | 'info' | 'warning' | 'error'>('info');
   const selectedOllamaChanged = Boolean(selectedOllamaModel) && selectedOllamaModel !== configuredOllamaModel;
+  const executionModeChanged = executionMode !== appliedExecutionMode;
 
   const persistConfig = useCallback((next: ExtensionConfig) => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -481,6 +496,89 @@ export function App() {
     }
   }, [appendDebug, asText, ddClient, findContainer]);
 
+  const detectExecutionMode = useCallback(async () => {
+    setExecutionModeChecking(true);
+    setError('');
+    setExecutionModeStatus('');
+    setExecutionModeAlertSeverity('info');
+    try {
+      const container = await findContainer();
+      if (!container || container.state !== 'running') {
+        throw new Error('Start OpenClaw before checking execution mode.');
+      }
+
+      const result = (await ddClient.docker.cli.exec('exec', [
+        container.id,
+        'node',
+        '-e',
+        buildExecModeReadScript(),
+      ])) as CliExecResult;
+      const stderr = asText(result.stderr).trim();
+      if (stderr) {
+        appendDebug(`execution mode detect stderr: ${stderr}`);
+      }
+
+      const detected = parseExecModeReadOutput(asText(result.stdout)).mode;
+      setExecutionMode(detected);
+      setAppliedExecutionMode(detected);
+      setExecutionModeAlertSeverity('success');
+      setExecutionModeStatus(
+        detected === 'full'
+          ? 'Full access is currently applied. Commands can run without approval prompts inside the OpenClaw container.'
+          : 'Safer mode is currently applied. Unknown commands require allowlist matching or approval.',
+      );
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`execution mode detect failed: ${text}`);
+      setExecutionModeAlertSeverity('error');
+      setExecutionModeStatus(`Could not read execution mode: ${text}`);
+    } finally {
+      setExecutionModeChecking(false);
+    }
+  }, [appendDebug, asText, ddClient, findContainer]);
+
+  const applyExecutionMode = useCallback(async () => {
+    setBusy(true);
+    setError('');
+    setMessage('');
+    setExecutionModeStatus('');
+    setExecutionModeAlertSeverity(executionMode === 'full' ? 'warning' : 'info');
+    try {
+      const container = await findContainer();
+      if (!container || container.state !== 'running') {
+        throw new Error('Start OpenClaw before applying execution mode.');
+      }
+
+      appendDebug(`applying OpenClaw execution mode: ${executionMode}`);
+      await ddClient.docker.cli.exec('exec', [
+        container.id,
+        'node',
+        '-e',
+        buildExecModeWriteScript(executionMode),
+      ]);
+      setExecutionModeStatus(
+        `Applied ${executionMode === 'full' ? 'Full access' : 'Safer'} mode. Restarting OpenClaw...`,
+      );
+      await restart();
+      setAppliedExecutionMode(executionMode);
+      setExecutionModeAlertSeverity(executionMode === 'full' ? 'warning' : 'success');
+      setExecutionModeStatus(
+        executionMode === 'full'
+          ? 'Restart complete. Full access is active; command approval protections are reduced.'
+          : 'Restart complete. Safer mode is active.',
+      );
+      setMessage(`OpenClaw execution mode applied: ${executionMode === 'full' ? 'Full access' : 'Safer'}.`);
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`execution mode apply failed: ${text}`);
+      setExecutionModeAlertSeverity('error');
+      setExecutionModeStatus(`Could not apply execution mode: ${text}`);
+      setError(text);
+    } finally {
+      setBusy(false);
+    }
+  }, [appendDebug, ddClient, executionMode, findContainer, restart]);
+
   const applyOllamaSetup = useCallback(async () => {
     const model = selectedOllamaModel.trim();
     if (!model) {
@@ -615,8 +713,9 @@ export function App() {
   useEffect(() => {
     if (phase === 'running') {
       void checkForUpdate();
+      void detectExecutionMode();
     }
-  }, [phase, checkForUpdate]);
+  }, [phase, checkForUpdate, detectExecutionMode]);
 
   useEffect(() => {
     if (phase !== 'running') {
@@ -855,6 +954,59 @@ export function App() {
               </TextField>
               {ollamaStatus && (
                 <Alert severity={ollamaAlertSeverity}>{ollamaStatus}</Alert>
+              )}
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Stack spacing={2}>
+              <Typography variant="h5">Execution Mode</Typography>
+              <Typography variant="body2" color="text.secondary">
+                OpenClaw may cache exec approval policy until the gateway restarts. Changing this mode writes
+                both OpenClaw exec policy and the host approvals file, then restarts OpenClaw automatically.
+              </Typography>
+              <RadioGroup
+                value={executionMode}
+                onChange={(event) => setExecutionMode(event.target.value as ExecutionMode)}
+              >
+                <FormControlLabel
+                  value="safer"
+                  control={<Radio />}
+                  label="Safer: allowlisted commands and approval prompts"
+                />
+                <FormControlLabel
+                  value="full"
+                  control={<Radio />}
+                  label="Full access: run commands without approval prompts"
+                />
+              </RadioGroup>
+              {executionMode === 'full' && (
+                <Alert severity="warning">
+                  Full access reduces command approval protections. Use it only when you trust the local
+                  OpenClaw session and understand commands can run inside the service container without prompts.
+                </Alert>
+              )}
+              <Stack direction="row" spacing={1} flexWrap="wrap">
+                <Button
+                  variant="outlined"
+                  startIcon={executionModeChecking ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  onClick={() => void detectExecutionMode()}
+                  disabled={busy || executionModeChecking || phase !== 'running'}
+                >
+                  {executionModeChecking ? 'Checking...' : 'Check Mode'}
+                </Button>
+                <Button
+                  variant="contained"
+                  onClick={() => void applyExecutionMode()}
+                  disabled={busy || phase !== 'running' || !executionModeChanged}
+                >
+                  {executionModeChanged ? 'Apply and Restart' : 'Already Applied'}
+                </Button>
+              </Stack>
+              {executionModeStatus && (
+                <Alert severity={executionModeAlertSeverity}>{executionModeStatus}</Alert>
               )}
             </Stack>
           </CardContent>

--- a/ui/src/execMode.test.ts
+++ b/ui/src/execMode.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildExecModeReadScript,
+  buildExecModeWriteScript,
+  buildExecutionModeConfig,
+  detectExecutionMode,
+  mergeExecApprovals,
+  mergeOpenClawExecConfig,
+} from './execMode';
+
+describe('execution mode config', () => {
+  it('builds safer mode with allowlist prompts and deny fallback', () => {
+    expect(buildExecutionModeConfig('safer')).toEqual({
+      approvalsDefaults: {
+        security: 'allowlist',
+        ask: 'on-miss',
+        askFallback: 'deny',
+        autoAllowSkills: false,
+      },
+      toolsExec: {
+        host: 'gateway',
+        security: 'allowlist',
+        ask: 'on-miss',
+      },
+    });
+  });
+
+  it('builds full access mode with prompts off and full fallback', () => {
+    expect(buildExecutionModeConfig('full')).toEqual({
+      approvalsDefaults: {
+        security: 'full',
+        ask: 'off',
+        askFallback: 'full',
+        autoAllowSkills: false,
+      },
+      toolsExec: {
+        host: 'gateway',
+        security: 'full',
+        ask: 'off',
+      },
+    });
+  });
+
+  it('merges approvals without losing socket or allowlist state', () => {
+    const merged = mergeExecApprovals(
+      {
+        version: 1,
+        socket: {
+          path: '/home/node/.openclaw/exec-approvals.sock',
+          token: 'preserved',
+        },
+        defaults: {
+          security: 'full',
+          ask: 'off',
+          askFallback: 'full',
+        },
+        agents: {
+          main: {
+            allowlist: [
+              {
+                id: 'entry-1',
+                pattern: '/usr/bin/ls',
+              },
+            ],
+          },
+        },
+      },
+      'safer',
+    );
+
+    expect(merged.socket).toEqual({
+      path: '/home/node/.openclaw/exec-approvals.sock',
+      token: 'preserved',
+    });
+    expect(merged.agents).toEqual({
+      main: {
+        allowlist: [
+          {
+            id: 'entry-1',
+            pattern: '/usr/bin/ls',
+          },
+        ],
+      },
+    });
+    expect(merged.defaults).toEqual({
+      security: 'allowlist',
+      ask: 'on-miss',
+      askFallback: 'deny',
+      autoAllowSkills: false,
+    });
+  });
+
+  it('merges OpenClaw tools.exec without clobbering unrelated config', () => {
+    const merged = mergeOpenClawExecConfig(
+      {
+        gateway: { auth: { token: 'keep' } },
+        tools: {
+          other: true,
+          exec: {
+            strictInlineEval: true,
+          },
+        },
+      },
+      'full',
+    );
+
+    expect(merged.gateway).toEqual({ auth: { token: 'keep' } });
+    expect(merged.tools).toEqual({
+      other: true,
+      exec: {
+        strictInlineEval: true,
+        host: 'gateway',
+        security: 'full',
+        ask: 'off',
+      },
+    });
+  });
+
+  it('detects full only when both config layers are full access', () => {
+    expect(
+      detectExecutionMode(
+        { defaults: { security: 'full', ask: 'off', askFallback: 'full' } },
+        { tools: { exec: { security: 'full', ask: 'off' } } },
+      ),
+    ).toBe('full');
+    expect(
+      detectExecutionMode(
+        { defaults: { security: 'full', ask: 'off', askFallback: 'full' } },
+        { tools: { exec: { security: 'allowlist', ask: 'on-miss' } } },
+      ),
+    ).toBe('safer');
+  });
+
+  it('builds a Docker SDK-safe write script for both config files', () => {
+    const script = buildExecModeWriteScript('full');
+
+    expect(script).toContain('/home/node/.openclaw/exec-approvals.json');
+    expect(script).toContain('/home/node/.openclaw/openclaw.json');
+    expect(script).toContain('copyFileSync');
+    expect(script).not.toContain('&&');
+    expect(script).not.toContain('|');
+  });
+
+  it('builds a read script that does not return socket token fields', () => {
+    const script = buildExecModeReadScript();
+
+    expect(script).toContain('approvals:{defaults:approvals.defaults');
+    expect(script).not.toContain('socket');
+    expect(script).not.toContain('token');
+    expect(script).not.toContain('&&');
+    expect(script).not.toContain('|');
+  });
+});

--- a/ui/src/execMode.ts
+++ b/ui/src/execMode.ts
@@ -1,0 +1,150 @@
+export type ExecutionMode = 'safer' | 'full';
+
+export type JsonObject = Record<string, unknown>;
+
+const OPENCLAW_CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
+const EXEC_APPROVALS_PATH = '/home/node/.openclaw/exec-approvals.json';
+
+type ExecutionModeConfig = {
+  approvalsDefaults: JsonObject;
+  toolsExec: JsonObject;
+};
+
+export function buildExecutionModeConfig(mode: ExecutionMode): ExecutionModeConfig {
+  if (mode === 'full') {
+    return {
+      approvalsDefaults: {
+        security: 'full',
+        ask: 'off',
+        askFallback: 'full',
+        autoAllowSkills: false,
+      },
+      toolsExec: {
+        host: 'gateway',
+        security: 'full',
+        ask: 'off',
+      },
+    };
+  }
+
+  return {
+    approvalsDefaults: {
+      security: 'allowlist',
+      ask: 'on-miss',
+      askFallback: 'deny',
+      autoAllowSkills: false,
+    },
+    toolsExec: {
+      host: 'gateway',
+      security: 'allowlist',
+      ask: 'on-miss',
+    },
+  };
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function mergeExecApprovals(existing: JsonObject, mode: ExecutionMode): JsonObject {
+  const next = buildExecutionModeConfig(mode);
+  const existingDefaults = isJsonObject(existing.defaults) ? existing.defaults : {};
+
+  return {
+    version: 1,
+    ...existing,
+    defaults: {
+      ...existingDefaults,
+      ...next.approvalsDefaults,
+    },
+  };
+}
+
+export function mergeOpenClawExecConfig(existing: JsonObject, mode: ExecutionMode): JsonObject {
+  const next = buildExecutionModeConfig(mode);
+  const existingTools = isJsonObject(existing.tools) ? existing.tools : {};
+  const existingExec = isJsonObject(existingTools.exec) ? existingTools.exec : {};
+
+  return {
+    ...existing,
+    tools: {
+      ...existingTools,
+      exec: {
+        ...existingExec,
+        ...next.toolsExec,
+      },
+    },
+  };
+}
+
+export function detectExecutionMode(approvals: JsonObject, openclawConfig: JsonObject): ExecutionMode {
+  const defaults = isJsonObject(approvals.defaults) ? approvals.defaults : {};
+  const tools = isJsonObject(openclawConfig.tools) ? openclawConfig.tools : {};
+  const exec = isJsonObject(tools.exec) ? tools.exec : {};
+  const approvalsFull =
+    defaults.security === 'full' &&
+    defaults.ask === 'off' &&
+    defaults.askFallback === 'full';
+  const configFull = exec.security === 'full' && exec.ask === 'off';
+
+  return approvalsFull && configFull ? 'full' : 'safer';
+}
+
+export function buildExecModeReadScript(): string {
+  return [
+    'const fs=require("fs");',
+    'const approvalsPath=' + JSON.stringify(EXEC_APPROVALS_PATH) + ';',
+    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
+    'function read(file){if(!fs.existsSync(file)){return {};} return JSON.parse(fs.readFileSync(file,"utf8"));}',
+    'const approvals=read(approvalsPath);',
+    'const config=read(configPath);',
+    'const tools=config.tools?config.tools:{};',
+    'process.stdout.write(JSON.stringify({approvals:{defaults:approvals.defaults?approvals.defaults:{}},config:{tools:{exec:tools.exec?tools.exec:{}}}}));',
+  ].join(' ');
+}
+
+export function buildExecModeWriteScript(mode: ExecutionMode): string {
+  const next = buildExecutionModeConfig(mode);
+
+  return [
+    'const fs=require("fs");',
+    'const path=require("path");',
+    'const approvalsPath=' + JSON.stringify(EXEC_APPROVALS_PATH) + ';',
+    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
+    'const approvalsDefaults=' + JSON.stringify(next.approvalsDefaults) + ';',
+    'const toolsExec=' + JSON.stringify(next.toolsExec) + ';',
+    'function read(file){if(!fs.existsSync(file)){return {};} return JSON.parse(fs.readFileSync(file,"utf8"));}',
+    'function writeJson(file,data){fs.mkdirSync(path.dirname(file),{recursive:true}); if(fs.existsSync(file)){fs.copyFileSync(file,file+".bak");} fs.writeFileSync(file,JSON.stringify(data,null,2)+"\\n");}',
+    'const approvals=read(approvalsPath);',
+    'const config=read(configPath);',
+    'approvals.version=1;',
+    'approvals.defaults=Object.assign({},approvals.defaults?approvals.defaults:{},approvalsDefaults);',
+    'config.tools=config.tools?config.tools:{};',
+    'config.tools.exec=Object.assign({},config.tools.exec?config.tools.exec:{},toolsExec);',
+    'writeJson(approvalsPath,approvals);',
+    'writeJson(configPath,config);',
+  ].join(' ');
+}
+
+export function parseExecModeReadOutput(stdout: string): {
+  approvals: JsonObject;
+  config: JsonObject;
+  mode: ExecutionMode;
+} {
+  if (!stdout.trim()) {
+    return { approvals: {}, config: {}, mode: 'safer' };
+  }
+
+  try {
+    const parsed = JSON.parse(stdout) as { approvals?: unknown; config?: unknown };
+    const approvals = isJsonObject(parsed.approvals) ? parsed.approvals : {};
+    const config = isJsonObject(parsed.config) ? parsed.config : {};
+    return {
+      approvals,
+      config,
+      mode: detectExecutionMode(approvals, config),
+    };
+  } catch {
+    return { approvals: {}, config: {}, mode: 'safer' };
+  }
+}


### PR DESCRIPTION
## Summary
- add a Docker Desktop Execution Mode card with Safer and Full access options
- write both OpenClaw tools.exec config and exec-approvals defaults, then restart OpenClaw so cached policy reloads
- add execution-mode helpers/tests that preserve existing approval metadata and avoid returning socket token fields on read
- document the execution-mode behavior in README

## Verification
- npm test
- npm run build
- git diff --cached --check

Closes #13