### PR TITLE
fix: apt-get upgrade in runtime Dockerfile to patch CVE-2026-33845

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -9,6 +9,7 @@ LABEL org.opencontainers.image.title="OpenClaw Docker Desktop Extension Runtime"
 USER root
 
 RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends socat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem
Trivy scanner now reports **CRITICAL** CVE-2026-33845 in `libgnutls30` (fixed in `3.7.9-2+deb12u7`) in the runtime image base.

The existing `apt-get update && apt-get install socat` only installs the requested package; it does not upgrade already-installed base packages.

## Fix
Add `apt-get upgrade -y` before the `install` so all base OS packages are patched to their latest fixed versions at build time.

## Next step after merge
Tag `v0.3.5` — the Publish workflow will build and push clean images (with `provenance: false` from #120) and Trivy will pass.