### PR TITLE
Improve smoke packet preflight evidence capture

### DIFF
--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -32,9 +32,9 @@ make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
 
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
 manual steps, artifact checklist, and a best-effort `capture-artifacts.sh`
-helper for the CLI evidence files already filled in, including release-channel
-preflight output, Docker image inventory, and partial-failure notes when one
-capture command fails.
+helper for the CLI evidence files already filled in, including macOS/Docker
+environment details, release-channel preflight output, Docker image inventory,
+and partial-failure notes when one capture command fails.
 
 1. Start Docker Desktop and wait for the Docker Engine to become ready.
 2. Confirm Docker Desktop allows local or non-Marketplace extension installs.

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -33,8 +33,9 @@ make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
 manual steps, artifact checklist, and a best-effort `capture-artifacts.sh`
 helper for the CLI evidence files already filled in, including macOS/Docker
-environment details, release-channel preflight output, Docker image inventory,
-and partial-failure notes when one capture command fails.
+environment details, release-channel preflight output, installed extension and
+runtime inspect output, Docker image inventory, and partial-failure notes when
+one capture command fails.
 
 1. Start Docker Desktop and wait for the Docker Engine to become ready.
 2. Confirm Docker Desktop allows local or non-Marketplace extension installs.

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -32,8 +32,9 @@ make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
 
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
 manual steps, artifact checklist, and a best-effort `capture-artifacts.sh`
-helper for the CLI evidence files already filled in, including Docker image
-inventory even when one capture command fails.
+helper for the CLI evidence files already filled in, including release-channel
+preflight output, Docker image inventory, and partial-failure notes when one
+capture command fails.
 
 1. Start Docker Desktop and wait for the Docker Engine to become ready.
 2. Confirm Docker Desktop allows local or non-Marketplace extension installs.

--- a/scripts/create-smoke-report.sh
+++ b/scripts/create-smoke-report.sh
@@ -61,6 +61,8 @@ cat >"$report_file" <<EOF
 
 ## Artifacts
 
