### PR TITLE
fix: address Docker extension validator metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
           esac
 
           echo "RELEASE_TAG=${release_tag}" >> "${GITHUB_ENV}"
+          echo "RELEASE_VERSION=${release_tag#v}" >> "${GITHUB_ENV}"
           ./scripts/release-channel.sh "${release_tag}" "${{ github.event_name }}" "${INPUT_PROMOTE_CHANNEL}" >> "${GITHUB_OUTPUT}"
 
       - name: Checkout release tag
@@ -80,6 +81,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ env.RELEASE_VERSION }}
             type=raw,value=${{ steps.release-context.outputs.channel_tag }},enable=${{ steps.release-context.outputs.has_channel_tag }}
             type=sha,prefix=sha-
 
@@ -88,7 +90,7 @@ jobs:
         with:
           context: runtime
           file: runtime/Dockerfile
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.runtime-meta.outputs.tags }}
           labels: ${{ steps.runtime-meta.outputs.labels }}
@@ -112,6 +114,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}
           tags: |
             type=raw,value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ env.RELEASE_VERSION }}
             type=raw,value=${{ steps.release-context.outputs.channel_tag }},enable=${{ steps.release-context.outputs.has_channel_tag }}
             type=sha,prefix=sha-
 
@@ -120,12 +123,12 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/arm64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.extension-meta.outputs.tags }}
           labels: ${{ steps.extension-meta.outputs.labels }}
           build-args: |
-            VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ steps.runtime-meta.outputs.version }}
+            VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
 
       - name: Run Trivy vulnerability scanner (extension)
         uses: aquasecurity/trivy-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS client-builder
+FROM --platform=$BUILDPLATFORM node:24-alpine AS client-builder
 ARG VITE_DEFAULT_RUNTIME_IMAGE=openclaw-docker-extension-runtime:dev
 WORKDIR /ui
 COPY ui/package.json /ui/package.json
@@ -9,14 +9,19 @@ ENV VITE_DEFAULT_RUNTIME_IMAGE=${VITE_DEFAULT_RUNTIME_IMAGE}
 RUN npm run build
 
 FROM alpine:3.20
-LABEL org.opencontainers.image.title="OpenClaw for Docker Desktop" \
+LABEL org.opencontainers.image.title="OpenClaw" \
     org.opencontainers.image.description="Run OpenClaw from Docker Desktop with a macOS-safe port bridge and one-click controls." \
     org.opencontainers.image.vendor="jcowhigjr/openclaw-docker-desktop-extension" \
     org.opencontainers.image.source="https://github.com/jcowhigjr/openclaw-docker-desktop-extension" \
     org.opencontainers.image.licenses="MIT" \
     com.docker.desktop.extension.api.version="0.4.2" \
-    com.docker.desktop.extension.icon="https://raw.githubusercontent.com/openclaw/openclaw/main/docs/static/icon.png" \
-    com.docker.extension.categories="ai,developer-tools"
+    com.docker.desktop.extension.icon="https://raw.githubusercontent.com/jcowhigjr/openclaw-docker-desktop-extension/main/openclaw.svg" \
+    com.docker.extension.categories="ai,developer-tools" \
+    com.docker.extension.publisher-url="https://github.com/jcowhigjr/openclaw-docker-desktop-extension" \
+    com.docker.extension.detailed-description="OpenClaw for Docker Desktop runs OpenClaw locally in a Docker Desktop extension with localhost-only access, a macOS-safe bridge, token bootstrap, host Ollama setup, execution-mode controls, and clear cleanup boundaries." \
+    com.docker.extension.changelog="Improves Docker Desktop submission metadata and release image compatibility for validator checks." \
+    com.docker.extension.screenshots="[{\"alt\":\"OpenClaw extension dashboard\",\"url\":\"https://raw.githubusercontent.com/jcowhigjr/openclaw-docker-desktop-extension/main/docs/assets/openclaw-extension-dashboard.png\"}]" \
+    com.docker.extension.additional-urls="[{\"title\":\"Documentation\",\"url\":\"https://github.com/jcowhigjr/openclaw-docker-desktop-extension#readme\"},{\"title\":\"Submission readiness\",\"url\":\"https://github.com/jcowhigjr/openclaw-docker-desktop-extension/blob/main/docs/submission-readiness.md\"},{\"title\":\"Issues\",\"url\":\"https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues\"}]"
 
 COPY docker-compose.yaml .
 COPY metadata.json .

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ RUNTIME_IMAGE ?= openclaw-docker-extension-runtime
 RUNTIME_TAG ?= dev
 GHCR_OWNER ?= jcowhigjr
 RELEASE_TAG ?=
