### PR TITLE
docs: document native migration investigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,12 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
 ## Current Roadmap
 
 - Treat issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) as the source of truth for roadmap and decision gates.
-- MVP foundations are complete enough for external review: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, repo metadata, `.env` documentation, and build validation.
-- Active pre-submission priorities:
-  1. [#11](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/11) public landing page / shareable project surface.
-  2. [#13](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/13) explicit execution-mode UX and restart flow for exec approvals.
-  3. [#14](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/14) offline-first local model exploration, only after the local Ollama path has enough validation to justify more scope.
-- Treat [#2](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/2) as historical context for #13, not a separate implementation track.
+- MVP foundations are complete enough for external review: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, execution mode UX, repo metadata, `.env` documentation, readiness checks, and build validation.
+- Active pre-submission priority is manual stable-channel smoke testing on a real Docker Desktop install.
+- Remaining roadmap work is investigation or long-term hardening:
+  1. [#64](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/64) native migration after Docker Desktop trial; keep this manual/documentation-only unless user demand justifies automation.
+  2. [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65) longer-term security, hardening, supply-chain, and network migration epic.
+- Treat [#2](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/2) and [#13](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/13) as historical execution-mode context, not active implementation tracks.
 - Do not start new feature branches from stale priority notes. Re-check #12, open issues, and the latest merged PRs first.
 
 ## Decision Gates

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ The roadmap source of truth is [issue #12](https://github.com/jcowhigjr/openclaw
 
 Current status: the MVP foundation is complete enough for external review. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README now documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary.
 
+Native migration after a successful Docker Desktop trial is documented as a manual investigation path in [docs/native-migration-investigation.md](docs/native-migration-investigation.md). Do not build native migration automation until real user demand and upstream OpenClaw portable-state guidance justify it.
+
 The repo should now move in this order:
 
 1. Keep the release/channel image path and public landing page current for external review.

--- a/docs/native-migration-investigation.md
+++ b/docs/native-migration-investigation.md
@@ -1,0 +1,84 @@
+# Native Migration Investigation
+
+This note answers issue #64: what a safe path could look like for someone who starts
+with the Docker Desktop extension and later wants to run OpenClaw natively.
+
+## Recommendation
+
+Keep native migration as a documented manual checklist for now. Do not build export
+or native-install automation until real users ask for it and the OpenClaw portable
+state model is better defined.
+
+The Docker Desktop extension should remain the low-friction trial path. Native
+OpenClaw should be treated as a later user-owned setup, not an automatic upgrade
+step.
+
+## What Can Be Reused
+
+Reusable state is limited to user-owned OpenClaw data that the user intentionally
+copies from the Docker named volume:
+
+- project and agent files under the OpenClaw home directory
+- non-secret configuration that describes selected providers or defaults
+- conversation or workspace artifacts that OpenClaw stores as normal user data
+- execution approval preferences after the user reviews them for the native host
+
+The extension should not promise that every file in the Docker volume is portable.
+The safe default is to copy only files OpenClaw documents as portable, or to recreate
+configuration in the native setup by hand.
+
+## What Should Not Be Copied Automatically
+
+Do not automatically export or import:
+
+- gateway socket tokens
+- provider API keys
+- auth profiles containing credentials or bearer tokens
+- temporary runtime files
+- container-specific paths or generated process state
+- Docker-only hostnames such as `host.docker.internal`
+- approval policy that grants broader native-host access than the user intended
+
+Native execution has a larger blast radius than container execution. Any copied exec
+approval policy should be reviewed before use.
+
+## Manual Migration Checklist
+
+Use this as an investigation checklist, not a guaranteed migration command sequence.
+
+1. Confirm the Docker Desktop extension is working and OpenClaw is not actively
+   writing important state.
+2. Install or prepare native OpenClaw using upstream OpenClaw instructions.
+3. Start native OpenClaw with a fresh home directory.
+4. Recreate provider auth manually in native OpenClaw.
+5. If using Ollama, point native OpenClaw at the host Ollama URL, usually
+   `http://127.0.0.1:11434`.
+6. Review the Docker volume contents and copy only user-owned files that are clearly
+   portable.
+7. Do not copy gateway tokens or container-generated auth material.
+8. Review execution mode and approval settings before enabling broad native command
+   access.
+9. Start native OpenClaw and run a basic chat prompt.
+10. Keep the Docker Desktop extension installed until the native setup has been
+    verified and the user is comfortable deleting the Docker-managed copy.
+
+## Extension UI Implications
+
+No UI support is recommended yet.
+
+If user demand appears, the first UI feature should be a read-only migration helper:
+
+- explain what the Docker volume contains
+- link to this guide
+- warn that secrets are not exported
+- show the current provider and execution-mode status without printing secrets
+- provide copy commands only after the portable file set is confirmed upstream
+
+Avoid a one-click "migrate to native" action. It would blur trust boundaries,
+increase support burden, and risk copying secrets or container-specific state.
+
+## Decision
+
+For the current submission-ready project, native migration is documented as a
+post-trial manual path. The Docker Desktop extension remains the supported product
+surface, and native migration automation stays deferred.

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -70,9 +70,10 @@ Use `DRY_RUN=1` when you want to validate command construction without mutating 
 
 Open issues at submission time:
 
-- [#64](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/64): investigate a native OpenClaw migration path after Docker Desktop trial.
 - [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65): long-term security, hardening, supply-chain, and network migration epic.
 - [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12): roadmap and decision gates tracker.
+
+Native migration after a Docker Desktop trial is documented as a manual investigation path in [native-migration-investigation.md](native-migration-investigation.md).
 
 These are not blockers for an external review of the current Docker Desktop extension path.
 


### PR DESCRIPTION
## Summary
- add a native migration investigation guide for users moving beyond the Docker Desktop trial path
- define reusable state, non-portable or secret state, and a safe manual checklist
- update README, submission packet, and agent roadmap notes to point at the manual/documentation-only decision

Closes #64.

## Verification
- git diff --cached --check
- rg -n "TBD|TODO|native migration|Native migration|#64|#13" AGENTS.md README.md docs/submission-readiness.md docs/native-migration-investigation.md