### PR TITLE
fix: use JSON ps output for requirements check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+make test-pre-push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
   - UI build for frontend changes
   - Docker image build for runtime or packaging changes
   - PR checks before merge
+- Before pushing, run the repo pre-push path with `make test-pre-push` or the installed `.githooks/pre-push`. Do not bypass it with `--no-verify` unless the maintainer explicitly approves the bypass and the PR states what verification replaced it.
 - Use manual UI testing plus screenshots when:
   - establishing a baseline before a meaningful UI or UX change
   - acting as QA after merging a user-facing change

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ test-runtime-bridge: ; @sh ./scripts/test-runtime-bridge.sh
 test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
+test-ui: ; @cd ui && npm test && npm run build
+test-pre-push: test-ui test-runtime-bridge test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run
+install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-bundle.sh
@@ -84,4 +87,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Submission review packet: [docs/submission-readiness.md](docs/submission-readine
 make install-dev
 ```
 
+Optional local push guard:
+
+```bash
+make install-hooks
+```
+
+This installs the repo pre-push hook, which runs `make test-pre-push` before allowing a push.
+
 Then:
 
 1. Open the `OpenClaw` extension in Docker Desktop.

--- a/ui/src/requirementChecks.test.ts
+++ b/ui/src/requirementChecks.test.ts
@@ -10,8 +10,7 @@ import {
 describe('requirement checks', () => {
   it('builds Docker ps args for checking published ports', () => {
     expect(buildDockerPsPortCheckArgs()).toEqual([
-      '--format',
-      '{{.ID}}\t{{.Names}}\t{{.Ports}}',
+      '--format={{json .}}',
     ]);
   });
 
@@ -31,6 +30,33 @@ describe('requirement checks', () => {
         id: 'def456',
         name: 'other-service',
         ports: '0.0.0.0:18789->8080/tcp',
+      },
+    ]);
+  });
+
+  it('detects Docker port conflicts from JSON-line ps output', () => {
+    const conflicts = parseDockerPublishedPortConflicts(
+      [
+        JSON.stringify({
+          ID: 'abc123',
+          Names: 'openclaw-docker-extension-service',
+          Ports: '127.0.0.1:18789->18790/tcp',
+        }),
+        JSON.stringify({
+          ID: 'def456',
+          Names: 'other-service',
+          Ports: '127.0.0.1:18789->8080/tcp, [::]:18789->8080/tcp',
+        }),
+      ].join('\n'),
+      18789,
+      'openclaw-docker-extension-service',
+    );
+
+    expect(conflicts).toEqual([
+      {
+        id: 'def456',
+        name: 'other-service',
+        ports: '127.0.0.1:18789->8080/tcp, [::]:18789->8080/tcp',
       },
     ]);
   });

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -5,7 +5,7 @@ export type PortConflict = {
 };
 
 export function buildDockerPsPortCheckArgs(): string[] {
-  return ['--format', '{{.ID}}\t{{.Names}}\t{{.Ports}}'];
+  return ['--format={{json .}}'];
 }
 
 export function parseDockerPublishedPortConflicts(
@@ -22,7 +22,23 @@ export function parseDockerPublishedPortConflicts(
       continue;
     }
 
-    const [id = '', name = '', ports = ''] = trimmed.split('\t');
+    let id = '';
+    let name = '';
+    let ports = '';
+
+    if (trimmed.startsWith('{')) {
+      try {
+        const row = JSON.parse(trimmed) as Record<string, unknown>;
+        id = typeof row.ID === 'string' ? row.ID : '';
+        name = typeof row.Names === 'string' ? row.Names : '';
+        ports = typeof row.Ports === 'string' ? row.Ports : '';
+      } catch {
+        continue;
+      }
+    } else {
+      [id = '', name = '', ports = ''] = trimmed.split('\t');
+    }
+
     if (!id || !ports || name === ownContainerName) {
       continue;
     }


### PR DESCRIPTION
## Summary
- fix Check Requirements port preflight by using Docker JSON-line ps output instead of a split Go template argument
- keep tab-delimited parsing as a fallback while adding JSON-line parser coverage
- add a repo-versioned pre-push hook and install target so local pushes run the same fast validation path

## Verification
- npm test -- requirementChecks.test.ts
- npm test
- npm run build
- make test-pre-push
- .githooks/pre-push
- git push exercised the installed pre-push hook successfully