### PR TITLE
docs: sync submission readiness guide to v0.3.5

### DIFF
--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -24,10 +24,14 @@ Use this path for a 5-10 minute functional review on macOS with Docker Desktop.
 The extension is not listed in the Docker Extensions Marketplace yet, so this
 review path uses the GHCR stable channel.
 
+Current validated release/install tag: `v0.3.5`.
+Latest committed manual stable-channel smoke packet: `v0.3.4` at
+`docs/exploratory/2026-05-22-stable-channel-smoke/`.
+
 If you want a timestamped evidence packet before starting, run:
 
 ```bash
-make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.4
+make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.5
 ```
 
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
@@ -64,7 +68,7 @@ Maintainer release-channel validation:
 
 ```bash
 make verify-channel-install RELEASE_CHANNEL=stable
-make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.4
+make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.5
 ```
 
 Use `DRY_RUN=1` when you want to validate command construction without mutating Docker Desktop.


### PR DESCRIPTION
## Summary
- update `docs/submission-readiness.md` to use the current validated release tag `v0.3.5`
- keep the last manual stable-channel smoke packet reference explicit as the existing `v0.3.4` evidence
- align maintainer verification examples with the current `stable -> v0.3.5` release mapping

## Verification
- `make test-pre-push`
- `make verify-release-tag RELEASE_TAG=v0.3.5`
- `make verify-release-install RELEASE_TAG=v0.3.5`
- `make verify-release-channel RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.5`

Contributes to #86.
