### PR TITLE
Fix release channel digest verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,12 @@ test-verify-release-tag-dockerhub-error: ; @./scripts/test-verify-release-tag-do
 test-verify-release-tag-title: ; @./scripts/test-verify-release-tag-title.sh
 test-release-install-dry-run: ; @./scripts/test-release-install-dry-run.sh
 test-release-channel-dry-run: ; @./scripts/test-release-channel-dry-run.sh
+test-verify-release-channel-digest: ; @./scripts/test-verify-release-channel-digest.sh
 test-create-smoke-report: ; @sh ./scripts/test-create-smoke-report.sh
 test-runtime-helper: ; @sh ./scripts/test-runtime-helper.sh
 test-security-local: ; @sh ./scripts/test-security-local.sh
 test-ui: ; @cd ui && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-runtime-helper test-security-local
+test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-security-local
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -95,4 +96,4 @@ capture-readme-screenshot:
 create-smoke-report:
 	@REPORT_DATE="$(REPORT_DATE)" RELEASE_CHANNEL="$(RELEASE_CHANNEL)" RELEASE_TAG="$(RELEASE_TAG)" REPORT_DIR="$(REPORT_DIR)" sh ./scripts/create-smoke-report.sh
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-create-smoke-report test-runtime-helper test-security-local test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-security-local test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report

--- a/scripts/test-verify-release-channel-digest.sh
+++ b/scripts/test-verify-release-channel-digest.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/docker" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ]; then
+  exit 0
+fi
+
+echo "unexpected docker invocation: $*" >&2
+exit 1
+EOF
+
+cat >"$tmp_dir/bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+url=""
+for arg in "$@"; do
+  case "$arg" in
+    http://*|https://*)
+      url="$arg"
+      ;;
+  esac
+done
+
+case "$url" in
+  https://ghcr.io/token\?*)
+    printf '%s' '{"token":"test-token"}'
+    ;;
+  */manifests/stable|*/manifests/v1.2.3)
+    printf 'HTTP/1.1 200 OK\r\n'
+    printf 'content-type: application/vnd.oci.image.index.v1+json\r\n'
+    printf 'docker-content-digest: sha256:testdigest\r\n'
+    printf '\r\n'
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+chmod +x "$tmp_dir/bin/docker" "$tmp_dir/bin/curl"
+
+output="$(
+  PATH="$tmp_dir/bin:$PATH" \
+    EXPECTED_RELEASE_TAG="v1.2.3" \
+    GHCR_OWNER="jcowhigjr" \
+    "$repo_root/scripts/verify-release-channel.sh" stable
+)"
+
+printf '%s\n' "$output" | grep -F "ghcr channel matches expected release: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:stable -> v1.2.3" >/dev/null
+printf '%s\n' "$output" | grep -F "ghcr channel matches expected release: ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:stable -> v1.2.3" >/dev/null
+
+echo "verify-release-channel digest parsing checks passed"

--- a/scripts/verify-release-channel.sh
+++ b/scripts/verify-release-channel.sh
@@ -87,7 +87,7 @@ fetch_registry_digest() {
     -H "Authorization: Bearer ${token}" \
     -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
     "https://ghcr.io/v2/${repo_path}/manifests/${reference}" \
-    | awk 'BEGIN { IGNORECASE = 1 } /^Docker-Content-Digest:/ { sub(/\r$/, "", $2); print $2; exit }'
+    | awk 'tolower($1) == "docker-content-digest:" { sub(/\r$/, "", $2); print $2; exit }'
 }
 
 require_matching_tag() {


### PR DESCRIPTION
## Summary

- make `verify-release-channel` parse `Docker-Content-Digest` headers portably on this macOS workstation
- add a regression test that stubs GHCR responses with lowercase header casing
- cover the new regression check in `make test-pre-push`

Contributes to #86.

## Test Plan

- `make test-verify-release-channel-digest`
- `make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4`
- `make test-pre-push`
