### PR TITLE
chore: fill LICENSE copyright, add NOTICE and TRADEMARKS.md, add SPDX headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025-2026 John Cowhig Jr.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,38 @@
+OpenClaw Docker Desktop Extension
+Copyright 2025-2026 John Cowhig Jr.
+
+This product is licensed under the Apache License, Version 2.0.
+You may obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+---
+
+This product incorporates software from the OpenClaw project,
+which is licensed under the MIT License:
+
+    Copyright (c) 2026 OpenClaw Foundation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+The upstream OpenClaw project is available at:
+    https://github.com/openclaw/openclaw
+
+This project is not affiliated with or endorsed by the OpenClaw project or the
+OpenClaw Foundation.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -14,3 +14,7 @@ OpenClaw Foundation trademark or logo.
 
 Docker and Docker Desktop are trademarks of Docker, Inc. This project is not
 affiliated with or endorsed by Docker, Inc.
+
+If the holder of any trademark referenced in this file requests a good-faith
+rename or change to reduce confusion, we will make reasonable efforts to
+comply.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,16 @@
+# Trademarks
+
+"OpenClaw" is a trademark or common-law mark of the OpenClaw Foundation or its
+respective owners. This project is not affiliated with, sponsored by, or
+endorsed by the OpenClaw project or the OpenClaw Foundation.
+
+The name "OpenClaw" is used in this repository solely to describe the upstream
+software that this Docker Desktop extension wraps, as permitted for factual
+identification of a dependency under Apache License 2.0 §6.
+
+The `openclaw.svg` icon and the visual design of this extension are original
+works Copyright 2025-2026 John Cowhig Jr. and are not derived from any
+OpenClaw Foundation trademark or logo.
+
+Docker and Docker Desktop are trademarks of Docker, Inc. This project is not
+affiliated with or endorsed by Docker, Inc.

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.title="OpenClaw Docker Desktop Extension Runtime"
     org.opencontainers.image.description="OpenClaw runtime wrapper with a localhost bridge for the Docker Desktop extension." \
     org.opencontainers.image.vendor="jcowhigjr/openclaw-docker-desktop-extension" \
     org.opencontainers.image.source="https://github.com/jcowhigjr/openclaw-docker-desktop-extension" \
-    org.opencontainers.image.licenses="MIT"
+    org.opencontainers.image.licenses="MIT AND Apache-2.0"
 
 USER root
 

--- a/runtime/openclaw-bridge.sh
+++ b/runtime/openclaw-bridge.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025-2026 John Cowhig Jr.
 set -eu
 
 tmp_dir="/tmp/openclaw-$(id -u)"

--- a/runtime/openclaw-extension-helper.js
+++ b/runtime/openclaw-extension-helper.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 
 const fs = require('fs');
 const path = require('path');

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import LaunchIcon from '@mui/icons-material/Launch';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import StopIcon from '@mui/icons-material/Stop';

--- a/ui/src/controlUiLaunch.test.ts
+++ b/ui/src/controlUiLaunch.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { buildControlUiLaunchUrl } from './controlUiLaunch';