+RELEASE_VERSION ?= $(patsubst v%,%,$(RELEASE_TAG))
 RELEASE_CHANNEL ?= stable
 REPO_OWNER ?= jcowhigjr
 REPO_NAME ?= openclaw-docker-desktop-extension
@@ -15,7 +16,7 @@ ifeq ($(RELEASE_TAG),)
 else
   DEFAULT_RUNTIME_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-extension-runtime:$(RELEASE_TAG)
 endif
-RELEASE_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_TAG)
+RELEASE_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_VERSION)
 CHANNEL_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_CHANNEL)
 SCREENSHOT_URL ?= http://127.0.0.1:4173/?demo=1
 SCREENSHOT_PATH ?= docs/assets/openclaw-extension-dashboard.png
@@ -42,9 +43,9 @@ publish-runtime:
 	  -f runtime/Dockerfile \
 	  runtime
 
-install-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(RELEASE_EXTENSION_IMAGE)"; else docker extension install -f $(RELEASE_EXTENSION_IMAGE); fi
+install-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make install-release RELEASE_TAG=v0.1.0" && exit 1); IMAGE_TAG="$(RELEASE_VERSION)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(RELEASE_EXTENSION_IMAGE)"; else docker extension install -f $(RELEASE_EXTENSION_IMAGE); fi
 
-update-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1); RELEASE_TAG="$(RELEASE_TAG)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(RELEASE_EXTENSION_IMAGE)"; else docker extension update $(RELEASE_EXTENSION_IMAGE); fi
+update-release: ; @test -n "$(RELEASE_TAG)" || (echo "RELEASE_TAG is required, for example: make update-release RELEASE_TAG=v0.1.0" && exit 1); IMAGE_TAG="$(RELEASE_VERSION)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(RELEASE_EXTENSION_IMAGE)"; else docker extension update $(RELEASE_EXTENSION_IMAGE); fi
 
 install-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is required, for example: make install-channel RELEASE_CHANNEL=stable" && exit 1); IMAGE_TAG="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension install -f $(CHANNEL_EXTENSION_IMAGE)"; else docker extension install -f $(CHANNEL_EXTENSION_IMAGE); fi
 
@@ -57,11 +58,12 @@ verify-release-channel: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GH
 
 test-release-channel: ; @./scripts/test-release-channel.sh
 test-runtime-bridge: ; @sh ./scripts/test-runtime-bridge.sh
+test-extension-metadata: ; @./scripts/test-extension-metadata.sh
 test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -87,4 +89,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot

--- a/scripts/test-extension-metadata.sh
+++ b/scripts/test-extension-metadata.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+dockerfile="${1:-Dockerfile}"
+workflow="${2:-.github/workflows/publish.yml}"
+
+require_file_contains() {
+  file="$1"
+  pattern="$2"
+  description="$3"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "missing ${description}: ${pattern}" >&2
+    return 1
+  fi
+}
+
+require_file_contains "$dockerfile" 'org.opencontainers.image.title="OpenClaw"' "validator-safe OCI title"
+require_file_contains "$dockerfile" 'com.docker.desktop.extension.icon="https://raw.githubusercontent.com/jcowhigjr/openclaw-docker-desktop-extension/main/openclaw.svg"' "repo-owned icon URL"
+require_file_contains "$dockerfile" 'com.docker.extension.publisher-url="https://github.com/jcowhigjr/openclaw-docker-desktop-extension"' "publisher URL label"
+require_file_contains "$dockerfile" 'com.docker.extension.detailed-description=' "detailed description label"
+require_file_contains "$dockerfile" 'com.docker.extension.changelog=' "changelog label"
+require_file_contains "$dockerfile" 'com.docker.extension.screenshots=' "screenshots label"
+
+require_file_contains "$workflow" 'RELEASE_VERSION=${release_tag#v}' "semver alias derivation"
+require_file_contains "$workflow" 'type=raw,value=${{ env.RELEASE_VERSION }}' "semver image tag alias"
+require_file_contains "$workflow" 'platforms: linux/arm64,linux/amd64' "multi-platform release build"
+require_file_contains "$workflow" 'VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}' "semver runtime default"
+
+echo "extension metadata checks passed"

