### PR TITLE
feat: add onboarding requirement checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,11 +363,13 @@ The developer-only local update path remains `make update-extension`. The releas
 - Basic startup workflow:
   - Open Docker Desktop and wait for it to finish starting.
   - Open the OpenClaw extension in Docker Desktop.
+  - Click `Check Requirements` if you want to confirm Docker is responsive and the configured host port is not already used by another Docker container.
   - Click `Start`; if the service already exists, use `Restart`.
   - Click `Open Control UI` after the status says `OpenClaw is ready`.
   - For local/offline model use, start Ollama on the host Mac first, then click `Detect Ollama Models` in `Local Model Setup`.
 - If `Detect Ollama Models` fails, confirm Ollama is running on the Mac and that `http://127.0.0.1:11434/api/tags` opens locally.
 - If no models appear, pull a practical model in Ollama first, then run detection again.
+- If `Start` reports that the host port is already in use, change `Host Port` in Settings or stop the other container using that port.
 - If the extension says `RUNNING` but the browser page does not open, check `http://127.0.0.1:18789/healthz`.
 - If the token field is empty, inspect the debug panel in the extension and fetch the token from the service container or volume.
 - If local installation fails, confirm Docker Desktop allows local extensions.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
 import {
   Alert,
+  AlertColor,
   Box,
   Button,
   Card,
@@ -41,6 +42,11 @@ import {
   type ExecutionMode,
 } from './execMode';
 import { buildRuntimeRunArgs } from './runtimeContainer';
+import {
+  buildDockerPsPortCheckArgs,
+  formatStartFailure,
+  parseDockerPublishedPortConflicts,
+} from './requirementChecks';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
@@ -136,6 +142,9 @@ export function App() {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [debugLog, setDebugLog] = useState('');
+  const [requirementsChecking, setRequirementsChecking] = useState(false);
+  const [requirementsStatus, setRequirementsStatus] = useState('');
+  const [requirementsSeverity, setRequirementsSeverity] = useState<AlertColor>('info');
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [updateChecking, setUpdateChecking] = useState(false);
   const [updateError, setUpdateError] = useState('');
@@ -202,6 +211,68 @@ export function App() {
       return next.slice(-12000);
     });
   }, []);
