### PR TITLE
[codex] Add Docker Hub publishing for Marketplace submission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ env:
   REGISTRY: ghcr.io
   EXTENSION_IMAGE_NAME: jcowhigjr/openclaw-docker-desktop-extension
   RUNTIME_IMAGE_NAME: jcowhigjr/openclaw-docker-desktop-extension-runtime
+  DOCKERHUB_EXTENSION_IMAGE_NAME: jcowhigjr/openclaw-docker-desktop-extension
 
 jobs:
   publish:
@@ -74,6 +75,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker metadata for runtime
         id: runtime-meta
         uses: docker/metadata-action@v5
@@ -111,7 +118,9 @@ jobs:
         id: extension-meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.EXTENSION_IMAGE_NAME }}
+            ${{ env.DOCKERHUB_EXTENSION_IMAGE_NAME }}
           labels: |
             org.opencontainers.image.title=OpenClaw
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TAG ?= dev
 RUNTIME_IMAGE ?= openclaw-docker-extension-runtime
 RUNTIME_TAG ?= dev
 GHCR_OWNER ?= jcowhigjr
+DOCKERHUB_OWNER ?= jcowhigjr
 RELEASE_TAG ?=
 RELEASE_VERSION ?= $(patsubst v%,%,$(RELEASE_TAG))
 RELEASE_CHANNEL ?= stable
@@ -52,7 +53,7 @@ install-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is re
 update-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is required, for example: make update-channel RELEASE_CHANNEL=stable" && exit 1); IMAGE_TAG="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" IMAGE_NAME="openclaw-docker-desktop-extension" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-image.sh; if [ "$(DRY_RUN)" = "1" ]; then echo "dry run: docker extension update $(CHANNEL_EXTENSION_IMAGE)"; else docker extension update $(CHANNEL_EXTENSION_IMAGE); fi
 
 verify-release-tag:
-	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-tag.sh
+	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DOCKERHUB_OWNER="$(DOCKERHUB_OWNER)" ./scripts/verify-release-tag.sh
 
 verify-release-channel: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-channel.sh
 
@@ -70,7 +71,7 @@ install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-
 verify-release-bundle:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-bundle.sh
 
-verify-release-install: ; @RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-install.sh
+verify-release-install: ; @RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DOCKERHUB_OWNER="$(DOCKERHUB_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-install.sh
 
 verify-channel-install: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-channel-install.sh
 
@@ -78,7 +79,7 @@ publish-release:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" DRY_RUN="$(DRY_RUN)" ./scripts/publish-release.sh
 
 ship-release:
-	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/ship-release.sh
+	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DOCKERHUB_OWNER="$(DOCKERHUB_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/ship-release.sh
 
 uninstall:
 	docker extension rm $(IMAGE)

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Use these commands depending on where you are in the flow:
 
 - `make install-dev`: build both local images and install the extension into Docker Desktop
 - `make update-extension`: rebuild both local images and refresh an existing local install
-- `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release exists, both GHCR tags are public, and the published extension title label stayed validator-safe
+- `make verify-release-tag RELEASE_TAG=vX.Y.Z`: maintainer check that the GitHub release exists, the GHCR tags and Docker Hub extension semver tag are public, and the published extension title label stayed validator-safe
 - `make verify-release-bundle RELEASE_TAG=vX.Y.Z`: maintainer check that a release extension build points at the matching GHCR runtime image
-- `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image
+- `make verify-release-install RELEASE_TAG=vX.Y.Z`: maintainer check that Docker Desktop can install and uninstall the GHCR extension image and Docker Hub Marketplace semver image
 - `make publish-release RELEASE_TAG=vX.Y.Z`: maintainer fallback if a tag exists but the GitHub release needs to be repaired manually
-- `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer repair path that publishes the GitHub release if needed, verifies the GHCR tags, then validates Docker Desktop install/uninstall
+- `make ship-release RELEASE_TAG=vX.Y.Z`: maintainer repair path that publishes the GitHub release if needed, verifies release tags, then validates Docker Desktop install/uninstall
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image after an anonymous GHCR preflight
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image after the same preflight
 - `make verify-release-channel RELEASE_CHANNEL=stable`: maintainer check that the floating channel tags are publicly readable
@@ -59,7 +59,14 @@ Tagged releases now publish both images to GHCR through GitHub Actions and creat
 
 - extension image: `ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:<tag>`
 - runtime image: `ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:<tag>`
-- published architecture today: `linux/arm64` (Apple Silicon path first)
+- published architectures: `linux/arm64` and `linux/amd64`
+
+The release workflow also publishes the extension image to Docker Hub for Docker Marketplace validation:
+
+- Marketplace image: `docker.io/jcowhigjr/openclaw-docker-desktop-extension:<semver>`
+- required GitHub Actions secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`
+
+Docker's automated Marketplace submission validates the greatest semver tag on Docker Hub, so the non-`v` semver tag, for example `0.3.4`, must be public before submission.
 
 Release builds of the extension UI default the runtime image field to the matching GHCR runtime tag. Local development still defaults to `openclaw-docker-extension-runtime:dev`.
 
