### PR TITLE
Scaffold stable-channel smoke reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,9 @@ test-verify-release-tag-dockerhub-error: ; @./scripts/test-verify-release-tag-do
 test-verify-release-tag-title: ; @./scripts/test-verify-release-tag-title.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
+test-create-smoke-report: ; @sh ./scripts/test-create-smoke-report.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -89,4 +90,7 @@ uninstall:
 capture-readme-screenshot:
 	SCREENSHOT_PORT="$(SCREENSHOT_PORT)" SCREENSHOT_URL="$(SCREENSHOT_URL)" SCREENSHOT_PATH="$(SCREENSHOT_PATH)" ./scripts/capture-readme-screenshot.sh
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot
+create-smoke-report:
+	@REPORT_DATE="$(REPORT_DATE)" RELEASE_CHANNEL="$(RELEASE_CHANNEL)" RELEASE_TAG="$(RELEASE_TAG)" REPORT_DIR="$(REPORT_DIR)" sh ./scripts/create-smoke-report.sh
+
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Use these commands depending on where you are in the flow:
 - `make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the floating channel still points at the intended release tag
 - `make verify-channel-install RELEASE_CHANNEL=stable`: maintainer check that Docker Desktop can install and uninstall the floating channel image
 - `make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the installable floating channel also matches the intended release tag
+- `make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=vX.Y.Z`: scaffold a timestamped manual smoke-test packet under `docs/exploratory/`
 - `make install-channel RELEASE_CHANNEL=stable`: install the current published GHCR channel image with the same preflight
 - `make update-channel RELEASE_CHANNEL=stable`: update an installed GHCR channel image with the same preflight
 - add `DRY_RUN=1` to `install-release`, `update-release`, or `ship-release` to rehearse the documented release path without mutating Docker Desktop

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use these commands depending on where you are in the flow:
 - `make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the floating channel still points at the intended release tag
 - `make verify-channel-install RELEASE_CHANNEL=stable`: maintainer check that Docker Desktop can install and uninstall the floating channel image
 - `make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=vX.Y.Z`: maintainer check that the installable floating channel also matches the intended release tag
-- `make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=vX.Y.Z`: scaffold a timestamped manual smoke-test packet under `docs/exploratory/`
+- `make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=vX.Y.Z`: scaffold a timestamped manual smoke-test packet under `docs/exploratory/`, including a `capture-artifacts.sh` helper
 - `make install-channel RELEASE_CHANNEL=stable`: install the current published GHCR channel image with the same preflight
 - `make update-channel RELEASE_CHANNEL=stable`: update an installed GHCR channel image with the same preflight
 - add `DRY_RUN=1` to `install-release`, `update-release`, or `ship-release` to rehearse the documented release path without mutating Docker Desktop

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -31,7 +31,8 @@ make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
 ```
 
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
-manual steps, and artifact checklist already filled in.
+manual steps, artifact checklist, and a `capture-artifacts.sh` helper for the
+CLI evidence files already filled in.
 
 1. Start Docker Desktop and wait for the Docker Engine to become ready.
 2. Confirm Docker Desktop allows local or non-Marketplace extension installs.

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -24,6 +24,15 @@ Use this path for a 5-10 minute functional review on macOS with Docker Desktop.
 The extension is not listed in the Docker Extensions Marketplace yet, so this
 review path uses the GHCR stable channel.
 
+If you want a timestamped evidence packet before starting, run:
+
+```bash
+make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
+```
+
+That scaffolds a report under `docs/exploratory/` with the preflight commands,
+manual steps, and artifact checklist already filled in.
+
 1. Start Docker Desktop and wait for the Docker Engine to become ready.
 2. Confirm Docker Desktop allows local or non-Marketplace extension installs.
 3. Install the current stable channel:

