### PR TITLE
fix: avoid whitespace in Docker ps format arg

### DIFF
--- a/ui/src/requirementChecks.test.ts
+++ b/ui/src/requirementChecks.test.ts
@@ -10,7 +10,7 @@ import {
 describe('requirement checks', () => {
   it('builds Docker ps args for checking published ports', () => {
     expect(buildDockerPsPortCheckArgs()).toEqual([
-      '--format={{json .}}',
+      '--format={{.ID}}|{{.Names}}|{{.Ports}}',
     ]);
   });
 
@@ -47,6 +47,25 @@ describe('requirement checks', () => {
           Names: 'other-service',
           Ports: '127.0.0.1:18789->8080/tcp, [::]:18789->8080/tcp',
         }),
+      ].join('\n'),
+      18789,
+      'openclaw-docker-extension-service',
+    );
+
+    expect(conflicts).toEqual([
+      {
+        id: 'def456',
+        name: 'other-service',
+        ports: '127.0.0.1:18789->8080/tcp, [::]:18789->8080/tcp',
+      },
+    ]);
+  });
+
+  it('detects Docker port conflicts from whitespace-free pipe-delimited ps output', () => {
+    const conflicts = parseDockerPublishedPortConflicts(
+      [
+        'abc123|openclaw-docker-extension-service|127.0.0.1:18789->18790/tcp',
+        'def456|other-service|127.0.0.1:18789->8080/tcp, [::]:18789->8080/tcp',
       ].join('\n'),
       18789,
       'openclaw-docker-extension-service',

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -5,7 +5,7 @@ export type PortConflict = {
 };
 
 export function buildDockerPsPortCheckArgs(): string[] {
-  return ['--format={{json .}}'];
+  return ['--format={{.ID}}|{{.Names}}|{{.Ports}}'];
 }
 
 export function parseDockerPublishedPortConflicts(
@@ -35,6 +35,8 @@ export function parseDockerPublishedPortConflicts(
       } catch {
         continue;
       }
+    } else if (trimmed.includes('|')) {
+      [id = '', name = '', ports = ''] = trimmed.split('|');
     } else {
       [id = '', name = '', ports = ''] = trimmed.split('\t');
     }


### PR DESCRIPTION
## Summary
- replace the requirements preflight ps format with a whitespace-free single argument
- parse pipe-delimited ps output while preserving the JSON and tab-delimited fallbacks
- add regression coverage for the whitespace-free format path

## Root cause
Docker Desktop SDK appears to split CLI args on whitespace inside argument strings. The JSON format argument from PR #71 still contained a space in the json template, so docker ps received an extra argument and failed with docker ps accepts no arguments.

## Verification
- docker ps with the whitespace-free pipe-delimited format
- npm test -- requirementChecks.test.ts
- npm run build
- make test-pre-push
- docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest --tag=openclaw-docker-extension:dev .
- docker extension update -f openclaw-docker-extension:dev
- verified installed extension asset contains the pipe-delimited format and not the json-template format