+
+  const findPortConflicts = useCallback(async () => {
+    const result = (await ddClient.docker.cli.exec('ps', buildDockerPsPortCheckArgs())) as CliExecResult;
+    return parseDockerPublishedPortConflicts(asText(result.stdout), config.port, CONTAINER_NAME);
+  }, [asText, config.port, ddClient]);
+
+  const checkRequirements = useCallback(async () => {
+    setRequirementsChecking(true);
+    setRequirementsStatus('');
+    setRequirementsSeverity('info');
+    setError('');
+    try {
+      const version = (await ddClient.docker.cli.exec('version', ['--format', '{{.Server.Version}}'])) as CliExecResult;
+      const dockerVersion = asText(version.stdout).trim();
+      if (!dockerVersion) {
+        throw new Error('Docker Desktop responded, but the Docker Engine version was empty.');
+      }
+
+      const conflicts = await findPortConflicts();
+      if (conflicts.length > 0) {
+        setRequirementsSeverity('warning');
+        setRequirementsStatus(
+          `Docker is ready, but host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port or stop the other container before starting OpenClaw.`,
+        );
+        return;
+      }
+
+      if (configuredOllamaModel && phase === 'running') {
+        try {
+          const container = await findContainer();
+          if (container?.state === 'running') {
+            await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
+          }
+          setRequirementsSeverity('success');
+          setRequirementsStatus(
+            `Docker is ready, host port ${config.port} is available, and host Ollama is reachable for ${configuredOllamaModel}.`,
+          );
+          return;
+        } catch (err) {
+          const text = err instanceof Error ? err.message : String(err);
+          appendDebug(`requirements Ollama check failed: ${text}`);
+          setRequirementsSeverity('warning');
+          setRequirementsStatus(
+            `Docker is ready and host port ${config.port} is available, but host Ollama was not reachable. Start Ollama before using the configured local model ${configuredOllamaModel}.`,
+          );
+          return;
+        }
+      }
+
+      setRequirementsSeverity('success');
+      setRequirementsStatus(
+        `Docker is ready and host port ${config.port} is available. Ollama is only required for Local Model Setup or an ollama/<model> default.`,
+      );
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err);
+      appendDebug(`requirements check failed: ${text}`);
+      setRequirementsSeverity('error');
+      setRequirementsStatus(formatStartFailure(text, config.port));
+    } finally {
+      setRequirementsChecking(false);
+    }
+  }, [appendDebug, asText, config.port, configuredOllamaModel, ddClient, findContainer, findPortConflicts, phase]);
 
   const fetchGatewayToken = useCallback(async (containerId: string) => {
     const result = (await ddClient.docker.cli.exec('exec', [
@@ -302,6 +373,13 @@ export function App() {
         await ddClient.docker.cli.exec('start', [existing.id]);
         setStatusText('Starting existing OpenClaw container...');
       } else {
+        const conflicts = await findPortConflicts();
+        if (conflicts.length > 0) {
+          throw new Error(
+            `Host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port in Settings or stop the other container, then try Start again.`,
+          );
+        }
+
         appendDebug(`creating container ${CONTAINER_NAME} from ${config.image}`);
         const result = (await ddClient.docker.cli.exec('run', buildRuntimeRunArgs({
           containerName: CONTAINER_NAME,
@@ -335,13 +413,13 @@ export function App() {
       await runAndPoll();
     } catch (err) {
       setPhase('error');
-      const text = err instanceof Error ? err.message : String(err);
+      const text = formatStartFailure(err instanceof Error ? err.message : String(err), config.port);
       appendDebug(`create/start failed: ${text}`);
       setError(text);
     } finally {
       setBusy(false);
     }
-  }, [appendDebug, asText, config.image, config.port, ddClient, findContainer, runAndPoll]);
+  }, [appendDebug, asText, config.image, config.port, ddClient, findContainer, findPortConflicts, runAndPoll]);
 
   const stop = useCallback(async () => {
     setBusy(true);
@@ -777,6 +855,11 @@ export function App() {
             Update check failed: {updateError}
           </Alert>
         )}
+        {requirementsStatus && (
+          <Alert severity={requirementsSeverity} onClose={() => setRequirementsStatus('')}>
+            {requirementsStatus}
+          </Alert>
+        )}
 
         <Card>
           <CardContent>
@@ -797,6 +880,14 @@ export function App() {
                   disabled={busy || phase === 'running'}
                 >
                   {busy ? 'Starting...' : 'Start'}
+                </Button>
+                <Button
+                  variant="outlined"
+                  startIcon={requirementsChecking ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  onClick={() => void checkRequirements()}
+                  disabled={busy || requirementsChecking}
+                >
+                  {requirementsChecking ? 'Checking...' : 'Check Requirements'}
                 </Button>
                 <Button
                   variant="outlined"

--- a/ui/src/requirementChecks.test.ts
+++ b/ui/src/requirementChecks.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDockerPsPortCheckArgs,
+  formatStartFailure,
+  parseDockerPublishedPortConflicts,
+} from './requirementChecks';
+
+describe('requirement checks', () => {
+  it('builds Docker ps args for checking published ports', () => {
+    expect(buildDockerPsPortCheckArgs()).toEqual([
+      '--format',
+      '{{.ID}}\t{{.Names}}\t{{.Ports}}',
+    ]);
+  });
+
+  it('detects Docker containers already publishing the configured host port', () => {
+    const conflicts = parseDockerPublishedPortConflicts(
+      [
+        'abc123\topenclaw-docker-extension-service\t127.0.0.1:18789->18790/tcp',
+        'def456\tother-service\t0.0.0.0:18789->8080/tcp',
+        'ghi789\tunrelated\t127.0.0.1:3000->3000/tcp',
+      ].join('\n'),
+      18789,
+      'openclaw-docker-extension-service',
+    );
+
+    expect(conflicts).toEqual([
+      {
+        id: 'def456',
+        name: 'other-service',
+        ports: '0.0.0.0:18789->8080/tcp',
+      },
+    ]);
+  });
+
+  it('formats Docker port binding failures as user-actionable messages', () => {
+    expect(
+      formatStartFailure(
+        'Error response from daemon: driver failed programming external connectivity on endpoint x: Bind for 127.0.0.1:18789 failed: port is already allocated',
+        18789,
+      ),
+    ).toBe(
+      'Host port 18789 is already in use. Change the Host Port in Settings or stop the other process, then try Start again.',
+    );
+  });
+
+  it('formats Docker engine availability failures as startup guidance', () => {
+    expect(formatStartFailure('Cannot connect to the Docker daemon', 18789)).toBe(
+      'Docker Desktop is not ready yet. Start Docker Desktop, wait until it finishes starting, then try again.',
+    );
+  });
+});

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -1,0 +1,48 @@
+export type PortConflict = {
+  id: string;
+  name: string;
+  ports: string;
+};
+
+export function buildDockerPsPortCheckArgs(): string[] {
+  return ['--format', '{{.ID}}\t{{.Names}}\t{{.Ports}}'];
+}
+
+export function parseDockerPublishedPortConflicts(
+  stdout: string,
+  hostPort: number,
+  ownContainerName: string,
+): PortConflict[] {
+  const conflicts: PortConflict[] = [];
+  const portPattern = new RegExp(`(?:^|[,:])(?:0\\.0\\.0\\.0|127\\.0\\.0\\.1|\\[::\\]|::)?[:]${hostPort}->`);
+
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const [id = '', name = '', ports = ''] = trimmed.split('\t');
+    if (!id || !ports || name === ownContainerName) {
+      continue;
+    }
+
+    if (portPattern.test(ports)) {
+      conflicts.push({ id, name, ports });
+    }
+  }
+
+  return conflicts;
+}
+
+export function formatStartFailure(message: string, hostPort: number): string {
+  if (/port is already allocated|bind for .* failed|address already in use/i.test(message)) {
+    return `Host port ${hostPort} is already in use. Change the Host Port in Settings or stop the other process, then try Start again.`;
+  }
+
+  if (/cannot connect to the docker daemon|docker daemon is not running|is the docker daemon running/i.test(message)) {
+    return 'Docker Desktop is not ready yet. Start Docker Desktop, wait until it finishes starting, then try again.';
+  }
+
+  return message;
+}


### PR DESCRIPTION
## Summary
- add a non-destructive Check Requirements action to verify Docker Engine readiness and configured Docker port conflicts
- improve Start error messages for Docker daemon and port binding failures
- check host Ollama reachability when an Ollama model is already configured and OpenClaw is running
- document the Check Requirements workflow in README troubleshooting

## Scope
- This intentionally does not add a full onboarding wizard.
- Port checks detect Docker-published port conflicts before start; non-Docker host processes are still handled through improved Docker bind error messaging.

## Verification
- npm test
- npm run build
- git diff --check
- inspected docker ps published ports locally

Closes #66