### PR TITLE
Fix runtime helper command handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,10 @@ test-verify-release-tag-title: ; @./scripts/test-verify-release-tag-title.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
 test-create-smoke-report: ; @sh ./scripts/test-create-smoke-report.sh
+test-runtime-helper: ; @sh ./scripts/test-runtime-helper.sh
+test-security-local: ; @sh ./scripts/test-security-local.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-runtime-helper test-security-local
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -93,4 +95,4 @@ capture-readme-screenshot:
 create-smoke-report:
 	@REPORT_DATE="$(REPORT_DATE)" RELEASE_CHANNEL="$(RELEASE_CHANNEL)" RELEASE_TAG="$(RELEASE_TAG)" REPORT_DIR="$(REPORT_DIR)" sh ./scripts/create-smoke-report.sh
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-runtime-helper test-security-local test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ make install-hooks
 ```
 
 This installs the repo pre-push hook, which runs `make test-pre-push` before allowing a push.
+The pre-push target also runs local security preflights where possible: Gitleaks when installed and `npm audit --audit-level=critical` for the UI package.
 
 Then:
 
@@ -358,7 +359,7 @@ Safe extension-level diagnostics are limited to project-specific state: containe
 
 ## Current limitations
 
-- If the gateway token field is blank, open the Control UI and paste the token manually after retrieving it from the service container or volume.
+- If the gateway token field is blank, click `Refresh Token`, then open the Control UI again. If it stays blank, restart OpenClaw from the extension and retry.
 - If `Open Control UI` reports that localhost is not reachable, start or restart OpenClaw before retrying.
 - The runtime can spend a short warm-up period in `starting` even after the host health check is already passing.
 - Provider auth beyond the Ollama setup flow should be managed through OpenClaw's own auth/onboarding paths or `/home/node/.openclaw/.env`.
@@ -398,7 +399,7 @@ The developer-only local update path remains `make update-extension`. The releas
 - If no models appear, pull a practical model in Ollama first, then run detection again.
 - If `Start` reports that the host port is already in use, change `Host Port` in Settings or stop the other container using that port.
 - If the extension says `RUNNING` but the browser page does not open, check `http://127.0.0.1:18789/healthz`.
-- If the token field is empty, inspect the debug panel in the extension and fetch the token from the service container or volume.
+- If the token field is empty, click `Refresh Token`, then `Open Control UI` again. If it stays empty, restart OpenClaw and retry.
 - If local installation fails, confirm Docker Desktop allows local extensions.
 - If Docker Desktop frequently stops after sleep or restart, start Docker Desktop first and then reopen the extension. Existing OpenClaw state remains in the named Docker volume.
 

--- a/runtime/.dockerignore
+++ b/runtime/.dockerignore
@@ -3,3 +3,4 @@
 
 !Dockerfile
 !openclaw-bridge.sh
+!openclaw-extension-helper.js

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY openclaw-bridge.sh /usr/local/bin/openclaw-bridge.sh
-RUN chmod 755 /usr/local/bin/openclaw-bridge.sh
+COPY openclaw-extension-helper.js /usr/local/bin/openclaw-extension-helper.js
+RUN chmod 755 /usr/local/bin/openclaw-bridge.sh /usr/local/bin/openclaw-extension-helper.js
 
 USER node
 

