### PR TITLE
Fix release verification diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,17 +56,18 @@ update-channel: ; @test -n "$(RELEASE_CHANNEL)" || (echo "RELEASE_CHANNEL is req
 verify-release-tag:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DOCKERHUB_OWNER="$(DOCKERHUB_OWNER)" ./scripts/verify-release-tag.sh
 
-verify-release-channel: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" ./scripts/verify-release-channel.sh
+verify-release-channel: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" EXPECTED_RELEASE_TAG="$(EXPECTED_RELEASE_TAG)" ./scripts/verify-release-channel.sh
 
 test-release-channel: ; @./scripts/test-release-channel.sh
 test-runtime-bridge: ; @sh ./scripts/test-runtime-bridge.sh
 test-extension-metadata: ; @./scripts/test-extension-metadata.sh
 test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
+test-verify-release-tag-dockerhub-error: ; @./scripts/test-verify-release-tag-dockerhub-error.sh
 test-verify-release-tag-title: ; @./scripts/test-verify-release-tag-title.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -74,7 +75,7 @@ verify-release-bundle:
 
 verify-release-install: ; @RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" GHCR_OWNER="$(GHCR_OWNER)" DOCKERHUB_OWNER="$(DOCKERHUB_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-release-install.sh
 
-verify-channel-install: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-channel-install.sh
+verify-channel-install: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GHCR_OWNER)" EXPECTED_RELEASE_TAG="$(EXPECTED_RELEASE_TAG)" DRY_RUN="$(DRY_RUN)" ./scripts/verify-channel-install.sh
 
 publish-release:
 	@RELEASE_TAG="$(RELEASE_TAG)" REPO_OWNER="$(REPO_OWNER)" REPO_NAME="$(REPO_NAME)" DRY_RUN="$(DRY_RUN)" ./scripts/publish-release.sh
@@ -88,4 +89,4 @@ uninstall:
 capture-readme-screenshot:
 	SCREENSHOT_PORT="$(SCREENSHOT_PORT)" SCREENSHOT_URL="$(SCREENSHOT_URL)" SCREENSHOT_PATH="$(SCREENSHOT_PATH)" ./scripts/capture-readme-screenshot.sh
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Use these commands depending on where you are in the flow:
 - `make install-release RELEASE_TAG=vX.Y.Z`: install a tagged GHCR-published extension image after an anonymous GHCR preflight
 - `make update-release RELEASE_TAG=vX.Y.Z`: update an installed GHCR-published extension image after the same preflight
 - `make verify-release-channel RELEASE_CHANNEL=stable`: maintainer check that the floating channel tags are publicly readable
+- `make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the floating channel still points at the intended release tag
 - `make verify-channel-install RELEASE_CHANNEL=stable`: maintainer check that Docker Desktop can install and uninstall the floating channel image
+- `make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the installable floating channel also matches the intended release tag
 - `make install-channel RELEASE_CHANNEL=stable`: install the current published GHCR channel image with the same preflight
 - `make update-channel RELEASE_CHANNEL=stable`: update an installed GHCR channel image with the same preflight
 - add `DRY_RUN=1` to `install-release`, `update-release`, or `ship-release` to rehearse the documented release path without mutating Docker Desktop
@@ -172,6 +174,7 @@ If you are maintaining the floating channel path, verify the anonymous channel t
 ```bash
 make verify-release-channel RELEASE_CHANNEL=stable
 make verify-release-channel RELEASE_CHANNEL=stable DRY_RUN=1
+make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z
 ```
 
 To rehearse the same install wrapper without changing Docker Desktop state:

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -45,6 +45,7 @@ Maintainer release-channel validation:
 
 ```bash
 make verify-channel-install RELEASE_CHANNEL=stable
+make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4
 ```
 
 Use `DRY_RUN=1` when you want to validate command construction without mutating Docker Desktop.

--- a/scripts/test-release-channel-dry-run.sh
+++ b/scripts/test-release-channel-dry-run.sh
@@ -19,9 +19,19 @@ assert_contains "$channel_output" "dry run: docker manifest inspect ghcr.io/jcow
 assert_contains "$channel_output" "dry run: docker manifest inspect ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:stable"
 echo "passed: verify-release-channel dry run prints both manifest checks"
 
+comparison_output="$(make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
+assert_contains "$comparison_output" "dry run: compare ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable to ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3"
+assert_contains "$comparison_output" "dry run: compare ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:stable to ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3"
+echo "passed: verify-release-channel dry run prints release parity checks"
+
 install_output="$(make verify-channel-install RELEASE_CHANNEL=stable DRY_RUN=1 2>&1)"
 assert_contains "$install_output" "dry run: RELEASE_CHANNEL=stable GHCR_OWNER=jcowhigjr ./scripts/verify-release-channel.sh"
 assert_contains "$install_output" "dry run: docker extension validate --validate-install-uninstall ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable"
 echo "passed: verify-channel-install dry run prints validate command"
+
+install_comparison_output="$(make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v1.2.3 DRY_RUN=1 2>&1)"
+assert_contains "$install_comparison_output" "dry run: RELEASE_CHANNEL=stable GHCR_OWNER=jcowhigjr EXPECTED_RELEASE_TAG=v1.2.3 ./scripts/verify-release-channel.sh"
+assert_contains "$install_comparison_output" "dry run: docker extension validate --validate-install-uninstall ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable"
+echo "passed: verify-channel-install dry run forwards EXPECTED_RELEASE_TAG"
 
 echo "release channel dry-run checks passed"

--- a/scripts/test-verify-release-tag-dockerhub-error.sh
+++ b/scripts/test-verify-release-tag-dockerhub-error.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fakebin="${tmp_dir}/fakebin"
+mkdir -p "$fakebin"
+
+cat >"${fakebin}/gh" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  cat <<'STATUS'
+github.com
+  ✓ Logged in to github.com account jcowhigjr (keyring)
+  - Active account: true
+STATUS
+  exit 0
+fi
+
+if [ "$1" = "api" ] && [ "$2" = "/repos/jcowhigjr/openclaw-docker-desktop-extension/releases/tags/v1.2.3" ]; then
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/gh"
+
+cat >"${fakebin}/docker" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ -z "${DOCKER_CONFIG:-}" ]; then
+  echo "expected DOCKER_CONFIG for anonymous reads" >&2
+  exit 1
+fi
+
+case "$3" in
+  ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3|\
+  ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3|\
+  ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3|\
+  ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3)
+    exit 0
+    ;;
+  docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3)
+    exit 1
+    ;;
+esac
+
+echo "unexpected docker invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/docker"
+
+cat >"${fakebin}/curl" <<'EOF'
+#!/bin/sh
+set -eu
+echo "unexpected curl invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fakebin}/curl"
+
+set +e
+output="$(
+  PATH="${fakebin}:$PATH" \
+  "${repo_root}/scripts/verify-release-tag.sh" v1.2.3 2>&1
+)"
+status=$?
+set -e
+
+[ "$status" -ne 0 ]
+printf '%s\n' "$output" | grep -F "docker.io tag is missing or not publicly readable: docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" >/dev/null
+printf '%s\n' "$output" | grep -F "Next step: confirm the publish workflow completed and the Docker Hub repository/tag is public." >/dev/null
+
+echo "release tag docker hub failure messaging checks passed"

