### PR TITLE
fix: use docker pull+inspect for Docker Hub label verification

### DIFF
--- a/scripts/test-verify-release-tag-title.sh
+++ b/scripts/test-verify-release-tag-title.sh
@@ -35,58 +35,26 @@ cat >"${fakebin}/docker" <<'EOF'
 #!/bin/sh
 set -eu
 
-if [ -z "${DOCKER_CONFIG:-}" ]; then
-  echo "expected DOCKER_CONFIG for anonymous GHCR reads" >&2
-  exit 1
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ]; then
+  case "${DOCKER_CONFIG:-}" in
+    '') echo "expected DOCKER_CONFIG for anonymous GHCR reads" >&2; exit 1 ;;
+  esac
+  case "$3" in
+    ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3|\
+    ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3|\
+    ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3|\
+    ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3|\
+    docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3)
+      exit 0 ;;
+  esac
 fi
 
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" ]; then
+if [ "$1" = "pull" ] && [ "$3" = "docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
   exit 0
 fi
 
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:v1.2.3" ]; then
-  exit 0
-fi
-
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
-  exit 0
-fi
-
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:1.2.3" ]; then
-  exit 0
-fi
-
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
-  exit 0
-fi
-
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "--verbose" ] && [ "$4" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:v1.2.3" ]; then
-  cat <<'JSON'
-[
-  {
-    "OCIManifest": {
-      "config": {
-        "digest": "sha256:testconfigv"
-      }
-    }
-  }
-]
-JSON
-  exit 0
-fi
-
-if [ "$1" = "manifest" ] && [ "$2" = "inspect" ] && [ "$3" = "--verbose" ] && [ "$4" = "ghcr.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
-  cat <<'JSON'
-[
-  {
-    "OCIManifest": {
-      "config": {
-        "digest": "sha256:testconfigsemver"
-      }
-    }
-  }
-]
-JSON
+if [ "$1" = "inspect" ] && [ "$2" = "docker.io/jcowhigjr/openclaw-docker-desktop-extension:1.2.3" ]; then
+  printf '%s\n' '[{"Config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}]'
   exit 0
 fi
 
@@ -119,18 +87,6 @@ case "$*" in
     printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
     ;;
   *"https://ghcr.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigsemver"*)
-    printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
-    ;;
-  *"https://auth.docker.io/token?service=registry.docker.io&scope=repository:jcowhigjr/openclaw-docker-desktop-extension:pull"*)
-    printf '%s\n' '{"token":"test-token"}'
-    ;;
-  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/1.2.3"*)
-    printf '%s\n' '{"config":{"digest":"sha256:testconfigdockerhub"}}'
-    ;;
-  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/manifests/sha256:testconfigdockerhub"*)
-    printf '%s\n' '{"config":{"digest":"sha256:testconfigdockerhub"}}'
-    ;;
-  *"https://registry-1.docker.io/v2/jcowhigjr/openclaw-docker-desktop-extension/blobs/sha256:testconfigdockerhub"*)
     printf '%s\n' '{"config":{"Labels":{"org.opencontainers.image.title":"OpenClaw"}}}'
     ;;
   *)

--- a/scripts/verify-release-tag.sh
+++ b/scripts/verify-release-tag.sh
@@ -197,27 +197,17 @@ require_dockerhub_registry_label() {
   label_key="$3"
   expected_value="$4"
 
-  token="$(fetch_dockerhub_token "$repo_path")"
-  manifest_json="$(
-    curl -fsSL \
-      -H "Authorization: Bearer ${token}" \
-      -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
-      "https://registry-1.docker.io/v2/${repo_path}/manifests/${reference}"
-  )"
-  manifest_digest="$(printf '%s' "$manifest_json" | resolve_config_digest)"
-  image_manifest_json="$(
-    curl -fsSL \
-      -H "Authorization: Bearer ${token}" \
-      -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
-      "https://registry-1.docker.io/v2/${repo_path}/manifests/${manifest_digest}"
-  )"
-  config_digest="$(
-    printf '%s' "$image_manifest_json" \
-      | python3 -c 'import json,sys; print(json.load(sys.stdin)["config"]["digest"])'
-  )"
+  image_ref="docker.io/${repo_path}:${reference}"
+
+  if ! docker pull --quiet "${image_ref}" >/dev/null 2>&1; then
+    echo "docker pull failed for ${image_ref}" >&2
+    echo "Next step: confirm Docker Hub login and that the image is publicly accessible." >&2
+    return 1
+  fi
+
   actual_value="$(
-    curl -fsSL -H "Authorization: Bearer ${token}" "https://registry-1.docker.io/v2/${repo_path}/blobs/${config_digest}" \
-      | python3 -c 'import json,sys; obj=json.load(sys.stdin); value=obj.get("config", {}).get("Labels", {}).get(sys.argv[1]); print("" if value is None else value)' "${label_key}"
+    docker inspect "${image_ref}" \
+      | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[0].get("Config",{}).get("Labels",{}).get(sys.argv[1],""))' "${label_key}"
   )"
 
   if [ "$actual_value" = "$expected_value" ]; then


### PR DESCRIPTION
## Problem
`require_dockerhub_registry_label` used anonymous `curl` calls against `registry-1.docker.io` to fetch the config blob and read image labels. Docker Hub returns `401 UNAUTHORIZED` on anonymous blob pulls for personal namespaces.

## Fix
Replace with `docker pull` + `docker inspect`, which uses the local Docker credential helper. Works wherever the image is publicly pullable (which is already verified by `require_anonymous_manifest` earlier in the same script).

Update the title test stub to handle the new `pull`/`inspect` calls.