### PR TITLE
fix: verify published release title label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,11 @@ test-release-channel: ; @./scripts/test-release-channel.sh
 test-runtime-bridge: ; @sh ./scripts/test-runtime-bridge.sh
 test-extension-metadata: ; @./scripts/test-extension-metadata.sh
 test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
+test-verify-release-tag-title: ; @./scripts/test-verify-release-tag-title.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -89,4 +90,4 @@ capture-readme-screenshot:
 	npx --yes playwright screenshot --device="Desktop Chrome" --color-scheme=light --wait-for-selector="text=OpenClaw Extension" --wait-for-timeout=1000 "$(SCREENSHOT_URL)" "$(SCREENSHOT_PATH)"
 	kill $$(cat /tmp/openclaw-vite-preview.pid) && rm -f /tmp/openclaw-vite-preview.pid
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Use these commands depending on where you are in the flow:
 
 - `make install-dev`: build both local images and install the extension into Docker Desktop
 - `make update-extension`: rebuild both local images and refresh an existing local install
-- `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release and both GHCR tags exist
+- `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release exists, both GHCR tags are public, and the published extension title label stayed validator-safe
 - `make verify-release-bundle RELEASE_TAG=vX.Y.Z`: maintainer check that a release extension build points at the matching GHCR runtime image
 - `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image
 - `make publish-release RELEASE_TAG=vX.Y.Z`: maintainer fallback if a tag exists but the GitHub release needs to be repaired manually
@@ -120,6 +120,8 @@ make verify-release-bundle RELEASE_TAG=vX.Y.Z
 make publish-release RELEASE_TAG=vX.Y.Z
 make verify-release-tag RELEASE_TAG=vX.Y.Z
 ```
+
+`make verify-release-tag` now reads the published extension image config from GHCR, so it can catch release-only metadata drift such as a workflow overriding `org.opencontainers.image.title` after the Dockerfile labels were already correct in `main`.
 
 If the GitHub Actions publish job needs to be re-run for an existing tag, use the `Publish` workflow's manual dispatch and pass `release_tag=vX.Y.Z` so it rebuilds the matching GHCR artifacts instead of publishing the default branch state.
 

--- a/scripts/test-release-tag-dry-run.sh
+++ b/scripts/test-release-tag-dry-run.sh
@@ -20,5 +20,7 @@ assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/op
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3"
+assert_contains "$output" "dry run: verify extension label org.opencontainers.image.title=OpenClaw on ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+assert_contains "$output" "dry run: verify extension label org.opencontainers.image.title=OpenClaw on ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 
 echo "release tag dry-run checks passed"

--- a/scripts/test-verify-release-tag-title.sh
+++ b/scripts/test-verify-release-tag-title.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fakebin="${tmp_dir}/fakebin"
+mkdir -p "$fakebin"
+
+cat >"${fakebin}/gh" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  cat <<'STATUS'
+github.com
+  ✓ Logged in to github.com account jcowhigjr (keyring)
+  - Active account: true
+STATUS
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "/repos/jcowhigjr/openclaw-docker-desktop-extension/releases/tags/v1.2.3" ]; then
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/gh"
+
+cat >"${fakebin}/docker" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ -z "${DOCKER_CONFIG:-}" ]; then
+  echo "expected DOCKER_CONFIG for anonymous GHCR reads" >&2
+  exit 1
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" ]; then
+  exit 0
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3" ]; then
+  exit 0
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
+  exit 0
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3" ]; then
+  exit 0
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "--verbose" ] && [ "$4" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" ]; then
+  cat <<'JSON'
+[
+  {
+    "OCIManifest": {
+      "config": {
+        "digest": "sha256:testconfigv"
+      }
+    }
+  }
+]
+JSON
+  exit 0
+fi
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "--verbose" ] && [ "$4" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
+  cat <<'JSON'
+[
+  {
+    "OCIManifest": {
+      "config": {
+        "digest": "sha256:testconfigsemver"
+      }
+    }
+  }
+]
+JSON
+  exit 0
+fi
+
+echo "unexpected docker invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/docker"
+
+cat >"${fakebin}/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+case "$*" in
+  *"https://ghcr.io/token?scope=repository:jcowhigjr/openclaw-docker-desktop-extension:pull&service=ghcr.io"*)
+    printf '%s\n' '{"token":"test-token"}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/v1.2.3"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigv"}}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/1.2.3"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigsemver"}}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/sha256:testconfigv"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigv"}}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/sha256:testconfigsemver"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigsemver"}}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigv"*)
+    printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
+    ;;
+  *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigsemver"*)
+    printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
+    ;;
+  *)
+    echo "unexpected curl invocation: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${fakebin}/curl"
+
+output="$(
+  PATH="${fakebin}:$PATH" \
+  "${repo_root}/scripts/verify-release-tag.sh" v1.2.3 2>&1
+)"
+
+printf '%s\n' "$output" | grep -F "published OCI title matches expected value: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" >/dev/null
+printf '%s\n' "$output" | grep -F "published OCI title matches expected value: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" >/dev/null
+printf '%s\n' "$output" | grep -F "Release install path is ready for this tag:" >/dev/null
+
+echo "release tag title verification checks passed"

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -12,6 +12,8 @@ extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${relea
 runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
 extension_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_version}"
 runtime_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_version}"