--- a/scripts/verify-channel-install.sh
+++ b/scripts/verify-channel-install.sh
@@ -4,6 +4,7 @@ set -eu
 
 release_channel="${1:-${RELEASE_CHANNEL:-stable}}"
 ghcr_owner="${GHCR_OWNER:-jcowhigjr}"
+expected_release_tag="${EXPECTED_RELEASE_TAG:-}"
 dry_run="${DRY_RUN:-0}"
 extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_channel}"
 
@@ -18,7 +19,11 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 if [ "$dry_run" = "1" ]; then
-  echo "dry run: RELEASE_CHANNEL=${release_channel} GHCR_OWNER=${ghcr_owner} ./scripts/verify-release-channel.sh"
+  if [ -n "$expected_release_tag" ]; then
+    echo "dry run: RELEASE_CHANNEL=${release_channel} GHCR_OWNER=${ghcr_owner} EXPECTED_RELEASE_TAG=${expected_release_tag} ./scripts/verify-release-channel.sh"
+  else
+    echo "dry run: RELEASE_CHANNEL=${release_channel} GHCR_OWNER=${ghcr_owner} ./scripts/verify-release-channel.sh"
+  fi
   echo "dry run: docker extension validate --validate-install-uninstall ${extension_image}"
   exit 0
 fi
