### PR TITLE
feat: preflight host Ollama readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ The developer-only local update path remains `make update-extension`. The releas
 - Basic startup workflow:
   - Open Docker Desktop and wait for it to finish starting.
   - Open the OpenClaw extension in Docker Desktop.
-  - Click `Check Requirements` if you want to confirm Docker is responsive and the configured host port is not already used by another Docker container.
+  - Click `Check Requirements` if you want to confirm Docker is responsive, the configured host port is not already used by another Docker container, and host Ollama is reachable whenever OpenClaw is already running.
   - Click `Start`; if the service already exists, use `Restart`.
   - Click `Open Control UI` after the status says `OpenClaw is ready`.
   - For local/offline model use, start Ollama on the host Mac first, then click `Detect Ollama Models` in `Local Model Setup`.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -45,6 +45,7 @@ import {
 import { buildRuntimeRunArgs } from './runtimeContainer';
 import {
   buildDockerPsPortCheckArgs,
+  formatOllamaRequirementStatus,
   formatStartFailure,
   formatUnknownError,
   parseDockerPublishedPortConflicts,
@@ -240,26 +241,33 @@ export function App() {
         return;
       }
 
-      if (configuredOllamaModel && phase === 'running') {
-        try {
-          const container = await findContainer();
-          if (container?.state === 'running') {
+      if (phase === 'running') {
+        const container = await findContainer();
+        if (container?.state === 'running') {
+          try {
             await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
+            const ollamaStatus = formatOllamaRequirementStatus({
+              hostPort: config.port,
+              configuredOllamaModel,
+              ollamaReachable: true,
+            });
+            setRequirementsSeverity(ollamaStatus.severity);
+            appendDebug(ollamaStatus.debug);
+            setRequirementsStatus(ollamaStatus.status);
+            return;
+          } catch (err) {
+            const text = formatUnknownError(err);
+            appendDebug(`requirements Ollama check failed: ${text}`);
+            const ollamaStatus = formatOllamaRequirementStatus({
+              hostPort: config.port,
+              configuredOllamaModel,
+              ollamaReachable: false,
+            });
+            setRequirementsSeverity(ollamaStatus.severity);
+            appendDebug(ollamaStatus.debug);
+            setRequirementsStatus(ollamaStatus.status);
+            return;
           }
-          setRequirementsSeverity('success');
-          appendDebug(`requirements check passed: Docker, host port ${config.port}, and Ollama are ready`);
-          setRequirementsStatus(
-            `Docker is ready, host port ${config.port} is available, and host Ollama is reachable for ${configuredOllamaModel}.`,
-          );
-          return;
-        } catch (err) {
-          const text = formatUnknownError(err);
-          appendDebug(`requirements Ollama check failed: ${text}`);
-          setRequirementsSeverity('warning');
-          setRequirementsStatus(
-            `Docker is ready and host port ${config.port} is available, but host Ollama was not reachable. Start Ollama before using the configured local model ${configuredOllamaModel}.`,
-          );
-          return;
         }
       }
 

--- a/ui/src/requirementChecks.test.ts
+++ b/ui/src/requirementChecks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildDockerPsPortCheckArgs,
+  formatOllamaRequirementStatus,
   formatStartFailure,
   formatUnknownError,
   parseDockerPublishedPortConflicts,
@@ -101,5 +102,31 @@ describe('requirement checks', () => {
     expect(formatUnknownError({ stderr: 'docker daemon unavailable\n' })).toBe('docker daemon unavailable');
     expect(formatUnknownError({ message: 'Docker command failed' })).toBe('Docker command failed');
     expect(formatUnknownError({ code: 1 })).toBe('{"code":1}');
+  });
+
+  it('reports host Ollama readiness for local model setup even before a model is configured', () => {
+    expect(formatOllamaRequirementStatus({
+      hostPort: 18789,
+      configuredOllamaModel: '',
+      ollamaReachable: true,
+    })).toEqual({
+      severity: 'success',
+      debug: 'requirements check passed: Docker, host port 18789, and host Ollama are ready',
+      status:
+        'Docker is ready, host port 18789 is available, and host Ollama is reachable for Local Model Setup.',
+    });
+  });
+
+  it('warns when host Ollama is not reachable before local model setup', () => {
+    expect(formatOllamaRequirementStatus({
+      hostPort: 18789,
+      configuredOllamaModel: '',
+      ollamaReachable: false,
+    })).toEqual({
+      severity: 'info',
+      debug: 'requirements check passed: Docker is ready and host port 18789 is available',
+      status:
+        'Docker is ready and host port 18789 is available. Host Ollama was not reachable yet, so start Ollama before using Local Model Setup.',
+    });
   });
 });

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -4,6 +4,14 @@ export type PortConflict = {
   ports: string;
 };
 
+export type RequirementSeverity = 'success' | 'warning' | 'info';
+
+export type OllamaRequirementStatus = {
+  severity: RequirementSeverity;
+  debug: string;
+  status: string;
+};
+
 export function buildDockerPsPortCheckArgs(): string[] {
   return ['--format={{.ID}}|{{.Names}}|{{.Ports}}'];
 }
@@ -63,6 +71,46 @@ export function formatStartFailure(message: string, hostPort: number): string {
   }
 
   return message;
+}
+
+export function formatOllamaRequirementStatus({
+  hostPort,
+  configuredOllamaModel,
+  ollamaReachable,
+}: {
+  hostPort: number;
+  configuredOllamaModel: string;
+  ollamaReachable: boolean;
+}): OllamaRequirementStatus {
+  if (configuredOllamaModel) {
+    if (ollamaReachable) {
+      return {
+        severity: 'success',
+        debug: `requirements check passed: Docker, host port ${hostPort}, and Ollama are ready`,
+        status: `Docker is ready, host port ${hostPort} is available, and host Ollama is reachable for ${configuredOllamaModel}.`,
+      };
+    }
+
+    return {
+      severity: 'warning',
+      debug: `requirements check passed: Docker is ready and host port ${hostPort} is available`,
+      status: `Docker is ready and host port ${hostPort} is available, but host Ollama was not reachable. Start Ollama before using the configured local model ${configuredOllamaModel}.`,
+    };
+  }
+
+  if (ollamaReachable) {
+    return {
+      severity: 'success',
+      debug: `requirements check passed: Docker, host port ${hostPort}, and host Ollama are ready`,
+      status: `Docker is ready, host port ${hostPort} is available, and host Ollama is reachable for Local Model Setup.`,
+    };
+  }
+
+  return {
+    severity: 'info',
+    debug: `requirements check passed: Docker is ready and host port ${hostPort} is available`,
+    status: `Docker is ready and host port ${hostPort} is available. Host Ollama was not reachable yet, so start Ollama before using Local Model Setup.`,
+  };
 }
 
 export function formatUnknownError(error: unknown): string {


### PR DESCRIPTION
## Summary
- extend `Check Requirements` to probe host Ollama whenever OpenClaw is already running, not only after a local model is configured
- keep the configured-model warning path, but add early success/info feedback for Local Model Setup preflight
- document the stronger requirements check behavior in the README

## Verification
- `cd ui && npm test -- src/requirementChecks.test.ts`
- `make test-pre-push`

Contributes to #65