### PR TITLE
docs: sync roadmap after stable smoke pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
 ## Current Roadmap
 
 - Treat issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) as the source of truth for roadmap and decision gates.
-- MVP foundations are complete enough for external review: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, execution mode UX, repo metadata, `.env` documentation, readiness checks, and build validation.
-- Active pre-submission priority is manual stable-channel smoke testing on a real Docker Desktop install.
+- MVP is complete enough to share: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, execution mode UX, repo metadata, `.env` documentation, readiness checks, build validation, and a real Docker Desktop stable-channel smoke pass for `v0.3.4`.
+- Default post-MVP posture is pause unless outside traction appears or a release/distribution gate fails and needs a small reproducible fix.
 - Remaining roadmap work is investigation or long-term hardening:
   1. [#64](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/64) native migration after Docker Desktop trial; keep this manual/documentation-only unless user demand justifies automation.
   2. [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65) longer-term security, hardening, supply-chain, and network migration epic.

--- a/README.md
+++ b/README.md
@@ -370,15 +370,16 @@ Safe extension-level diagnostics are limited to project-specific state: containe
 
 The roadmap source of truth is [issue #12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12). Keep this section aligned with that issue.
 
-Current status: the MVP foundation is complete enough for external review. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README now documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary.
+Current status: the MVP is complete enough to share. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary. A real Docker Desktop stable-channel smoke pass for `v0.3.4` is captured in [docs/exploratory/2026-05-22-stable-channel-smoke/](docs/exploratory/2026-05-22-stable-channel-smoke/).
 
 Native migration after a successful Docker Desktop trial is documented as a manual investigation path in [docs/native-migration-investigation.md](docs/native-migration-investigation.md). Do not build native migration automation until real user demand and upstream OpenClaw portable-state guidance justify it.
 
 The repo should now move in this order:
 
-1. Keep the release/channel image path and public landing page current for external review.
-2. Treat host Ollama as the supported offline-first local model path after initial setup.
-3. Defer bundled local inference runtime work unless real user traction justifies it.
+1. Pause unless outside users, upstream, or release/distribution friction provide evidence that more work is worth doing.
+2. Keep the release/channel image path and public landing page current when a real release or verification failure needs attention.
+3. Treat host Ollama as the supported offline-first local model path after initial setup.
+4. Defer bundled local inference runtime work and native migration automation unless real user traction justifies them.
 
 The developer-only local update path remains `make update-extension`. The release-image path is the preferred end-user path; local builds remain useful for development and validation.
 


### PR DESCRIPTION
## Summary
- update repo roadmap wording now that the `v0.3.4` stable-channel Docker Desktop smoke pass is verified
- switch AGENTS and README from pre-submission language to post-MVP pause-unless-traction guidance
- link the README roadmap section to the committed smoke evidence packet

## Verification
- `git diff --check`
- `make test-pre-push`

Contributes to #12
Contributes to #86