+extension_repo="${ghcr_owner}/openclaw-docker-desktop-extension"
+expected_extension_title="${EXPECTED_EXTENSION_TITLE:-OpenClaw}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-tag RELEASE_TAG=v0.1.0" >&2
@@ -25,9 +27,14 @@ dry run: docker manifest inspect ${extension_image}
 dry run: docker manifest inspect ${runtime_image}
 dry run: docker manifest inspect ${extension_semver_image}
 dry run: docker manifest inspect ${runtime_semver_image}
+dry run: verify extension label org.opencontainers.image.title=${expected_extension_title} on ${extension_image}
+dry run: verify extension label org.opencontainers.image.title=${expected_extension_title} on ${extension_semver_image}
 EOF
   exit 0
 fi
+
+anonymous_docker_config="$(mktemp -d)"
+trap 'rm -rf "$anonymous_docker_config"' EXIT HUP INT TERM
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "GitHub CLI is required for release verification." >&2
@@ -36,6 +43,16 @@ fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker CLI is required for release verification." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required for release verification." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for release verification." >&2
   exit 1
 fi
 
@@ -66,7 +83,7 @@ require_release() {
 require_anonymous_manifest() {
   image_ref="$1"
 
-  if docker manifest inspect "$image_ref" >/dev/null 2>&1; then
+  if DOCKER_CONFIG="$anonymous_docker_config" docker manifest inspect "$image_ref" >/dev/null 2>&1; then
     echo "ghcr tag is publicly readable: ${image_ref}"
     return 0
   fi
@@ -76,11 +93,97 @@ require_anonymous_manifest() {
   return 1
 }
 
+fetch_ghcr_token() {
+  repo_path="$1"
+
+  curl -fsSL "https://ghcr.io/token?scope=repository:${repo_path}:pull&service=ghcr.io" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+}
+
+resolve_config_digest() {
+  python3 -c '
+import json
+import sys
+
+obj = json.load(sys.stdin)
+media_type = obj.get("mediaType", "")
+
+if media_type in {
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+}:
+    manifests = obj.get("manifests", [])
+    preferred = None
+    fallback = None
+    for manifest in manifests:
+        platform = manifest.get("platform", {})
+        if platform.get("os") != "linux":
+            continue
+        if fallback is None:
+            fallback = manifest.get("digest")
+        if platform.get("architecture") == "arm64":
+            preferred = manifest.get("digest")
+            break
+    digest = preferred or fallback
+    if not digest:
+        raise SystemExit("no linux image manifest found")
+    print(digest)
+    raise SystemExit(0)
+
+config = obj.get("config", {})
+digest = config.get("digest")
+if not digest:
+    raise SystemExit("manifest config digest is missing")
+print(digest)
+'
+}
+
+require_registry_label() {
+  repo_path="$1"
+  reference="$2"
+  label_key="$3"
+  expected_value="$4"
+
+  token="$(fetch_ghcr_token "$repo_path")"
+  manifest_json="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+      "https://ghcr.io/v2/${repo_path}/manifests/${reference}"
+  )"
+  manifest_digest="$(printf '%s' "$manifest_json" | resolve_config_digest)"
+  image_manifest_json="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+      "https://ghcr.io/v2/${repo_path}/manifests/${manifest_digest}"
+  )"
+  config_digest="$(
+    printf '%s' "$image_manifest_json" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["config"]["digest"])'
+  )"
+  actual_value="$(
+    curl -fsSL -H "Authorization: Bearer ${token}" "https://ghcr.io/v2/${repo_path}/blobs/${config_digest}" \
+      | python3 -c 'import json,sys; obj=json.load(sys.stdin); value=obj.get("config", {}).get("Labels", {}).get(sys.argv[1]); print("" if value is None else value)' "${label_key}"
+  )"
+
+  if [ "$actual_value" = "$expected_value" ]; then
+    echo "published OCI title matches expected value: ghcr.io/${repo_path}:${reference}"
+    return 0
+  fi
+
+  echo "published OCI title mismatch: ghcr.io/${repo_path}:${reference} ${label_key}=${actual_value:-<missing>} (expected ${expected_value})" >&2
+  echo "Next step: fix the publish workflow labels before promoting or relying on this release tag." >&2
+  return 1
+}
+
 require_release
 require_anonymous_manifest "${extension_image}"
 require_anonymous_manifest "${runtime_image}"
 require_anonymous_manifest "${extension_semver_image}"
 require_anonymous_manifest "${runtime_semver_image}"
+require_registry_label "${extension_repo}" "${release_tag}" "org.opencontainers.image.title" "${expected_extension_title}"
+require_registry_label "${extension_repo}" "${release_version}" "org.opencontainers.image.title" "${expected_extension_title}"
 
 cat <<EOF
 Release install path is ready for this tag:


### PR DESCRIPTION
Contributes to #79

## Summary
- verify the published extension OCI title label directly from GHCR in `make verify-release-tag`
- keep public-tag verification anonymous so local Docker credential helper state does not mask GHCR readability
- document the stronger maintainer verification in the README

## Verification
- `make test-pre-push`
- `./scripts/verify-release-tag.sh v0.3.2` (fails on the published tag with the expected OCI title mismatch, proving the new check catches the release-only regression)