### PR TITLE
fix: clarify extension debug output

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,6 +34,7 @@ import {
   type OllamaModel,
 } from './ollamaSetup';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
+import { appendDebugEntry } from './debugLog';
 import { readGatewayTokenWithRetry } from './tokenRetry';
 import {
   buildExecModeReadScript,
@@ -208,8 +209,7 @@ export function App() {
 
   const appendDebug = useCallback((entry: string) => {
     setDebugLog((current) => {
-      const next = current ? `${current}\n${entry}` : entry;
-      return next.slice(-12000);
+      return appendDebugEntry(current, entry);
     });
   }, []);
 
@@ -232,6 +232,7 @@ export function App() {
 
       const conflicts = await findPortConflicts();
       if (conflicts.length > 0) {
+        appendDebug(`requirements check found port conflict on ${config.port}`);
         setRequirementsSeverity('warning');
         setRequirementsStatus(
           `Docker is ready, but host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port or stop the other container before starting OpenClaw.`,
@@ -246,6 +247,7 @@ export function App() {
             await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
           }
           setRequirementsSeverity('success');
+          appendDebug(`requirements check passed: Docker, host port ${config.port}, and Ollama are ready`);
           setRequirementsStatus(
             `Docker is ready, host port ${config.port} is available, and host Ollama is reachable for ${configuredOllamaModel}.`,
           );
@@ -262,6 +264,7 @@ export function App() {
       }
 
       setRequirementsSeverity('success');
+      appendDebug(`requirements check passed: Docker is ready and host port ${config.port} is available`);
       setRequirementsStatus(
         `Docker is ready and host port ${config.port} is available. Ollama is only required for Local Model Setup or an ollama/<model> default.`,
       );
@@ -1120,7 +1123,17 @@ export function App() {
         <Card>
           <CardContent>
             <Stack spacing={1.5}>
-              <Typography variant="h5">Debug Output</Typography>
+              <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+                <Typography variant="h5">Debug Output</Typography>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={() => setDebugLog('')}
+                  disabled={!debugLog}
+                >
+                  Clear Debug
+                </Button>
+              </Stack>
               <TextField
                 value={debugLog}
                 multiline

--- a/ui/src/debugLog.test.ts
+++ b/ui/src/debugLog.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { appendDebugEntry, formatDebugEntry } from './debugLog';
+
+describe('debug log helpers', () => {
+  it('formats entries with a local time prefix', () => {
+    const date = new Date('2026-05-12T23:45:06Z');
+
+    expect(formatDebugEntry('host health check passed', date)).toMatch(
+      /^\[\d{2}:\d{2}:\d{2}\] host health check passed$/,
+    );
+  });
+
+  it('appends new entries after existing output', () => {
+    const date = new Date('2026-05-12T23:45:06Z');
+
+    expect(appendDebugEntry('previous line', 'requirements check passed', date)).toMatch(
+      /^previous line\n\[\d{2}:\d{2}:\d{2}\] requirements check passed$/,
+    );
+  });
+
+  it('trims old output when the log exceeds the configured limit', () => {
+    const date = new Date('2026-05-12T23:45:06Z');
+
+    const next = appendDebugEntry('abcdef', 'new', date, 10);
+
+    expect(next.length).toBeLessThanOrEqual(10);
+    expect(next).toContain('new');
+    expect(next).not.toContain('abcdef');
+  });
+});

--- a/ui/src/debugLog.ts
+++ b/ui/src/debugLog.ts
@@ -1,0 +1,22 @@
+const DEFAULT_DEBUG_LOG_LIMIT = 12000;
+
+export function formatDebugEntry(entry: string, date = new Date()): string {
+  const time = date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+  return `[${time}] ${entry}`;
+}
+
+export function appendDebugEntry(
+  current: string,
+  entry: string,
+  date = new Date(),
+  limit = DEFAULT_DEBUG_LOG_LIMIT,
+): string {
+  const formatted = formatDebugEntry(entry, date);
+  const next = current ? `${current}\n${formatted}` : formatted;
+  return next.slice(-limit);
+}


### PR DESCRIPTION
## Summary
- Closes #74
- Timestamp Debug Output entries so support screenshots have action order
- Add a Clear Debug button for stale diagnostics
- Record successful requirements checks in Debug Output so old failures are visibly superseded

## Verification
- npm test -- debugLog.test.ts
- make test-pre-push
- docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest --tag=openclaw-docker-extension:dev .
- docker extension update -f openclaw-docker-extension:dev
- Verified installed extension asset contains Clear Debug and requirements check passed text
- Restored local OpenClaw service container and verified /healthz returns {"ok":true,"status":"live"}