--- a/scripts/create-smoke-report.sh
+++ b/scripts/create-smoke-report.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+report_date="${REPORT_DATE:-$(date +%F)}"
+release_channel="${RELEASE_CHANNEL:-stable}"
+release_tag="${RELEASE_TAG:-}"
+report_slug="${REPORT_SLUG:-${release_channel}-channel-smoke}"
+report_dir="${REPORT_DIR:-${repo_root}/docs/exploratory/${report_date}-${report_slug}}"
+report_file="${report_dir}/report.md"
+
+if [ -e "$report_file" ]; then
+  echo "Smoke report already exists: ${report_file}" >&2
+  echo "Next step: set REPORT_DIR or REPORT_DATE to create a new packet." >&2
+  exit 1
+fi
+
+mkdir -p "$report_dir"
+
+branch_name="$(git -C "$repo_root" branch --show-current)"
+commit_short="$(git -C "$repo_root" rev-parse --short HEAD)"
+if [ -n "$release_tag" ]; then
+  release_reference="Release tag under test: \`${release_tag}\`"
+else
+  release_reference="Release tag under test: _fill in after selecting the target release_"
+fi
+
+cat >"$report_file" <<EOF
+# ${release_channel} Channel Smoke Test - ${report_date}
+
+## Environment
+
+- Repo branch: \`${branch_name}\`
+- Base commit under test: \`${commit_short}\`
+- ${release_reference}
+- Channel under test: \`${release_channel}\`
+- Extension install under test: \`ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:${release_channel}\`
+- Runtime image under test: \`ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:${release_channel}\`
+- Docker Desktop version: _fill in_
+- macOS version / chip: _fill in_
+- Host Ollama status: _fill in if used_
+
+## Preflight
+
+1. \`make verify-release-channel RELEASE_CHANNEL=${release_channel}${release_tag:+ EXPECTED_RELEASE_TAG=${release_tag}}\`
+2. \`make verify-channel-install RELEASE_CHANNEL=${release_channel}${release_tag:+ EXPECTED_RELEASE_TAG=${release_tag}}\`
+3. \`docker extension ls\`
+4. \`docker ps -a --format 'table {{.Names}}\\t{{.Image}}\\t{{.Status}}\\t{{.Ports}}'\`
+
+## Manual Flow
+
+1. Install the channel image in Docker Desktop if it is not already installed.
+2. Open the \`OpenClaw\` extension.
+3. Click \`Check Requirements\`.
+4. Click \`Start\`.
+5. Wait for \`OpenClaw is ready\`.
+6. Click \`Open Control UI\`.
+7. Confirm the Control UI opens on localhost without manual token editing.
+8. If testing the local-model path, confirm host Ollama is already running with a model pulled, then finish one chat prompt through \`Local Model Setup\`.
+
+## Artifacts
+
+- \`docker-extension-ls.txt\`
+- \`docker-ps-a.txt\`
+- \`openclaw-service.log\`
+- \`control-ui-healthz.txt\`
+- \`control-ui.png\`
+- \`extension-ui.png\` or note why Docker Desktop UI capture was blocked
+
+## Results
+
+| Flow | Result | Evidence |
+| --- | --- | --- |
+| Channel preflight | TODO | |
+| Extension registered in Docker Desktop | TODO | |
+| Runtime container running | TODO | |
+| Localhost exposure | TODO | |
+| Control UI bootstrap from extension button | TODO | |
+| Local-model flow (if used) | TODO | |
+
+## Findings
+
+1. _Add findings, regressions, or blockers here._
+
+## Recommendation
+
+_State whether this smoke pass blocks release or Marketplace submission._
+EOF
+
+printf '%s\n' "$report_file"

--- a/scripts/create-smoke-report.sh
+++ b/scripts/create-smoke-report.sh
@@ -8,6 +8,7 @@ release_tag="${RELEASE_TAG:-}"
 report_slug="${REPORT_SLUG:-${release_channel}-channel-smoke}"
 report_dir="${REPORT_DIR:-${repo_root}/docs/exploratory/${report_date}-${report_slug}}"
 report_file="${report_dir}/report.md"
+capture_script="${report_dir}/capture-artifacts.sh"
 
 if [ -e "$report_file" ]; then
   echo "Smoke report already exists: ${report_file}" >&2
@@ -86,5 +87,24 @@ cat >"$report_file" <<EOF
 
 _State whether this smoke pass blocks release or Marketplace submission._
 EOF
+
+cat >"$capture_script" <<EOF
+#!/bin/sh
+set -eu
+
+# Capture smoke-test CLI artifacts into this packet directory.
+report_dir="\$(CDPATH= cd -- "\$(dirname "\$0")" && pwd)"
+
+docker extension ls >"\${report_dir}/docker-extension-ls.txt"
+docker ps -a --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' >"\${report_dir}/docker-ps-a.txt"
+docker logs openclaw-docker-extension-service >"\${report_dir}/openclaw-service.log" 2>&1
+curl -fsS http://127.0.0.1:18789/healthz >"\${report_dir}/control-ui-healthz.txt"
+EOF
+
+chmod +x "$capture_script"
+
+for artifact in docker-extension-ls.txt docker-ps-a.txt openclaw-service.log control-ui-healthz.txt; do
+  : >"${report_dir}/${artifact}"
+done
 
 printf '%s\n' "$report_file"

--- a/scripts/test-create-smoke-report.sh
+++ b/scripts/test-create-smoke-report.sh
@@ -8,15 +8,24 @@ report_dir="${tmp_dir}/2026-05-17-stable-channel-smoke"
 output="$(REPORT_DIR="$report_dir" REPORT_DATE="2026-05-17" RELEASE_CHANNEL="stable" RELEASE_TAG="v0.3.4" sh ./scripts/create-smoke-report.sh)"
 
 report_file="${report_dir}/report.md"
+capture_script="${report_dir}/capture-artifacts.sh"
 
 [ "$output" = "$report_file" ]
 [ -f "$report_file" ]
+[ -f "$capture_script" ]
 
 grep -F '# stable Channel Smoke Test - 2026-05-17' "$report_file" >/dev/null
 grep -F 'Release tag under test: `v0.3.4`' "$report_file" >/dev/null
 grep -F 'make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4' "$report_file" >/dev/null
 grep -F 'docker extension ls' "$report_file" >/dev/null
 grep -F 'Control UI bootstrap from extension button' "$report_file" >/dev/null
+grep -F 'Capture smoke-test CLI artifacts into this packet directory.' "$capture_script" >/dev/null
+grep -F 'docker-extension-ls.txt' "$capture_script" >/dev/null
+grep -F 'curl -fsS http://127.0.0.1:18789/healthz' "$capture_script" >/dev/null
+
+for artifact in docker-extension-ls.txt docker-ps-a.txt openclaw-service.log control-ui-healthz.txt; do
+  [ -f "${report_dir}/${artifact}" ]
+done
 
 if REPORT_DIR="$report_dir" REPORT_DATE="2026-05-17" RELEASE_CHANNEL="stable" RELEASE_TAG="v0.3.4" sh ./scripts/create-smoke-report.sh >/dev/null 2>&1; then
   echo "expected create-smoke-report to refuse overwriting an existing report" >&2

--- a/scripts/test-create-smoke-report.sh
+++ b/scripts/test-create-smoke-report.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+report_dir="${tmp_dir}/2026-05-17-stable-channel-smoke"
+output="$(REPORT_DIR="$report_dir" REPORT_DATE="2026-05-17" RELEASE_CHANNEL="stable" RELEASE_TAG="v0.3.4" sh ./scripts/create-smoke-report.sh)"
+
+report_file="${report_dir}/report.md"
+
+[ "$output" = "$report_file" ]
+[ -f "$report_file" ]
+
+grep -F '# stable Channel Smoke Test - 2026-05-17' "$report_file" >/dev/null
+grep -F 'Release tag under test: `v0.3.4`' "$report_file" >/dev/null
+grep -F 'make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4' "$report_file" >/dev/null
+grep -F 'docker extension ls' "$report_file" >/dev/null
+grep -F 'Control UI bootstrap from extension button' "$report_file" >/dev/null
+
+if REPORT_DIR="$report_dir" REPORT_DATE="2026-05-17" RELEASE_CHANNEL="stable" RELEASE_TAG="v0.3.4" sh ./scripts/create-smoke-report.sh >/dev/null 2>&1; then
+  echo "expected create-smoke-report to refuse overwriting an existing report" >&2
+  exit 1
+fi
+
+echo "create-smoke-report checks passed"


### PR DESCRIPTION
## Summary
- add a `make create-smoke-report` helper that scaffolds a timestamped manual stable-channel smoke packet
- add coverage for the scaffold script and fold it into `make test-pre-push`
- document the helper in the README and submission readiness packet

## Verification
- `make test-pre-push`

Contributes to #86