### PR TITLE
ci: enforce marketplace metadata guards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,17 @@ jobs:
       - name: Verify runtime bridge wiring
         run: make test-runtime-bridge
 
+      - name: Verify extension marketplace metadata
+        run: make test-extension-metadata
+
       - name: Verify release channel mapping
         run: make test-release-channel
 
       - name: Verify release tag dry-run
         run: make test-release-tag-dry-run
+
+      - name: Verify release title dry-run
+        run: make test-verify-release-tag-title
 
       - name: Verify release install dry-run wrappers
         run: make test-release-install-dry-run

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,6 +14,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: github-pages
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- run `make test-extension-metadata` in the Build workflow so marketplace labels are checked in CI
- run `make test-verify-release-tag-title` in the Build workflow so published-title guard coverage is represented remotely, not only in local pre-push

## Verification
- `make test-extension-metadata`
- `make test-verify-release-tag-title`
- `make test-pre-push`

Contributes to #65