### PR TITLE
chore: keep Dependabot UI updates compatible

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,25 @@ updates:
     allow:
       - dependency-type: "direct"
     ignore:
+      # Docker's current extension theme package peers with MUI 5-6.
+      # Keep this lane on compatible UI majors until that package supports newer MUI.
+      - dependency-name: "@mui/material"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@mui/icons-material"
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@types/react-dom"
         update-types:
           - "version-update:semver-major"
     labels:
       - "dependencies"
-      - "dependabot"
     groups:
       ui-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- ignore incompatible semver-major MUI and React DOM updates in the weekly UI Dependabot lane
- remove the missing `dependabot` label from Dependabot config so new dependency PRs do not get label warnings

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "dependabot yaml ok"'`
- `make test-pre-push`

Contributes to #86 by keeping release-readiness automation clean.