--- a/scripts/test-release-install-dry-run.sh
+++ b/scripts/test-release-install-dry-run.sh
@@ -29,14 +29,14 @@ assert_case() {
 assert_case \
   "install-release dry run prints install command" \
   "install-release" \
-  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" \
-  "dry run: docker extension install -f ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" \
+  "dry run: docker extension install -f ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 
 assert_case \
   "update-release dry run prints update command" \
   "update-release" \
-  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" \
-  "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+  "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" \
+  "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 
 assert_case \
   "install-channel dry run prints channel install command" \

--- a/scripts/test-release-tag-dry-run.sh
+++ b/scripts/test-release-tag-dry-run.sh
@@ -18,5 +18,7 @@ output="$(make verify-release-tag RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
 assert_contains "$output" "dry run: gh api /repos/jcowhigjr/openclaw-docker-desktop-extension/releases/tags/v1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3"
+assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
+assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3"
 
 echo "release tag dry-run checks passed"

--- a/scripts/verify-release-bundle.sh
+++ b/scripts/verify-release-bundle.sh
@@ -3,6 +3,7 @@
 set -eu
 
 release_tag="${1:-${RELEASE_TAG:-}}"
+release_version="${release_tag#v}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
 verify_image="${VERIFY_IMAGE:-openclaw-docker-extension-release-check}"
@@ -19,7 +20,7 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-expected_runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
+expected_runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_version}"
 image_ref="${verify_image}:${verify_tag}"
 
 if [ "$dry_run" = "1" ]; then

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -3,11 +3,12 @@
 set -eu
 
 release_tag="${1:-${RELEASE_TAG:-}}"
+release_version="${release_tag#v}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
-extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}"
+extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_version}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-install RELEASE_TAG=v0.1.0" >&2

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -3,12 +3,15 @@
 set -eu
 
 release_tag="${1:-${RELEASE_TAG:-}}"
+release_version="${release_tag#v}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
 extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}"
 runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
+extension_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_version}"
+runtime_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_version}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-tag RELEASE_TAG=v0.1.0" >&2
@@ -20,6 +23,8 @@ if [ "$dry_run" = "1" ]; then
 dry run: gh api /repos/${repo_owner}/${repo_name}/releases/tags/${release_tag}
 dry run: docker manifest inspect ${extension_image}
 dry run: docker manifest inspect ${runtime_image}
+dry run: docker manifest inspect ${extension_semver_image}
+dry run: docker manifest inspect ${runtime_semver_image}
 EOF
   exit 0
 fi
@@ -74,6 +79,8 @@ require_anonymous_manifest() {
 require_release
 require_anonymous_manifest "${extension_image}"
 require_anonymous_manifest "${runtime_image}"
+require_anonymous_manifest "${extension_semver_image}"
+require_anonymous_manifest "${runtime_semver_image}"
 
 cat <<EOF
 Release install path is ready for this tag:


### PR DESCRIPTION
## Summary
- Closes #77
- Replace inaccessible/upstream icon label with repo-owned OpenClaw SVG
- Add required Docker extension publisher, description, changelog, and screenshot labels
- Publish release images with both GitHub-style v* tags and Docker-validator semver aliases
- Build release runtime and extension images for linux/arm64 and linux/amd64
- Run the UI builder on BUILDPLATFORM so multi-arch builds do not execute esbuild under target-platform emulation
- Add a pre-push metadata regression check

## Verification
- ./scripts/test-extension-metadata.sh
- make test-pre-push
- make verify-release-bundle RELEASE_TAG=v0.3.2
- docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:0.3.2 --tag=openclaw-docker-extension:0.3.2-validator .
- docker image inspect openclaw-docker-extension:0.3.2-validator --format '{{json .Config.Labels}}'
- docker extension validate --validate-install-uninstall openclaw-docker-extension:0.3.2-validator
- docker buildx build --platform linux/arm64,linux/amd64 --build-arg VITE_DEFAULT_RUNTIME_IMAGE=ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:0.3.2 --tag openclaw-docker-extension:metadata-multiarch-check --output=type=cacheonly .

## Validator note
Local validation now passes label, metadata, semver-tag, and metadata checks. The remaining local validator failures are expected until an image is pushed as multi-platform, and local install validation collides with the already-installed OpenClaw extension ID. The multi-platform build itself now succeeds locally.