--- a/runtime/openclaw-extension-helper.js
+++ b/runtime/openclaw-extension-helper.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const OPENCLAW_CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH || '/home/node/.openclaw/openclaw.json';
+const EXEC_APPROVALS_PATH = process.env.EXEC_APPROVALS_PATH || '/home/node/.openclaw/exec-approvals.json';
+const OPENCLAW_AUTH_PROFILES_PATH =
+  process.env.OPENCLAW_AUTH_PROFILES_PATH || '/home/node/.openclaw/agents/main/agent/auth-profiles.json';
+
+function readJson(file) {
+  if (!fs.existsSync(file)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function writeJson(file, data, backup) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  if (backup && fs.existsSync(file)) {
+    fs.copyFileSync(file, file + '.bak');
+  }
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+}
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function executionModeConfig(mode) {
+  if (mode === 'full') {
+    return {
+      approvalsDefaults: {
+        security: 'full',
+        ask: 'off',
+        askFallback: 'full',
+        autoAllowSkills: false,
+      },
+      toolsExec: {
+        host: 'gateway',
+        security: 'full',
+        ask: 'off',
+      },
+    };
+  }
+
+  return {
+    approvalsDefaults: {
+      security: 'allowlist',
+      ask: 'on-miss',
+      askFallback: 'deny',
+      autoAllowSkills: false,
+    },
+    toolsExec: {
+      host: 'gateway',
+      security: 'allowlist',
+      ask: 'on-miss',
+    },
+  };
+}
+
+function buildOllamaAuthConfigProfile() {
+  return {
+    provider: 'ollama',
+    mode: 'api_key',
+  };
+}
+
+function gatewayToken() {
+  const config = readJson(OPENCLAW_CONFIG_PATH);
+  const gateway = isObject(config.gateway) ? config.gateway : {};
+  const auth = isObject(gateway.auth) ? gateway.auth : {};
+  process.stdout.write(typeof auth.token === 'string' ? auth.token : '');
+}
+
+function execModeRead() {
+  const approvals = readJson(EXEC_APPROVALS_PATH);
+  const config = readJson(OPENCLAW_CONFIG_PATH);
+  const defaults = isObject(approvals.defaults) ? approvals.defaults : {};
+  const tools = isObject(config.tools) ? config.tools : {};
+  const exec = isObject(tools.exec) ? tools.exec : {};
+
+  process.stdout.write(JSON.stringify({
+    approvals: { defaults },
+    config: { tools: { exec } },
+  }));
+}
+
+function execModeWrite(mode) {
+  if (mode !== 'safer' && mode !== 'full') {
+    throw new Error('exec-mode-write requires safer or full');
+  }
+
+  const next = executionModeConfig(mode);
+  const approvals = readJson(EXEC_APPROVALS_PATH);
+  const config = readJson(OPENCLAW_CONFIG_PATH);
+
+  approvals.version = 1;
+  approvals.defaults = Object.assign({}, isObject(approvals.defaults) ? approvals.defaults : {}, next.approvalsDefaults);
+  config.tools = isObject(config.tools) ? config.tools : {};
+  config.tools.exec = Object.assign({}, isObject(config.tools.exec) ? config.tools.exec : {}, next.toolsExec);
+
+  writeJson(EXEC_APPROVALS_PATH, approvals, true);
+  writeJson(OPENCLAW_CONFIG_PATH, config, true);
+}
+
+function ollamaConfigWrite(model) {
+  const selectedModel = String(model || '').trim();
+  if (!selectedModel) {
+    throw new Error('ollama-config-write requires a model');
+  }
+
+  const config = readJson(OPENCLAW_CONFIG_PATH);
+  config.agents = isObject(config.agents) ? config.agents : {};
+  config.agents.defaults = isObject(config.agents.defaults) ? config.agents.defaults : {};
+  config.agents.defaults.model = isObject(config.agents.defaults.model) ? config.agents.defaults.model : {};
+  config.agents.defaults.model.primary = 'ollama/' + selectedModel;
+  config.agents.defaults.timeoutSeconds = 300;
+  config.models = isObject(config.models) ? config.models : {};
+  config.models.providers = isObject(config.models.providers) ? config.models.providers : {};
+  config.models.providers.ollama = {
+    api: 'ollama',
+    apiKey: 'ollama-local',
+    baseUrl: 'http://host.docker.internal:11434',
+    models: [
+      {
+        id: selectedModel,
+        name: selectedModel,
+        reasoning: false,
+      },
+    ],
+  };
+  config.auth = isObject(config.auth) ? config.auth : {};
+  config.auth.profiles = isObject(config.auth.profiles) ? config.auth.profiles : {};
+  config.auth.profiles['ollama:manual'] = buildOllamaAuthConfigProfile();
+  config.auth.order = isObject(config.auth.order) ? config.auth.order : {};
+  config.auth.order.ollama = ['ollama:manual'];
+
+  writeJson(OPENCLAW_CONFIG_PATH, config, true);
+}
+
+function ollamaAuthProfilesWrite() {
+  writeJson(OPENCLAW_AUTH_PROFILES_PATH, {
+    version: 1,
+    profiles: {
+      'ollama:manual': {
+        type: 'api_key',
+        provider: 'ollama',
+        key: 'ollama-local',
+      },
+    },
+  }, false);
+}
+
+const command = process.argv[2];
+const args = process.argv.slice(3);
+
+try {
+  if (command === 'gateway-token') {
+    gatewayToken();
+  } else if (command === 'exec-mode-read') {
+    execModeRead();
+  } else if (command === 'exec-mode-write') {
+    execModeWrite(args[0]);
+  } else if (command === 'ollama-config-write') {
+    ollamaConfigWrite(args[0]);
+  } else if (command === 'ollama-auth-profiles-write') {
+    ollamaAuthProfilesWrite();
+  } else {
+    throw new Error('Unknown command: ' + command);
+  }
+} catch (error) {
+  process.stderr.write((error && error.message ? error.message : String(error)) + '\n');
+  process.exit(1);
+}

--- a/scripts/test-runtime-helper.sh
+++ b/scripts/test-runtime-helper.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+config_path="${tmp_dir}/openclaw.json"
+approvals_path="${tmp_dir}/exec-approvals.json"
+auth_profiles_path="${tmp_dir}/auth-profiles.json"
+
+cat >"$config_path" <<'JSON'
+{
+  "gateway": {
+    "auth": {
+      "mode": "token",
+      "token": "test-token"
+    }
+  },
+  "tools": {
+    "exec": {
+      "security": "full",
+      "ask": "off"
+    }
+  }
+}
+JSON
+
+cat >"$approvals_path" <<'JSON'
+{
+  "version": 1,
+  "socket": {
+    "path": "/home/node/.openclaw/exec-approvals.sock",
+    "token": "preserve-socket-token"
+  },
+  "defaults": {
+    "security": "full",
+    "ask": "off",
+    "askFallback": "full"
+  }
+}
+JSON
+
+helper_env="OPENCLAW_CONFIG_PATH=${config_path} EXEC_APPROVALS_PATH=${approvals_path} OPENCLAW_AUTH_PROFILES_PATH=${auth_profiles_path}"
+
+token="$(env $helper_env node runtime/openclaw-extension-helper.js gateway-token)"
+[ "$token" = "test-token" ]
+
+mode_json="$(env $helper_env node runtime/openclaw-extension-helper.js exec-mode-read)"
+printf '%s' "$mode_json" | grep -F '"security":"full"' >/dev/null
+printf '%s' "$mode_json" | grep -F 'preserve-socket-token' >/dev/null && {
+  echo "exec-mode-read must not expose socket tokens" >&2
+  exit 1
+}
+
+env $helper_env node runtime/openclaw-extension-helper.js exec-mode-write safer
+grep -F '"security": "allowlist"' "$config_path" >/dev/null
+grep -F '"askFallback": "deny"' "$approvals_path" >/dev/null
+grep -F 'preserve-socket-token' "$approvals_path" >/dev/null
+
+env $helper_env node runtime/openclaw-extension-helper.js ollama-config-write qwen3.5:latest
+grep -F '"primary": "ollama/qwen3.5:latest"' "$config_path" >/dev/null
+grep -F '"ollama:manual"' "$config_path" >/dev/null
+
+env $helper_env node runtime/openclaw-extension-helper.js ollama-auth-profiles-write
+grep -F '"key": "ollama-local"' "$auth_profiles_path" >/dev/null
+
+echo "runtime helper checks passed"

--- a/scripts/test-security-local.sh
+++ b/scripts/test-security-local.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks detect --source "$repo_root" --redact --no-banner
+else
+  echo "gitleaks is not installed; skipping local secret scan" >&2
+  echo "Install gitleaks to match the GitHub Secret scan before pushing." >&2
+fi
+
+(cd "$repo_root/ui" && npm audit --audit-level=critical)
+
+echo "local security checks passed"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -25,8 +25,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getDDClient, isDemoMode } from './dockerDesktopClient';
 import {
-  buildOllamaAuthProfilesWriteScript,
-  buildOllamaConfigWriteScript,
   buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
   normalizeOllamaModelName,
@@ -35,15 +33,14 @@ import {
 } from './ollamaSetup';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
-import { buildSdkSafeNodeEvalArgs } from './dockerExec';
+import { buildRuntimeHelperArgs } from './dockerExec';
 import { readGatewayTokenWithRetry } from './tokenRetry';
 import {
-  buildExecModeReadScript,
-  buildExecModeWriteScript,
   parseExecModeReadOutput,
   type ExecutionMode,
 } from './execMode';
 import { buildRuntimeRunArgs } from './runtimeContainer';
+import { getGatewayTokenHelperText, type TokenStatus } from './tokenStatus';
 import {
   buildDockerPsPortCheckArgs,
   formatOllamaRequirementStatus,
@@ -54,7 +51,6 @@ import {
 import { updateActionButtonSx } from './updateActionButton';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
-type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
 
 type ExtensionConfig = {
   image: string;
@@ -292,9 +288,7 @@ export function App() {
   const fetchGatewayToken = useCallback(async (containerId: string) => {
     const result = (await ddClient.docker.cli.exec('exec', [
       containerId,
-      ...buildSdkSafeNodeEvalArgs(
-        'const fs=require("fs"); const file="/home/node/.openclaw/openclaw.json"; if (!fs.existsSync(file)) { process.exit(0); } const cfg=JSON.parse(fs.readFileSync(file,"utf8")); process.stdout.write(cfg.gateway?.auth?.token || "");',
-      ),
+      ...buildRuntimeHelperArgs('gateway-token'),
     ])) as CliExecResult;
     return asText(result.stdout).trim();
   }, [asText, ddClient]);
@@ -308,12 +302,43 @@ export function App() {
       );
       setToken(nextToken);
       setTokenStatus(nextToken ? 'ready' : 'empty');
+      return nextToken;
     } catch (err) {
       appendDebug(`token read failed: ${formatUnknownError(err)}`);
       setToken('');
       setTokenStatus('error');
+      return '';
     }
   }, [appendDebug, fetchGatewayToken]);
+
+  const refreshToken = useCallback(async () => {
+    setError('');
+    setMessage('');
+    try {
+      const container = await findContainer();
+      if (!container || container.state !== 'running') {
+        setToken('');
+        setTokenStatus('error');
+        setError('Start OpenClaw before refreshing the gateway token.');
+        return '';
+      }
+
+      const nextToken = await readToken(container.id);
+      setMessage(
+        nextToken
+          ? 'Gateway token refreshed.'
+          : 'Gateway token is still blank. Restart OpenClaw if Refresh Token does not recover it.',
+      );
+      return nextToken;
+    } catch (err) {
+      const text = formatUnknownError(err);
+      appendDebug(`token refresh failed: ${text}`);
+      setToken('');
+      setTokenStatus('error');
+      setError(`Could not refresh gateway token: ${text}`);
+      return '';
+    }
+  }, [appendDebug, findContainer, readToken]);
 
   const checkReady = useCallback(async () => {
     if (demoMode) {
@@ -510,7 +535,10 @@ export function App() {
     try {
       const container = await findContainer();
       if (container?.state === 'running') {
-        launchToken = await fetchGatewayToken(container.id);
+        launchToken = await readGatewayTokenWithRetry(
+          () => fetchGatewayToken(container.id),
+          { attempts: 5, delayMs: 1000 },
+        );
         setToken(launchToken);
         setTokenStatus(launchToken ? 'ready' : 'empty');
       }
@@ -524,7 +552,7 @@ export function App() {
     setMessage(
       launchToken
         ? 'Opened OpenClaw Control with gateway token bootstrap.'
-        : 'Opened OpenClaw Control. Paste the gateway token if the dashboard asks for one.',
+        : 'Opened OpenClaw Control without a token. Click Refresh Token, then Open Control UI again if the dashboard asks.',
     );
   }, [appendDebug, checkReady, ddClient, fetchGatewayToken, findContainer, openUrl, token]);
 
@@ -599,7 +627,7 @@ export function App() {
 
       const result = (await ddClient.docker.cli.exec('exec', [
         container.id,
-        ...buildSdkSafeNodeEvalArgs(buildExecModeReadScript()),
+        ...buildRuntimeHelperArgs('exec-mode-read'),
       ])) as CliExecResult;
       const stderr = asText(result.stderr).trim();
       if (stderr) {
@@ -640,7 +668,7 @@ export function App() {
       appendDebug(`applying OpenClaw execution mode: ${executionMode}`);
       await ddClient.docker.cli.exec('exec', [
         container.id,
-        ...buildSdkSafeNodeEvalArgs(buildExecModeWriteScript(executionMode)),
+        ...buildRuntimeHelperArgs('exec-mode-write', [executionMode]),
       ]);
       setExecutionModeStatus(
         `Applied ${executionMode === 'full' ? 'Full access' : 'Safer'} mode. Restarting OpenClaw...`,
@@ -684,11 +712,11 @@ export function App() {
       appendDebug(`configuring OpenClaw Ollama provider for ${model}`);
       await ddClient.docker.cli.exec('exec', [
         container.id,
-        ...buildSdkSafeNodeEvalArgs(buildOllamaConfigWriteScript(model)),
+        ...buildRuntimeHelperArgs('ollama-config-write', [model]),
       ]);
       await ddClient.docker.cli.exec('exec', [
         container.id,
-        ...buildSdkSafeNodeEvalArgs(buildOllamaAuthProfilesWriteScript()),
+        ...buildRuntimeHelperArgs('ollama-auth-profiles-write'),
       ]);
       await ddClient.docker.cli.exec('exec', [
         container.id,
@@ -821,21 +849,7 @@ export function App() {
     };
   }, [phase, checkForUpdate]);
 
-  const tokenHelperText = (() => {
-    if (token) {
-      return 'Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again.';
-    }
-    if (tokenStatus === 'checking') {
-      return 'Waiting for OpenClaw to write the gateway token. This should resolve shortly after startup.';
-    }
-    if (tokenStatus === 'empty') {
-      return 'Gateway token is still blank after retries. Open Control UI can still launch; paste the token manually if asked.';
-    }
-    if (tokenStatus === 'error') {
-      return 'Could not read the gateway token. Open Control UI can still launch; use manual fallback if asked.';
-    }
-    return 'Gateway token appears here after the OpenClaw service is ready.';
-  })();
+  const tokenHelperText = getGatewayTokenHelperText(token, tokenStatus);
 
   return (
     <Box sx={{ p: 3, maxWidth: 1100, mx: 'auto' }}>
@@ -963,6 +977,14 @@ export function App() {
                   InputProps={{ readOnly: true }}
                   helperText={tokenHelperText}
                 />
+                <Button
+                  variant="outlined"
+                  startIcon={tokenStatus === 'checking' ? <CircularProgress size={20} /> : <RefreshIcon />}
+                  onClick={() => void refreshToken()}
+                  disabled={busy || tokenStatus === 'checking' || phase !== 'running'}
+                >
+                  Refresh Token
+                </Button>
                 <Button
                   variant="outlined"
                   startIcon={<ContentCopyIcon />}

--- a/ui/src/dockerExec.test.ts
+++ b/ui/src/dockerExec.test.ts
@@ -1,19 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSdkSafeNodeEvalArgs } from './dockerExec';
+import { buildRuntimeHelperArgs } from './dockerExec';
 
 describe('Docker Desktop exec helpers', () => {
-  it('wraps Node scripts without shell operators in the SDK command argument', () => {
-    const args = buildSdkSafeNodeEvalArgs('const fs=require("fs"); process.stdout.write("ok");');
+  it('builds runtime helper argv without inline JavaScript for Docker Desktop SDK', () => {
+    const args = buildRuntimeHelperArgs('exec-mode-read');
 
-    expect(args.slice(0, 3)).toEqual([
+    expect(args).toEqual([
       'node',
-      '-e',
-      'eval(Buffer.from(process.argv[1],"base64").toString("utf8"))',
+      '/usr/local/bin/openclaw-extension-helper.js',
+      'exec-mode-read',
     ]);
-    expect(args[2]).not.toContain(';');
-    expect(args[2]).not.toContain('&&');
-    expect(args[2]).not.toContain('|');
-    expect(args[3]).toMatch(/^[A-Za-z0-9+/=]+$/);
+    expect(args.join(' ')).not.toContain(' -e ');
+    expect(args.join(' ')).not.toContain('eval(');
+    expect(args.join(' ')).not.toContain(';');
+    expect(args.join(' ')).not.toContain('&&');
+    expect(args.join(' ')).not.toContain('|');
   });
 });

--- a/ui/src/dockerExec.ts
+++ b/ui/src/dockerExec.ts
@@ -1,17 +1,5 @@
-function encodeBase64Utf8(value: string): string {
-  const bytes = new TextEncoder().encode(value);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary);
-}
+const RUNTIME_HELPER_PATH = '/usr/local/bin/openclaw-extension-helper.js';
 
-export function buildSdkSafeNodeEvalArgs(script: string): string[] {
-  return [
-    'node',
-    '-e',
-    'eval(Buffer.from(process.argv[1],"base64").toString("utf8"))',
-    encodeBase64Utf8(script),
-  ];
+export function buildRuntimeHelperArgs(command: string, args: string[] = []): string[] {
+  return ['node', RUNTIME_HELPER_PATH, command, ...args];
 }

--- a/ui/src/execMode.test.ts
+++ b/ui/src/execMode.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  buildExecModeReadScript,
-  buildExecModeWriteScript,
   buildExecutionModeConfig,
   detectExecutionMode,
   mergeExecApprovals,
   mergeOpenClawExecConfig,
+  parseExecModeReadOutput,
 } from './execMode';
 
 describe('execution mode config', () => {
@@ -132,23 +131,8 @@ describe('execution mode config', () => {
     ).toBe('safer');
   });
 
-  it('builds a Docker SDK-safe write script for both config files', () => {
-    const script = buildExecModeWriteScript('full');
-
-    expect(script).toContain('/home/node/.openclaw/exec-approvals.json');
-    expect(script).toContain('/home/node/.openclaw/openclaw.json');
-    expect(script).toContain('copyFileSync');
-    expect(script).not.toContain('&&');
-    expect(script).not.toContain('|');
-  });
-
-  it('builds a read script that does not return socket token fields', () => {
-    const script = buildExecModeReadScript();
-
-    expect(script).toContain('approvals:{defaults:approvals.defaults');
-    expect(script).not.toContain('socket');
-    expect(script).not.toContain('token');
-    expect(script).not.toContain('&&');
-    expect(script).not.toContain('|');
+  it('treats empty or invalid helper output as safer mode', () => {
+    expect(parseExecModeReadOutput('')).toEqual({ approvals: {}, config: {}, mode: 'safer' });
+    expect(parseExecModeReadOutput('not-json')).toEqual({ approvals: {}, config: {}, mode: 'safer' });
   });
 });

--- a/ui/src/execMode.ts
+++ b/ui/src/execMode.ts
@@ -2,9 +2,6 @@ export type ExecutionMode = 'safer' | 'full';
 
 export type JsonObject = Record<string, unknown>;
 
-const OPENCLAW_CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
-const EXEC_APPROVALS_PATH = '/home/node/.openclaw/exec-approvals.json';
-
 type ExecutionModeConfig = {
   approvalsDefaults: JsonObject;
   toolsExec: JsonObject;
@@ -88,42 +85,6 @@ export function detectExecutionMode(approvals: JsonObject, openclawConfig: JsonO
   const configFull = exec.security === 'full' && exec.ask === 'off';
 
   return approvalsFull && configFull ? 'full' : 'safer';
-}
-
-export function buildExecModeReadScript(): string {
-  return [
-    'const fs=require("fs");',
-    'const approvalsPath=' + JSON.stringify(EXEC_APPROVALS_PATH) + ';',
-    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
-    'function read(file){if(!fs.existsSync(file)){return {};} return JSON.parse(fs.readFileSync(file,"utf8"));}',
-    'const approvals=read(approvalsPath);',
-    'const config=read(configPath);',
-    'const tools=config.tools?config.tools:{};',
-    'process.stdout.write(JSON.stringify({approvals:{defaults:approvals.defaults?approvals.defaults:{}},config:{tools:{exec:tools.exec?tools.exec:{}}}}));',
-  ].join(' ');
-}
-
-export function buildExecModeWriteScript(mode: ExecutionMode): string {
-  const next = buildExecutionModeConfig(mode);
-
-  return [
-    'const fs=require("fs");',
-    'const path=require("path");',
-    'const approvalsPath=' + JSON.stringify(EXEC_APPROVALS_PATH) + ';',
-    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
-    'const approvalsDefaults=' + JSON.stringify(next.approvalsDefaults) + ';',
-    'const toolsExec=' + JSON.stringify(next.toolsExec) + ';',
-    'function read(file){if(!fs.existsSync(file)){return {};} return JSON.parse(fs.readFileSync(file,"utf8"));}',
-    'function writeJson(file,data){fs.mkdirSync(path.dirname(file),{recursive:true}); if(fs.existsSync(file)){fs.copyFileSync(file,file+".bak");} fs.writeFileSync(file,JSON.stringify(data,null,2)+"\\n");}',
-    'const approvals=read(approvalsPath);',
-    'const config=read(configPath);',
-    'approvals.version=1;',
-    'approvals.defaults=Object.assign({},approvals.defaults?approvals.defaults:{},approvalsDefaults);',
-    'config.tools=config.tools?config.tools:{};',
-    'config.tools.exec=Object.assign({},config.tools.exec?config.tools.exec:{},toolsExec);',
-    'writeJson(approvalsPath,approvals);',
-    'writeJson(configPath,config);',
-  ].join(' ');
 }
 
 export function parseExecModeReadOutput(stdout: string): {

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -4,8 +4,6 @@ import {
   buildOllamaAuthConfigProfile,
   buildOllamaAuthOrder,
   buildOllamaAuthProfilesStore,
-  buildOllamaAuthProfilesWriteScript,
-  buildOllamaConfigWriteScript,
   buildOllamaProviderPatch,
   buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
@@ -82,21 +80,6 @@ describe('ollamaSetup helpers', () => {
       },
     });
     expect(buildOllamaAuthOrder()).toEqual(['ollama:manual']);
-  });
-
-  it('builds Docker SDK-safe Node scripts for Ollama setup', () => {
-    const scripts = [
-      buildOllamaConfigWriteScript('gemma4:latest'),
-      buildOllamaAuthProfilesWriteScript(),
-    ];
-
-    for (const script of scripts) {
-      expect(script).not.toContain('=>');
-      expect(script).not.toContain('`');
-    }
-
-    expect(buildOllamaConfigWriteScript('gemma4:latest')).toContain('gemma4:latest');
-    expect(buildOllamaAuthProfilesWriteScript()).toContain('auth-profiles.json');
   });
 
   it('builds Docker SDK-safe argv for fetching host Ollama tags', () => {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -8,8 +8,6 @@ export type JsonObject = Record<string, unknown>;
 const DEFAULT_OLLAMA_BASE_URL = 'http://host.docker.internal:11434';
 const DEFAULT_OLLAMA_API_KEY = 'ollama-local';
 const OLLAMA_AUTH_PROFILE_ID = 'ollama:manual';
-const OPENCLAW_CONFIG_PATH = '/home/node/.openclaw/openclaw.json';
-const OPENCLAW_AUTH_PROFILES_PATH = '/home/node/.openclaw/agents/main/agent/auth-profiles.json';
 const RECOMMENDED_MODEL_ORDER = [
   'gemma4:latest',
   'gemma4',
@@ -127,47 +125,6 @@ export function buildOllamaTagsFetchArgs(): string[] {
     '5',
     `${DEFAULT_OLLAMA_BASE_URL}/api/tags`,
   ];
-}
-
-export function buildOllamaConfigWriteScript(model: string): string {
-  const selectedModel = model.trim();
-  if (!selectedModel) {
-    throw new Error('Choose an Ollama model before applying local setup.');
-  }
-
-  return [
-    'const fs=require("fs");',
-    'const configPath=' + JSON.stringify(OPENCLAW_CONFIG_PATH) + ';',
-    'const model=' + JSON.stringify(selectedModel) + ';',
-    'var config={};',
-    'if(fs.existsSync(configPath)){config=JSON.parse(fs.readFileSync(configPath,"utf8"));}',
-    'config.agents=config.agents||{};',
-    'config.agents.defaults=config.agents.defaults||{};',
-    'config.agents.defaults.model=config.agents.defaults.model||{};',
-    'config.agents.defaults.model.primary="ollama/"+model;',
-    'config.agents.defaults.timeoutSeconds=300;',
-    'config.models=config.models||{};',
-    'config.models.providers=config.models.providers||{};',
-    'config.models.providers.ollama={api:"ollama",apiKey:"ollama-local",baseUrl:"http://host.docker.internal:11434",models:[{id:model,name:model,reasoning:false}]};',
-    'config.auth=config.auth||{};',
-    'config.auth.profiles=config.auth.profiles||{};',
-    'config.auth.profiles["ollama:manual"]=' + JSON.stringify(buildOllamaAuthConfigProfile()) + ';',
-    'config.auth.order=config.auth.order||{};',
-    'config.auth.order.ollama=["ollama:manual"];',
-    'if(fs.existsSync(configPath)){fs.copyFileSync(configPath,configPath+".bak");}',
-    'fs.writeFileSync(configPath,JSON.stringify(config,null,2)+"\\n");',
-  ].join(' ');
-}
-
-export function buildOllamaAuthProfilesWriteScript(): string {
-  return [
-    'const fs=require("fs");',
-    'const path=require("path");',
-    'const file=' + JSON.stringify(OPENCLAW_AUTH_PROFILES_PATH) + ';',
-    'const data=' + JSON.stringify(buildOllamaAuthProfilesStore()) + ';',
-    'fs.mkdirSync(path.dirname(file),{recursive:true});',
-    'fs.writeFileSync(file,JSON.stringify(data,null,2)+"\\n");',
-  ].join(' ');
 }
 
 export function chooseRecommendedOllamaModel(models: OllamaModel[]): string {

--- a/ui/src/tokenStatus.test.ts
+++ b/ui/src/tokenStatus.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGatewayTokenHelperText } from './tokenStatus';
+
+describe('gateway token status text', () => {
+  it('gives a simple recovery action when token retries are exhausted', () => {
+    expect(getGatewayTokenHelperText('', 'empty')).toBe(
+      'Gateway token is still blank after retries. Click Refresh Token, then Open Control UI again.',
+    );
+  });
+
+  it('keeps the successful bootstrap guidance when a token is available', () => {
+    expect(getGatewayTokenHelperText('token-value', 'ready')).toBe(
+      'Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again.',
+    );
+  });
+});

--- a/ui/src/tokenStatus.ts
+++ b/ui/src/tokenStatus.ts
@@ -1,0 +1,17 @@
+export type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
+
+export function getGatewayTokenHelperText(token: string, tokenStatus: TokenStatus): string {
+  if (token) {
+    return 'Open Control UI passes this token in the URL fragment. Use Copy only if the dashboard asks again.';
+  }
+  if (tokenStatus === 'checking') {
+    return 'Waiting for OpenClaw to write the gateway token. This should resolve shortly after startup.';
+  }
+  if (tokenStatus === 'empty') {
+    return 'Gateway token is still blank after retries. Click Refresh Token, then Open Control UI again.';
+  }
+  if (tokenStatus === 'error') {
+    return 'Could not read the gateway token. Click Refresh Token, then restart OpenClaw if it is still blank.';
+  }
+  return 'Gateway token appears here after the OpenClaw service is ready.';
+}


### PR DESCRIPTION
## Summary

- Replace Docker Desktop SDK inline `node -e` calls with a packaged runtime helper command.
- Use the helper for gateway token reads, execution-mode reads/writes, and Ollama setup writes.
- Add a `Refresh Token` recovery path and update docs away from manual container/volume token retrieval.

Fixes #104.
Fixes #105.

## Test Plan

- `cd ui && npm test`
- `cd ui && npm run build`
- `make test-runtime-helper`
- `make test-pre-push`
- `docker build -t openclaw-docker-extension-runtime:helper-test -f runtime/Dockerfile runtime`
- `docker run --rm --entrypoint node openclaw-docker-extension-runtime:helper-test /usr/local/bin/openclaw-extension-helper.js exec-mode-read`
- Browser demo check at `http://127.0.0.1:5173/?demo=1`
