### PR TITLE
fix: disable provenance attestations on Docker Hub push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,7 @@ jobs:
           file: runtime/Dockerfile
           platforms: linux/arm64,linux/amd64
           push: true
+          provenance: false
           tags: ${{ steps.runtime-meta.outputs.tags }}
           labels: ${{ steps.runtime-meta.outputs.labels }}
 
@@ -136,6 +137,7 @@ jobs:
           file: Dockerfile
           platforms: linux/arm64,linux/amd64
           push: true
+          provenance: false
           tags: ${{ steps.extension-meta.outputs.tags }}
           labels: ${{ steps.extension-meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
## Problem
The `build-push-action@v7` default enables provenance attestations, which adds two `unknown/unknown` platform entries to the OCI manifest index pushed to Docker Hub.

Docker Hub's extension marketplace validator rejects the image with:
```
Use "--platform=linux/amd64,linux/arm64" when pushing your image to DockerHub
The extension hasn't passed the checks to be published.
```

## Fix
Add `provenance: false` to both the runtime and extension `build-push-action` steps so the pushed manifest contains only `linux/arm64` and `linux/amd64`.

## After merge
Trigger the Publish workflow manually with `release_tag=v0.3.4` and `promote_channel=true` to republish the Docker Hub image cleanly, then re-run:
```
make verify-release-install RELEASE_TAG=v0.3.4
```