### PR TITLE
fix: restore runtime hardening args

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,20 @@ Do not use Portless or another alternate hostname for the default installed-app 
 - This is a more isolated local packaging path, not a perfect security boundary.
 - This project is not an official Docker or OpenClaw extension.
 
+## Host posture checklist
+
+Host security posture is intentionally a user-run checklist, not automatic extension scanning. The extension should avoid collecting broad host state such as backup status, disk encryption status, account privilege details, or home-directory configuration. Those checks can be useful before relying on any local agent, but they are outside this extension's trust boundary.
+
+Recommended manual checks before using Full access execution mode or sensitive local data:
+
+- Confirm the OpenClaw Control UI is reachable only on localhost, for example `127.0.0.1:<port>`.
+- Confirm Docker Desktop is up to date.
+- Confirm macOS security updates, FileVault, and backups are configured according to your own workstation policy.
+- Keep provider credentials and OpenClaw auth material out of screenshots, logs, issues, and PRs.
+- Prefer `Safer` execution mode unless you trust the local OpenClaw session and understand that commands can run inside the service container without approval prompts.
+
+Safe extension-level diagnostics are limited to project-specific state: container health, localhost binding, runtime image, named volume, selected model provider, and recent Docker command output. Do not add automatic host posture scans unless a future issue narrows the exact checks and privacy expectations.
+
 ## Current limitations
 
 - If the gateway token field is blank, open the Control UI and paste the token manually after retrieving it from the service container or volume.