@@ -31,6 +36,7 @@ fi
 
 RELEASE_CHANNEL="$release_channel" \
   GHCR_OWNER="$ghcr_owner" \
+  EXPECTED_RELEASE_TAG="$expected_release_tag" \
   ./scripts/verify-release-channel.sh
 
 docker extension validate --validate-install-uninstall "$extension_image"

--- a/scripts/verify-release-channel.sh
+++ b/scripts/verify-release-channel.sh
@@ -4,9 +4,12 @@ set -eu
 
 release_channel="${1:-${RELEASE_CHANNEL:-stable}}"
 ghcr_owner="${GHCR_OWNER:-jcowhigjr}"
+expected_release_tag="${EXPECTED_RELEASE_TAG:-}"
 dry_run="${DRY_RUN:-0}"
 extension_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension:${release_channel}"
 runtime_image="ghcr.io/${ghcr_owner}/openclaw-docker-desktop-extension-runtime:${release_channel}"
+extension_repo="${ghcr_owner}/openclaw-docker-desktop-extension"
+runtime_repo="${ghcr_owner}/openclaw-docker-desktop-extension-runtime"
 
 if [ -z "$release_channel" ]; then
   echo "RELEASE_CHANNEL is required, for example: make verify-release-channel RELEASE_CHANNEL=stable" >&2
@@ -18,11 +21,27 @@ if [ "$dry_run" = "1" ]; then
 dry run: docker manifest inspect ${extension_image}
 dry run: docker manifest inspect ${runtime_image}
 EOF
+  if [ -n "$expected_release_tag" ]; then
+    cat <<EOF
+dry run: compare ${extension_image} to ghcr.io/${extension_repo}:${expected_release_tag}
+dry run: compare ${runtime_image} to ghcr.io/${runtime_repo}:${expected_release_tag}
+EOF
+  fi
   exit 0
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker CLI is required for release-channel verification." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required for release-channel verification." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for release-channel verification." >&2
   exit 1
 fi
 