@@ -95,13 +102,15 @@ make verify-release-bundle RELEASE_TAG=vX.Y.Z
 
 That build-time check proves the extension bundle is wired to the matching GHCR runtime tag instead of falling back to the local dev runtime image.
 
-That check verifies all three requirements for the documented install path:
+That check verifies the requirements for the documented install path and Marketplace submission:
 
 - the GitHub release exists for the tag
 - both GHCR image tags exist
 - both GHCR packages are public to anonymous users
+- the Docker Hub extension semver tag exists for Marketplace validation
+- the published extension title label remains validator-safe on GHCR and Docker Hub
 
-If you want the full maintainer handoff in one command after the tag is published to GHCR:
+If you want the full maintainer handoff in one command after the tag is published:
 
 ```bash
 make ship-release RELEASE_TAG=vX.Y.Z

--- a/scripts/ship-release.sh
+++ b/scripts/ship-release.sh
@@ -6,6 +6,7 @@ release_tag="${1:-${RELEASE_TAG:-}}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+dockerhub_owner="${DOCKERHUB_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
 
 if [ -z "$release_tag" ]; then
@@ -26,11 +27,11 @@ run_step "Publish GitHub release if needed" \
   ./scripts/publish-release.sh
 
 run_step "Verify GitHub release and GHCR tags" \
-  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DRY_RUN="$dry_run" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DOCKERHUB_OWNER="$dockerhub_owner" DRY_RUN="$dry_run" \
   ./scripts/verify-release-tag.sh
 
 run_step "Validate Docker Desktop install/uninstall" \
-  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DRY_RUN="$dry_run" \
+  env RELEASE_TAG="$release_tag" REPO_OWNER="$repo_owner" REPO_NAME="$repo_name" GHCR_OWNER="$ghcr_owner" DOCKERHUB_OWNER="$dockerhub_owner" DRY_RUN="$dry_run" \
   ./scripts/verify-release-install.sh
 
 cat <<EOF
@@ -38,4 +39,7 @@ Release shipping flow completed for ${release_tag}
 
 End-user install command:
   docker extension install ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}
+
+Marketplace submission image:
+  docker.io/${dockerhub_owner}/openclaw-docker-desktop-extension:${release_tag#v}
 EOF

--- a/scripts/test-extension-metadata.sh
+++ b/scripts/test-extension-metadata.sh
@@ -27,6 +27,9 @@ require_file_contains "$dockerfile" 'com.docker.extension.categories="utility-to
 
 require_file_contains "$workflow" 'RELEASE_VERSION=${release_tag#v}' "semver alias derivation"
 require_file_contains "$workflow" 'org.opencontainers.image.title=OpenClaw' "published validator-safe OCI title override"
+require_file_contains "$workflow" 'DOCKERHUB_EXTENSION_IMAGE_NAME: jcowhigjr/openclaw-docker-desktop-extension' "Docker Hub extension image target"
+require_file_contains "$workflow" 'username: ${{ secrets.DOCKERHUB_USERNAME }}' "Docker Hub login username secret"
+require_file_contains "$workflow" 'password: ${{ secrets.DOCKERHUB_TOKEN }}' "Docker Hub login token secret"
 require_file_contains "$workflow" 'type=raw,value=${{ env.RELEASE_VERSION }}' "semver image tag alias"
 require_file_contains "$workflow" 'platforms: linux/arm64,linux/amd64' "multi-platform release build"
 require_file_contains "$workflow" 'VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}' "semver runtime default"

--- a/scripts/test-release-install-dry-run.sh
+++ b/scripts/test-release-install-dry-run.sh
@@ -50,4 +50,8 @@ assert_case \
   "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable" \
   "dry run: docker extension update ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable"
 
+output="$(make verify-release-install RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
+assert_contains "$output" "dry run: docker extension validate --validate-install-uninstall ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
+assert_contains "$output" "dry run: docker extension validate --validate-install-uninstall docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
+
 echo "release install dry-run checks passed"

--- a/scripts/test-release-tag-dry-run.sh
+++ b/scripts/test-release-tag-dry-run.sh
@@ -20,7 +20,9 @@ assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/op
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 assert_contains "$output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3"
+assert_contains "$output" "dry run: docker manifest inspect docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 assert_contains "$output" "dry run: verify extension label org.opencontainers.image.title=OpenClaw on ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
 assert_contains "$output" "dry run: verify extension label org.opencontainers.image.title=OpenClaw on ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
+assert_contains "$output" "dry run: verify extension label org.opencontainers.image.title=OpenClaw on docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3"
 
 echo "release tag dry-run checks passed"

--- a/scripts/test-verify-release-tag-title.sh
+++ b/scripts/test-verify-release-tag-title.sh
@@ -56,6 +56,10 @@ if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/
   exit 0
 fi
 
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
+  exit 0
+fi
+
 if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "--verbose" ] && [ "$4" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" ]; then
   cat <<'JSON'
 [
@@ -117,6 +121,18 @@ case "$*" in
   *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigsemver"*)
     printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
     ;;
+  *"https://auth.docker.io/token?service=registry.docker.io&scope=repository:jcowhigjr/openclaw-docker-desktop-extension:pull"*)
+    printf '%s\n' '{"token":"test-token"}'
+    ;;
+  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/1.2.3"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigdockerhub"}}'
+    ;;
+  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/sha256:testconfigdockerhub"*)
+    printf '%s\n' '{"config":{"digest":"sha256:testconfigdockerhub"}}'
+    ;;
+  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigdockerhub"*)
+    printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
+    ;;
   *)
     echo "unexpected curl invocation: $*" >&2
     exit 1
@@ -132,6 +148,7 @@ output="$(
 
 printf '%s\n' "$output" | grep -F "published OCI title matches expected value: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" >/dev/null
 printf '%s\n' "$output" | grep -F "published OCI title matches expected value: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" >/dev/null
+printf '%s\n' "$output" | grep -F "published OCI title matches expected value: docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" >/dev/null
 printf '%s\n' "$output" | grep -F "Release install path is ready for this tag:" >/dev/null
 
 echo "release tag title verification checks passed"

--- a/scripts/verify-release-install.sh
+++ b/scripts/verify-release-install.sh
@@ -7,8 +7,10 @@ release_version="${release_tag#v}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+dockerhub_owner="${DOCKERHUB_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
 extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_version}"
+dockerhub_extension_image="docker.io/${dockerhub_owner}/openclaw-docker-desktop-extension:${release_version}"
 
 if [ -z "$release_tag" ]; then
   echo "RELEASE_TAG is required, for example: make verify-release-install RELEASE_TAG=v0.1.0" >&2
@@ -21,8 +23,9 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 if [ "$dry_run" = "1" ]; then
-  echo "dry run: RELEASE_TAG=${release_tag} REPO_OWNER=${repo_owner} REPO_NAME=${repo_name} GHCR_OWNER=${ghcr_owner} ./scripts/verify-release-tag.sh"
+  echo "dry run: RELEASE_TAG=${release_tag} REPO_OWNER=${repo_owner} REPO_NAME=${repo_name} GHCR_OWNER=${ghcr_owner} DOCKERHUB_OWNER=${dockerhub_owner} ./scripts/verify-release-tag.sh"
   echo "dry run: docker extension validate --validate-install-uninstall ${extension_image}"
+  echo "dry run: docker extension validate --validate-install-uninstall ${dockerhub_extension_image}"
   exit 0
 fi
 
@@ -36,13 +39,18 @@ RELEASE_TAG="$release_tag" \
   REPO_OWNER="$repo_owner" \
   REPO_NAME="$repo_name" \
   GHCR_OWNER="$ghcr_owner" \
+  DOCKERHUB_OWNER="$dockerhub_owner" \
   ./scripts/verify-release-tag.sh
 
 docker extension validate --validate-install-uninstall "$extension_image"
+docker extension validate --validate-install-uninstall "$dockerhub_extension_image"
 
 cat <<EOF
 Release install validation passed for this image:
   ${extension_image}
+
+Marketplace submission validation passed for this Docker Hub image:
+  ${dockerhub_extension_image}
 
 End-user install command:
   docker extension install ${extension_image}

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -7,12 +7,15 @@ release_version="${release_tag#v}"
 repo_owner="${REPO_OWNER:-jcowhigjr}"
 repo_name="${REPO_NAME:-openclaw-docker-desktop-extension}"
 ghcr_owner="${GHCR_OWNER:-$repo_owner}"
+dockerhub_owner="${DOCKERHUB_OWNER:-$repo_owner}"
 dry_run="${DRY_RUN:-0}"
 extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_tag}"
 runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_tag}"
 extension_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_version}"
 runtime_semver_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_version}"
+dockerhub_extension_semver_image="docker.io/${dockerhub_owner}/openclaw-docker-desktop-extension:${release_version}"
 extension_repo="${ghcr_owner}/openclaw-docker-desktop-extension"
+dockerhub_extension_repo="${dockerhub_owner}/openclaw-docker-desktop-extension"
 expected_extension_title="${EXPECTED_EXTENSION_TITLE:-OpenClaw}"
 
 if [ -z "$release_tag" ]; then
@@ -27,8 +30,10 @@ dry run: docker manifest inspect ${extension_image}
 dry run: docker manifest inspect ${runtime_image}
 dry run: docker manifest inspect ${extension_semver_image}
 dry run: docker manifest inspect ${runtime_semver_image}
+dry run: docker manifest inspect ${dockerhub_extension_semver_image}
 dry run: verify extension label org.opencontainers.image.title=${expected_extension_title} on ${extension_image}
 dry run: verify extension label org.opencontainers.image.title=${expected_extension_title} on ${extension_semver_image}
+dry run: verify extension label org.opencontainers.image.title=${expected_extension_title} on ${dockerhub_extension_semver_image}
 EOF
   exit 0
 fi
@@ -97,6 +102,13 @@ fetch_ghcr_token() {
   repo_path="$1"
 
   curl -fsSL "https://ghcr.io/token?scope=repository:${repo_path}:pull&service=ghcr.io" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+}
+
+fetch_dockerhub_token() {
+  repo_path="$1"
+
+  curl -fsSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo_path}:pull" \
     | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
 }
 
@@ -177,13 +189,54 @@ require_registry_label() {
   return 1
 }
 
+require_dockerhub_registry_label() {
+  repo_path="$1"
+  reference="$2"
+  label_key="$3"
+  expected_value="$4"
+
+  token="$(fetch_dockerhub_token "$repo_path")"
+  manifest_json="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+      "https://registry-1.docker.io/v2/${repo_path}/manifests/${reference}"
+  )"
+  manifest_digest="$(printf '%s' "$manifest_json" | resolve_config_digest)"
+  image_manifest_json="$(
+    curl -fsSL \
+      -H "Authorization: Bearer ${token}" \
+      -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+      "https://registry-1.docker.io/v2/${repo_path}/manifests/${manifest_digest}"
+  )"
+  config_digest="$(
+    printf '%s' "$image_manifest_json" \
+      | python3 -c 'import json,sys; print(json.load(sys.stdin)["config"]["digest"])'
+  )"
+  actual_value="$(
+    curl -fsSL -H "Authorization: Bearer ${token}" "https://registry-1.docker.io/v2/${repo_path}/blobs/${config_digest}" \
+      | python3 -c 'import json,sys; obj=json.load(sys.stdin); value=obj.get("config", {}).get("Labels", {}).get(sys.argv[1]); print("" if value is None else value)' "${label_key}"
+  )"
+
+  if [ "$actual_value" = "$expected_value" ]; then
+    echo "published OCI title matches expected value: docker.io/${repo_path}:${reference}"
+    return 0
+  fi
+
+  echo "published OCI title mismatch: docker.io/${repo_path}:${reference} ${label_key}=${actual_value:-<missing>} (expected ${expected_value})" >&2
+  echo "Next step: fix the publish workflow labels before submitting to Docker Marketplace." >&2
+  return 1
+}
+
 require_release
 require_anonymous_manifest "${extension_image}"
 require_anonymous_manifest "${runtime_image}"
 require_anonymous_manifest "${extension_semver_image}"
 require_anonymous_manifest "${runtime_semver_image}"
+require_anonymous_manifest "${dockerhub_extension_semver_image}"
 require_registry_label "${extension_repo}" "${release_tag}" "org.opencontainers.image.title" "${expected_extension_title}"
 require_registry_label "${extension_repo}" "${release_version}" "org.opencontainers.image.title" "${expected_extension_title}"
+require_dockerhub_registry_label "${dockerhub_extension_repo}" "${release_version}" "org.opencontainers.image.title" "${expected_extension_title}"
 
 cat <<EOF
 Release install path is ready for this tag:


### PR DESCRIPTION
## Summary

Adds Docker Hub publication and verification for the extension image so Docker Marketplace automated validation can use the semver image tag.

## Why

Docker Marketplace submission asks for a Docker Hub repository name and validates the greatest semver tag available there. The existing release flow only published GHCR images, which left #86 blocked for Marketplace submission.

## Changes

- Publish the extension image to both GHCR and Docker Hub in the `Publish` workflow.
- Require `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` for release publishing.
- Extend release verification to check the Docker Hub semver image and validator-safe title label.
- Extend install validation to run Docker Desktop validation against both GHCR and Docker Hub semver images.
- Document the Docker Hub Marketplace image and required secrets.

## Verification

- `make test-pre-push`
- `make ship-release RELEASE_TAG=v1.2.3 DRY_RUN=1`

Contributes to #87.
Contributes to #86.
Contributes to #65.