+- \`verify-release-channel.txt\`
+- \`verify-channel-install-dry-run.txt\`
 - \`docker-extension-ls.txt\`
 - \`docker-ps-a.txt\`
 - \`docker-image-ls.txt\`
@@ -96,6 +98,9 @@ set -eu
 # Capture smoke-test CLI artifacts into this packet directory.
 # Keep gathering evidence even when one command fails.
 report_dir="\$(CDPATH= cd -- "\$(dirname "\$0")" && pwd)"
+repo_root="${repo_root}"
+release_channel="${release_channel}"
+release_tag="${release_tag}"
 
 capture_cmd() {
   output_file="\$1"
@@ -118,6 +123,14 @@ capture_cmd() {
   mv "\${report_dir}/\${output_file}.tmp" "\${report_dir}/\${output_file}"
 }
 
+if [ -n "\$release_tag" ]; then
+  capture_cmd verify-release-channel.txt make -C "\$repo_root" verify-release-channel RELEASE_CHANNEL="\$release_channel" EXPECTED_RELEASE_TAG="\$release_tag"
+  capture_cmd verify-channel-install-dry-run.txt make -C "\$repo_root" verify-channel-install RELEASE_CHANNEL="\$release_channel" EXPECTED_RELEASE_TAG="\$release_tag" DRY_RUN=1
+else
+  capture_cmd verify-release-channel.txt make -C "\$repo_root" verify-release-channel RELEASE_CHANNEL="\$release_channel"
+  capture_cmd verify-channel-install-dry-run.txt make -C "\$repo_root" verify-channel-install RELEASE_CHANNEL="\$release_channel" DRY_RUN=1
+fi
+
 capture_cmd docker-extension-ls.txt docker extension ls
 capture_cmd docker-ps-a.txt docker ps -a --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
 capture_cmd docker-image-ls.txt docker image ls --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}'
@@ -127,7 +140,7 @@ EOF
 
 chmod +x "$capture_script"
 
-for artifact in docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
   : >"${report_dir}/${artifact}"
 done
 

--- a/scripts/create-smoke-report.sh
+++ b/scripts/create-smoke-report.sh
@@ -65,8 +65,10 @@ cat >"$report_file" <<EOF
 - \`verify-release-channel.txt\`
 - \`verify-channel-install-dry-run.txt\`
 - \`docker-extension-ls.txt\`
+- \`docker-extension-inspect.txt\`
 - \`docker-ps-a.txt\`
 - \`docker-image-ls.txt\`
+- \`openclaw-service-inspect.txt\`
 - \`openclaw-service.log\`
 - \`control-ui-healthz.txt\`
 - \`control-ui.png\`
@@ -160,15 +162,17 @@ else
 fi
 
 capture_cmd docker-extension-ls.txt docker extension ls
+capture_cmd docker-extension-inspect.txt docker extension inspect openclaw-docker-extension
 capture_cmd docker-ps-a.txt docker ps -a --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'
 capture_cmd docker-image-ls.txt docker image ls --format 'table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}'
+capture_cmd openclaw-service-inspect.txt docker inspect openclaw-docker-extension-service
 capture_cmd openclaw-service.log docker logs openclaw-docker-extension-service
 capture_cmd control-ui-healthz.txt curl -fsS http://127.0.0.1:18789/healthz
 EOF
 
 chmod +x "$capture_script"
 
-for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-extension-inspect.txt docker-ps-a.txt docker-image-ls.txt openclaw-service-inspect.txt openclaw-service.log control-ui-healthz.txt; do
   : >"${report_dir}/${artifact}"
 done
 

--- a/scripts/create-smoke-report.sh
+++ b/scripts/create-smoke-report.sh
@@ -61,6 +61,7 @@ cat >"$report_file" <<EOF
 
 ## Artifacts
 
+- \`environment.txt\`
 - \`verify-release-channel.txt\`
 - \`verify-channel-install-dry-run.txt\`
 - \`docker-extension-ls.txt\`
@@ -123,6 +124,33 @@ capture_cmd() {
   mv "\${report_dir}/\${output_file}.tmp" "\${report_dir}/\${output_file}"
 }
 
+capture_environment() {
+  output_file="\${report_dir}/environment.txt"
+
+  {
+    printf 'captured_at=%s\n' "\$(date -u +%FT%TZ)"
+    printf 'repo_root=%s\n' "\$repo_root"
+    printf 'release_channel=%s\n' "\$release_channel"
+    printf 'release_tag=%s\n' "\${release_tag:-}"
+    printf '\n[sw_vers]\n'
+    sw_vers
+    printf '\n[uname]\n'
+    uname -a
+    printf '\n[docker version]\n'
+    docker version
+  } >"\$output_file" 2>&1 || {
+    status="\$?"
+    {
+      printf 'capture failed with exit %s\n' "\$status"
+      printf 'command: capture_environment\n\n'
+      cat "\$output_file"
+    } >"\${output_file}.tmp"
+    mv "\${output_file}.tmp" "\$output_file"
+  }
+}
+
+capture_environment
+
 if [ -n "\$release_tag" ]; then
   capture_cmd verify-release-channel.txt make -C "\$repo_root" verify-release-channel RELEASE_CHANNEL="\$release_channel" EXPECTED_RELEASE_TAG="\$release_tag"
   capture_cmd verify-channel-install-dry-run.txt make -C "\$repo_root" verify-channel-install RELEASE_CHANNEL="\$release_channel" EXPECTED_RELEASE_TAG="\$release_tag" DRY_RUN=1
@@ -140,7 +168,7 @@ EOF
 
 chmod +x "$capture_script"
 
-for artifact in verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
   : >"${report_dir}/${artifact}"
 done
 

--- a/scripts/test-create-smoke-report.sh
+++ b/scripts/test-create-smoke-report.sh
@@ -17,6 +17,7 @@ capture_script="${report_dir}/capture-artifacts.sh"
 grep -F '# stable Channel Smoke Test - 2026-05-17' "$report_file" >/dev/null
 grep -F 'Release tag under test: `v0.3.4`' "$report_file" >/dev/null
 grep -F 'make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4' "$report_file" >/dev/null
+grep -F 'environment.txt' "$report_file" >/dev/null
 grep -F 'verify-release-channel.txt' "$report_file" >/dev/null
 grep -F 'verify-channel-install-dry-run.txt' "$report_file" >/dev/null
 grep -F 'docker extension ls' "$report_file" >/dev/null
@@ -26,6 +27,9 @@ grep -F 'Keep gathering evidence even when one command fails.' "$capture_script"
 grep -F 'repo_root="' "$capture_script" >/dev/null
 grep -F 'release_channel="stable"' "$capture_script" >/dev/null
 grep -F 'release_tag="v0.3.4"' "$capture_script" >/dev/null
+grep -F 'capture_environment' "$capture_script" >/dev/null
+grep -F "printf 'captured_at=%s" "$capture_script" >/dev/null
+grep -F 'docker version' "$capture_script" >/dev/null
 grep -F 'capture_cmd verify-release-channel.txt make -C "$repo_root" verify-release-channel RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag"' "$capture_script" >/dev/null
 grep -F 'capture_cmd verify-channel-install-dry-run.txt make -C "$repo_root" verify-channel-install RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag" DRY_RUN=1' "$capture_script" >/dev/null
 grep -F 'docker-extension-ls.txt' "$capture_script" >/dev/null
@@ -33,7 +37,7 @@ grep -F "capture_cmd docker-image-ls.txt docker image ls --format 'table {{.Repo
 grep -F 'capture failed with exit' "$capture_script" >/dev/null
 grep -F 'curl -fsS http://127.0.0.1:18789/healthz' "$capture_script" >/dev/null
 
-for artifact in verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
   [ -f "${report_dir}/${artifact}" ]
 done
 

--- a/scripts/test-create-smoke-report.sh
+++ b/scripts/test-create-smoke-report.sh
@@ -17,16 +17,23 @@ capture_script="${report_dir}/capture-artifacts.sh"
 grep -F '# stable Channel Smoke Test - 2026-05-17' "$report_file" >/dev/null
 grep -F 'Release tag under test: `v0.3.4`' "$report_file" >/dev/null
 grep -F 'make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4' "$report_file" >/dev/null
+grep -F 'verify-release-channel.txt' "$report_file" >/dev/null
+grep -F 'verify-channel-install-dry-run.txt' "$report_file" >/dev/null
 grep -F 'docker extension ls' "$report_file" >/dev/null
 grep -F 'docker-image-ls.txt' "$report_file" >/dev/null
 grep -F 'Control UI bootstrap from extension button' "$report_file" >/dev/null
 grep -F 'Keep gathering evidence even when one command fails.' "$capture_script" >/dev/null
+grep -F 'repo_root="' "$capture_script" >/dev/null
+grep -F 'release_channel="stable"' "$capture_script" >/dev/null
+grep -F 'release_tag="v0.3.4"' "$capture_script" >/dev/null
+grep -F 'capture_cmd verify-release-channel.txt make -C "$repo_root" verify-release-channel RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag"' "$capture_script" >/dev/null
+grep -F 'capture_cmd verify-channel-install-dry-run.txt make -C "$repo_root" verify-channel-install RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag" DRY_RUN=1' "$capture_script" >/dev/null
 grep -F 'docker-extension-ls.txt' "$capture_script" >/dev/null
 grep -F "capture_cmd docker-image-ls.txt docker image ls --format 'table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.CreatedSince}}\\t{{.Size}}'" "$capture_script" >/dev/null
 grep -F 'capture failed with exit' "$capture_script" >/dev/null
 grep -F 'curl -fsS http://127.0.0.1:18789/healthz' "$capture_script" >/dev/null
 
-for artifact in docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
   [ -f "${report_dir}/${artifact}" ]
 done
 

--- a/scripts/test-create-smoke-report.sh
+++ b/scripts/test-create-smoke-report.sh
@@ -21,7 +21,9 @@ grep -F 'environment.txt' "$report_file" >/dev/null
 grep -F 'verify-release-channel.txt' "$report_file" >/dev/null
 grep -F 'verify-channel-install-dry-run.txt' "$report_file" >/dev/null
 grep -F 'docker extension ls' "$report_file" >/dev/null
+grep -F 'docker-extension-inspect.txt' "$report_file" >/dev/null
 grep -F 'docker-image-ls.txt' "$report_file" >/dev/null
+grep -F 'openclaw-service-inspect.txt' "$report_file" >/dev/null
 grep -F 'Control UI bootstrap from extension button' "$report_file" >/dev/null
 grep -F 'Keep gathering evidence even when one command fails.' "$capture_script" >/dev/null
 grep -F 'repo_root="' "$capture_script" >/dev/null
@@ -33,11 +35,13 @@ grep -F 'docker version' "$capture_script" >/dev/null
 grep -F 'capture_cmd verify-release-channel.txt make -C "$repo_root" verify-release-channel RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag"' "$capture_script" >/dev/null
 grep -F 'capture_cmd verify-channel-install-dry-run.txt make -C "$repo_root" verify-channel-install RELEASE_CHANNEL="$release_channel" EXPECTED_RELEASE_TAG="$release_tag" DRY_RUN=1' "$capture_script" >/dev/null
 grep -F 'docker-extension-ls.txt' "$capture_script" >/dev/null
+grep -F 'capture_cmd docker-extension-inspect.txt docker extension inspect openclaw-docker-extension' "$capture_script" >/dev/null
 grep -F "capture_cmd docker-image-ls.txt docker image ls --format 'table {{.Repository}}\\t{{.Tag}}\\t{{.ID}}\\t{{.CreatedSince}}\\t{{.Size}}'" "$capture_script" >/dev/null
+grep -F 'capture_cmd openclaw-service-inspect.txt docker inspect openclaw-docker-extension-service' "$capture_script" >/dev/null
 grep -F 'capture failed with exit' "$capture_script" >/dev/null
 grep -F 'curl -fsS http://127.0.0.1:18789/healthz' "$capture_script" >/dev/null
 
-for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-ps-a.txt docker-image-ls.txt openclaw-service.log control-ui-healthz.txt; do
+for artifact in environment.txt verify-release-channel.txt verify-channel-install-dry-run.txt docker-extension-ls.txt docker-extension-inspect.txt docker-ps-a.txt docker-image-ls.txt openclaw-service-inspect.txt openclaw-service.log control-ui-healthz.txt; do
   [ -f "${report_dir}/${artifact}" ]
 done
 


### PR DESCRIPTION
## Summary
- capture release-channel verification output inside generated smoke-test packets
- capture channel-install dry-run output alongside existing Docker state artifacts
- document the richer packet contents in the submission-readiness guide

## Testing
- make test-create-smoke-report
- make test-pre-push

Contributes to #86