@@ -51,6 +70,54 @@ require_anonymous_manifest() {
 
 require_anonymous_manifest "${extension_image}"
 require_anonymous_manifest "${runtime_image}"
+
+fetch_ghcr_token() {
+  repo_path="$1"
+
+  curl -fsSL "https://ghcr.io/token?scope=repository:${repo_path}:pull&service=ghcr.io" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+}
+
+fetch_registry_digest() {
+  repo_path="$1"
+  reference="$2"
+  token="$(fetch_ghcr_token "$repo_path")"
+
+  curl -fsSL -D - -o /dev/null \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+    "https://ghcr.io/v2/${repo_path}/manifests/${reference}" \
+    | awk 'BEGIN { IGNORECASE = 1 } /^Docker-Content-Digest:/ { sub(/\r$/, "", $2); print $2; exit }'
+}
+
+require_matching_tag() {
+  repo_path="$1"
+  channel_ref="$2"
+  release_ref="$3"
+
+  channel_digest="$(fetch_registry_digest "$repo_path" "$channel_ref")"
+  release_digest="$(fetch_registry_digest "$repo_path" "$release_ref")"
+
+  if [ -z "$channel_digest" ] || [ -z "$release_digest" ]; then
+    echo "Unable to resolve GHCR digests for comparison: ghcr.io/${repo_path}:${channel_ref} vs ghcr.io/${repo_path}:${release_ref}" >&2
+    echo "Next step: confirm the publish workflow completed and both tags are public." >&2
+    return 1
+  fi
+
+  if [ "$channel_digest" = "$release_digest" ]; then
+    echo "ghcr channel matches expected release: ghcr.io/${repo_path}:${channel_ref} -> ${release_ref}"
+    return 0
+  fi
+
+  echo "ghcr channel does not match expected release: ghcr.io/${repo_path}:${channel_ref}=${channel_digest} expected ${release_ref}=${release_digest}" >&2
+  echo "Next step: repair or republish the intended release so the floating channel points at the expected tag." >&2
+  return 1
+}
+
+if [ -n "$expected_release_tag" ]; then
+  require_matching_tag "${extension_repo}" "${release_channel}" "${expected_release_tag}"
+  require_matching_tag "${runtime_repo}" "${release_channel}" "${expected_release_tag}"
+fi
 
 cat <<EOF
 Release channel path is ready for this channel:

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -87,14 +87,16 @@ require_release() {
 
 require_anonymous_manifest() {
   image_ref="$1"
+  registry_name="$2"
+  next_step="$3"
 
   if DOCKER_CONFIG="$anonymous_docker_config" docker manifest inspect "$image_ref" >/dev/null 2>&1; then
-    echo "ghcr tag is publicly readable: ${image_ref}"
+    echo "${registry_name} tag is publicly readable: ${image_ref}"
     return 0
   fi
 
-  echo "ghcr tag is missing or not publicly readable: ${image_ref}" >&2
-  echo "Next step: confirm the publish workflow completed and the GHCR package is public." >&2
+  echo "${registry_name} tag is missing or not publicly readable: ${image_ref}" >&2
+  echo "Next step: ${next_step}" >&2
   return 1
 }
 
@@ -229,11 +231,11 @@ require_dockerhub_registry_label() {
 }
 
 require_release
-require_anonymous_manifest "${extension_image}"
-require_anonymous_manifest "${runtime_image}"
-require_anonymous_manifest "${extension_semver_image}"
-require_anonymous_manifest "${runtime_semver_image}"
-require_anonymous_manifest "${dockerhub_extension_semver_image}"
+require_anonymous_manifest "${extension_image}" "ghcr" "confirm the publish workflow completed and the GHCR package is public."
+require_anonymous_manifest "${runtime_image}" "ghcr" "confirm the publish workflow completed and the GHCR package is public."
+require_anonymous_manifest "${extension_semver_image}" "ghcr" "confirm the publish workflow completed and the GHCR package is public."
+require_anonymous_manifest "${runtime_semver_image}" "ghcr" "confirm the publish workflow completed and the GHCR package is public."
+require_anonymous_manifest "${dockerhub_extension_semver_image}" "docker.io" "confirm the publish workflow completed and the Docker Hub repository/tag is public."
 require_registry_label "${extension_repo}" "${release_tag}" "org.opencontainers.image.title" "${expected_extension_title}"
 require_registry_label "${extension_repo}" "${release_version}" "org.opencontainers.image.title" "${expected_extension_title}"
 require_dockerhub_registry_label "${dockerhub_extension_repo}" "${release_version}" "org.opencontainers.image.title" "${expected_extension_title}"


### PR DESCRIPTION
## Summary
- clarify release-verification failure output so Docker Hub failures name Docker Hub instead of GHCR
- add regression coverage for the Docker Hub anonymous-readability failure path
- document the optional `EXPECTED_RELEASE_TAG` parity check for `verify-release-channel` and `verify-channel-install`

## Verification
- `make verify-release-tag RELEASE_TAG=v0.3.4`
- `make verify-release-install RELEASE_TAG=v0.3.4 DRY_RUN=1`
- `make verify-release-channel RELEASE_CHANNEL=stable`
- `make test-pre-push`

Contributes to #86
