### PR TITLE
[codex] Fix update hover and SDK exec scripts

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -35,6 +35,7 @@ import {
 } from './ollamaSetup';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
+import { buildSdkSafeNodeEvalArgs } from './dockerExec';
 import { readGatewayTokenWithRetry } from './tokenRetry';
 import {
   buildExecModeReadScript,
@@ -50,6 +51,7 @@ import {
   formatUnknownError,
   parseDockerPublishedPortConflicts,
 } from './requirementChecks';
+import { updateActionButtonSx } from './updateActionButton';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
@@ -289,9 +291,9 @@ export function App() {
   const fetchGatewayToken = useCallback(async (containerId: string) => {
     const result = (await ddClient.docker.cli.exec('exec', [
       containerId,
-      'node',
-      '-e',
-      'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
+      ...buildSdkSafeNodeEvalArgs(
+        'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
+      ),
     ])) as CliExecResult;
     return asText(result.stdout).trim();
   }, [asText, ddClient]);
@@ -592,9 +594,7 @@ export function App() {
 
       const result = (await ddClient.docker.cli.exec('exec', [
         container.id,
-        'node',
-        '-e',
-        buildExecModeReadScript(),
+        ...buildSdkSafeNodeEvalArgs(buildExecModeReadScript()),
       ])) as CliExecResult;
       const stderr = asText(result.stderr).trim();
       if (stderr) {
@@ -635,9 +635,7 @@ export function App() {
       appendDebug(`applying OpenClaw execution mode: ${executionMode}`);
       await ddClient.docker.cli.exec('exec', [
         container.id,
-        'node',
-        '-e',
-        buildExecModeWriteScript(executionMode),
+        ...buildSdkSafeNodeEvalArgs(buildExecModeWriteScript(executionMode)),
       ]);
       setExecutionModeStatus(
         `Applied ${executionMode === 'full' ? 'Full access' : 'Safer'} mode. Restarting OpenClaw...`,
@@ -679,8 +677,14 @@ export function App() {
       }
 
       appendDebug(`configuring OpenClaw Ollama provider for ${model}`);
-      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', buildOllamaConfigWriteScript(model)]);
-      await ddClient.docker.cli.exec('exec', [container.id, 'node', '-e', buildOllamaAuthProfilesWriteScript()]);
+      await ddClient.docker.cli.exec('exec', [
+        container.id,
+        ...buildSdkSafeNodeEvalArgs(buildOllamaConfigWriteScript(model)),
+      ]);
+      await ddClient.docker.cli.exec('exec', [
+        container.id,
+        ...buildSdkSafeNodeEvalArgs(buildOllamaAuthProfilesWriteScript()),
+      ]);
       await ddClient.docker.cli.exec('exec', [
         container.id,
         'node',
@@ -851,6 +855,7 @@ export function App() {
               <Button
                 color="inherit"
                 size="small"
+                sx={updateActionButtonSx}
                 startIcon={<SystemUpdateAltIcon />}
                 onClick={() => void updateAndRestart()}
                 disabled={busy || updateChecking}

--- a/ui/src/dockerExec.test.ts
+++ b/ui/src/dockerExec.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSdkSafeNodeEvalArgs } from './dockerExec';
+
+describe('Docker Desktop exec helpers', () => {
+  it('wraps Node scripts without shell operators in the SDK command argument', () => {
+    const args = buildSdkSafeNodeEvalArgs('const fs=require("fs"); process.stdout.write("ok");');
+
+    expect(args.slice(0, 3)).toEqual([
+      'node',
+      '-e',
+      'eval(Buffer.from(process.argv[1],"base64").toString("utf8"))',
+    ]);
+    expect(args[2]).not.toContain(';');
+    expect(args[2]).not.toContain('&&');
+    expect(args[2]).not.toContain('|');
+    expect(args[3]).toMatch(/^[A-Za-z0-9+/=]+$/);
+  });
+});

--- a/ui/src/dockerExec.ts
+++ b/ui/src/dockerExec.ts
@@ -1,0 +1,17 @@
+function encodeBase64Utf8(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+export function buildSdkSafeNodeEvalArgs(script: string): string[] {
+  return [
+    'node',
+    '-e',
+    'eval(Buffer.from(process.argv[1],"base64").toString("utf8"))',
+    encodeBase64Utf8(script),
+  ];
+}

--- a/ui/src/updateActionButton.test.ts
+++ b/ui/src/updateActionButton.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateActionButtonSx } from './updateActionButton';
+
+describe('update action button style', () => {
+  it('keeps readable contrast when hovered', () => {
+    expect(updateActionButtonSx).toMatchObject({
+      bgcolor: 'info.main',
+      color: 'common.white',
+      '&:hover': {
+        bgcolor: 'info.dark',
+        color: 'common.white',
+      },
+    });
+  });
+});

--- a/ui/src/updateActionButton.ts
+++ b/ui/src/updateActionButton.ts
@@ -1,0 +1,8 @@
+export const updateActionButtonSx = {
+  bgcolor: 'info.main',
+  color: 'common.white',
+  '&:hover': {
+    bgcolor: 'info.dark',
+    color: 'common.white',
+  },
+};


### PR DESCRIPTION
## Summary

Fixes two findings from the automated exploratory testing pass:

- keeps the update-available action button readable on hover
- avoids Docker Desktop SDK shell-operator rejection for inline Node scripts used by token reads, execution-mode reads/writes, and Ollama config writes

## Root Cause

Docker Desktop SDK command execution rejects shell operators inside command arguments. The inline `node -e` scripts included semicolons, so execution-mode detection could log `shell operators are not allowed when executing commands through SDK APIs` even though the runtime continued.

The update action button inherited alert button hover styling, which could turn the button white against a white background.

## Changes

- Added `buildSdkSafeNodeEvalArgs()` to base64-wrap Node scripts behind a semicolon-free eval command.
- Reused that wrapper for gateway token reads, execution-mode read/write, and Ollama config writes.
- Added explicit update action button colors for normal and hover states.
- Added focused tests for both fixes.

## Verification

- `cd ui && npm test -- dockerExec.test.ts updateActionButton.test.ts execMode.test.ts ollamaSetup.test.ts tokenRetry.test.ts`
- `cd ui && npm test && npm run build`
- `make test-pre-push`
- `docker extension update -f openclaw-docker-extension:dev`
- smoke-tested wrapped Node command inside the running OpenClaw container

Contributes to #89.