--- a/ui/src/controlUiLaunch.ts
+++ b/ui/src/controlUiLaunch.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export function buildControlUiLaunchUrl(baseUrl: string, token: string): string {
   const trimmedBaseUrl = baseUrl.trim();
   const trimmedToken = token.trim();

--- a/ui/src/debugLog.test.ts
+++ b/ui/src/debugLog.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { appendDebugEntry, formatDebugEntry } from './debugLog';

--- a/ui/src/debugLog.ts
+++ b/ui/src/debugLog.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 const DEFAULT_DEBUG_LOG_LIMIT = 12000;
 
 export function formatDebugEntry(entry: string, date = new Date()): string {

--- a/ui/src/dockerDesktopClient.ts
+++ b/ui/src/dockerDesktopClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 
 import { createDemoDDClient, isDemoModeSearch, type DemoDockerDesktopClient } from './dockerDesktopDemoClient';

--- a/ui/src/dockerDesktopDemoClient.test.ts
+++ b/ui/src/dockerDesktopDemoClient.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { createDemoDDClient, isDemoModeSearch } from './dockerDesktopDemoClient';

--- a/ui/src/dockerDesktopDemoClient.ts
+++ b/ui/src/dockerDesktopDemoClient.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 type DemoExecResult = {
   stdout: string;
   stderr: string;

--- a/ui/src/dockerExec.test.ts
+++ b/ui/src/dockerExec.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { buildRuntimeHelperArgs } from './dockerExec';

--- a/ui/src/dockerExec.ts
+++ b/ui/src/dockerExec.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 const RUNTIME_HELPER_PATH = '/usr/local/bin/openclaw-extension-helper.js';
 
 export function buildRuntimeHelperArgs(command: string, args: string[] = []): string[] {

--- a/ui/src/execMode.test.ts
+++ b/ui/src/execMode.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/ui/src/execMode.ts
+++ b/ui/src/execMode.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type ExecutionMode = 'safer' | 'full';
 
 export type JsonObject = Record<string, unknown>;

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { DockerMuiV6ThemeProvider } from '@docker/docker-mui-theme';
 import CssBaseline from '@mui/material/CssBaseline';
 import React from 'react';

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type OllamaModel = {
   name: string;
   size?: number;

--- a/ui/src/requirementChecks.test.ts
+++ b/ui/src/requirementChecks.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type PortConflict = {
   id: string;
   name: string;

--- a/ui/src/runtimeContainer.test.ts
+++ b/ui/src/runtimeContainer.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { buildRuntimeRunArgs } from './runtimeContainer';

--- a/ui/src/runtimeContainer.ts
+++ b/ui/src/runtimeContainer.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 type RuntimeRunArgsOptions = {
   containerName: string;
   image: string;

--- a/ui/src/runtimeUpdate.test.ts
+++ b/ui/src/runtimeUpdate.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/ui/src/runtimeUpdate.ts
+++ b/ui/src/runtimeUpdate.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type UpdatePolicy = 'check-only' | 'auto-before-launch';
 
 export type RuntimeUpdateCheckResult = {

--- a/ui/src/tokenRetry.test.ts
+++ b/ui/src/tokenRetry.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { readGatewayTokenWithRetry } from './tokenRetry';

--- a/ui/src/tokenRetry.ts
+++ b/ui/src/tokenRetry.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type GatewayTokenRetryOptions = {
   attempts: number;
   delayMs: number;

--- a/ui/src/tokenStatus.test.ts
+++ b/ui/src/tokenStatus.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { getGatewayTokenHelperText } from './tokenStatus';

--- a/ui/src/tokenStatus.ts
+++ b/ui/src/tokenStatus.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export type TokenStatus = 'unknown' | 'checking' | 'ready' | 'empty' | 'error';
 
 export function getGatewayTokenHelperText(token: string, tokenStatus: TokenStatus): string {

--- a/ui/src/updateActionButton.test.ts
+++ b/ui/src/updateActionButton.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, expect, it } from 'vitest';
 
 import { updateActionButtonSx } from './updateActionButton';

--- a/ui/src/updateActionButton.ts
+++ b/ui/src/updateActionButton.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 export const updateActionButtonSx = {
   bgcolor: 'info.main',
   color: 'common.white',


### PR DESCRIPTION
## Summary

Closes licensing and attribution gaps before making the extension public / Marketplace submission.

### Changes

**Commit 1 — licensing core:**
- `LICENSE` — fill Apache-2.0 placeholder: `Copyright 2025-2026 John Cowhig Jr.`
- `NOTICE` — new file; reproduces upstream MIT copyright verbatim from `openclaw/openclaw` (satisfies Apache-2.0 §4(d)); asserts authorship of the wrapper
- `TRADEMARKS.md` — new file; clarifies OpenClaw and Docker trademark status; asserts original authorship of the SVG icon; adds good-faith rename commitment
- `runtime/Dockerfile` — correct license label from `MIT` → `MIT AND Apache-2.0` (SPDX compound: upstream base is MIT, added bridge layer is Apache-2.0)
- `runtime/openclaw-bridge.sh`, `runtime/openclaw-extension-helper.js` — add `SPDX-License-Identifier: Apache-2.0` + copyright header
- `ui/src/*.ts` / `ui/src/*.tsx` (14 files) — add SPDX + copyright header to all original source files

**Commit 2 — review feedback:**
- `ui/src/*.test.ts` (12 files) — add SPDX + copyright header to test files (tests are copyrightable originals)
- `TRADEMARKS.md` — add good-faith rename sentence

### Out of scope
The `scripts/verify-release-tag.sh` + `scripts/test-verify-release-tag-title.sh` refactor (curl → docker pull+inspect) was already merged separately in #122 and is not part of this PR.

### Upstream NOTICE verification
Upstream `openclaw/openclaw` LICENSE text confirmed verbatim at time of commit:
`Copyright (c) 2026 OpenClaw Foundation` — matches NOTICE exactly.

### Verification
All pre-push checks pass: `make test-pre-push` (43 tests, metadata, security, dry-run checks)