@@ -330,7 +344,7 @@ Do not use Portless or another alternate hostname for the default installed-app 
 
 The roadmap source of truth is [issue #12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12). Keep this section aligned with that issue.
 
-Current status: the MVP foundation is complete enough for external review. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README now documents the current provider-auth, `.env`, and host-Ollama offline-first behavior.
+Current status: the MVP foundation is complete enough for external review. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README now documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary.
 
 The repo should now move in this order:
 
@@ -342,9 +356,22 @@ The developer-only local update path remains `make update-extension`. The releas
 
 ## Troubleshooting
 
+- Required apps:
+  - Docker Desktop must be running before the extension can start or manage OpenClaw.
+  - Ollama only needs to be running when you use `Local Model Setup` or an already configured `ollama/<model>` default.
+  - Hosted-provider use does not require Ollama, but it does require the relevant provider auth and network access.
+- Basic startup workflow:
+  - Open Docker Desktop and wait for it to finish starting.
+  - Open the OpenClaw extension in Docker Desktop.
+  - Click `Start`; if the service already exists, use `Restart`.
+  - Click `Open Control UI` after the status says `OpenClaw is ready`.
+  - For local/offline model use, start Ollama on the host Mac first, then click `Detect Ollama Models` in `Local Model Setup`.
+- If `Detect Ollama Models` fails, confirm Ollama is running on the Mac and that `http://127.0.0.1:11434/api/tags` opens locally.
+- If no models appear, pull a practical model in Ollama first, then run detection again.
 - If the extension says `RUNNING` but the browser page does not open, check `http://127.0.0.1:18789/healthz`.
 - If the token field is empty, inspect the debug panel in the extension and fetch the token from the service container or volume.
 - If local installation fails, confirm Docker Desktop allows local extensions.
+- If Docker Desktop frequently stops after sleep or restart, start Docker Desktop first and then reopen the extension. Existing OpenClaw state remains in the named Docker volume.
 
 ## Repository layout
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -40,6 +40,7 @@ import {
   parseExecModeReadOutput,
   type ExecutionMode,
 } from './execMode';
+import { buildRuntimeRunArgs } from './runtimeContainer';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
@@ -302,22 +303,14 @@ export function App() {
         setStatusText('Starting existing OpenClaw container...');
       } else {
         appendDebug(`creating container ${CONTAINER_NAME} from ${config.image}`);
-        const result = (await ddClient.docker.cli.exec('run', [
-          '-d',
-          '--name',
-          CONTAINER_NAME,
-          '--platform',
-          'linux/arm64',
-          '-v',
-          `${VOLUME_NAME}:/home/node`,
-          '-p',
-          `127.0.0.1:${config.port}:${BRIDGE_PORT}`,
-          '--label',
-          `com.docker.extension.openclaw=${LABELS['com.docker.extension.openclaw']}`,
-          '--label',
-          `com.docker.extension.openclaw.role=${LABELS['com.docker.extension.openclaw.role']}`,
-          config.image,
-        ])) as CliExecResult;
+        const result = (await ddClient.docker.cli.exec('run', buildRuntimeRunArgs({
+          containerName: CONTAINER_NAME,
+          image: config.image,
+          volumeName: VOLUME_NAME,
+          hostPort: config.port,
+          bridgePort: BRIDGE_PORT,
+          labels: LABELS,
+        }))) as CliExecResult;
         const stdout = asText(result.stdout).trim();
         const stderr = asText(result.stderr).trim();
         appendDebug(`docker run stdout: ${stdout || '<empty>'}`);

--- a/ui/src/runtimeContainer.test.ts
+++ b/ui/src/runtimeContainer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRuntimeRunArgs } from './runtimeContainer';
+
+describe('runtime container launch args', () => {
+  it('keeps the OpenClaw service localhost-bound and applies runtime hardening', () => {
+    const args = buildRuntimeRunArgs({
+      containerName: 'openclaw-docker-extension-service',
+      image: 'ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest',
+      volumeName: 'openclaw-docker-extension-home',
+      hostPort: 18789,
+      bridgePort: 18790,
+      labels: {
+        'com.docker.extension.openclaw': 'true',
+        'com.docker.extension.openclaw.role': 'service',
+      },
+    });
+
+    expect(args).toEqual([
+      '-d',
+      '--name',
+      'openclaw-docker-extension-service',
+      '--platform',
+      'linux/arm64',
+      '--read-only',
+      '--tmpfs',
+      '/tmp:rw,noexec,nosuid,size=64m',
+      '--cap-drop',
+      'ALL',
+      '--security-opt',
+      'no-new-privileges',
+      '--ulimit',
+      'nofile=1024:1024',
+      '-v',
+      'openclaw-docker-extension-home:/home/node',
+      '-p',
+      '127.0.0.1:18789:18790',
+      '--label',
+      'com.docker.extension.openclaw=true',
+      '--label',
+      'com.docker.extension.openclaw.role=service',
+      'ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest',
+    ]);
+  });
+});

--- a/ui/src/runtimeContainer.ts
+++ b/ui/src/runtimeContainer.ts
@@ -1,0 +1,38 @@
+type RuntimeRunArgsOptions = {
+  containerName: string;
+  image: string;
+  volumeName: string;
+  hostPort: number;
+  bridgePort: number;
+  labels: Record<string, string>;
+};
+
+const RUNTIME_PLATFORM = 'linux/arm64';
+const RUNTIME_SECURITY_ARGS = [
+  '--read-only',
+  '--tmpfs',
+  '/tmp:rw,noexec,nosuid,size=64m',
+  '--cap-drop',
+  'ALL',
+  '--security-opt',
+  'no-new-privileges',
+  '--ulimit',
+  'nofile=1024:1024',
+];
+
+export function buildRuntimeRunArgs(options: RuntimeRunArgsOptions): string[] {
+  return [
+    '-d',
+    '--name',
+    options.containerName,
+    '--platform',
+    RUNTIME_PLATFORM,
+    ...RUNTIME_SECURITY_ARGS,
+    '-v',
+    `${options.volumeName}:/home/node`,
+    '-p',
+    `127.0.0.1:${options.hostPort}:${options.bridgePort}`,
+    ...Object.entries(options.labels).flatMap(([key, value]) => ['--label', `${key}=${value}`]),
+    options.image,
+  ];
+}


### PR DESCRIPTION
## Summary
- restore the Docker run hardening flags through a tested runtime container arg builder
- keep the service localhost-bound while adding read-only rootfs, tmpfs /tmp, cap-drop, no-new-privileges, and nofile ulimit args
- document the #60 host posture decision as a user-run checklist, not automatic extension host scanning
- add a basic troubleshooting workflow that explains when Docker Desktop and Ollama need to be running

## Investigation Notes
- The running service container was localhost-bound and healthy.
- Docker inspect showed the current container had no SecurityOpt, no CapDrop, and ReadonlyRootfs=false.
- Root cause: hardening args introduced in earlier commits were removed during the update/restart refactor while README claims remained.
- This fix applies to newly created service containers. Existing containers must be removed/recreated to pick up Docker run-time hardening flags.
- Native migration is tracked separately in #64.

## Verification
- npm test
- npm run build
- git diff --cached --check

Closes #60