### PR TITLE
chore: constrain grouped UI dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,10 @@ updates:
       ui-dependencies:
         patterns:
           - "*"
+        # Keep grouped UI update PRs compatible with Docker's extension theme peer range.
+        update-types:
+          - "minor"
+          - "patch"
 
   # Ensure security updates for UI npm packages appear immediately
   - package-ecosystem: "npm_and_yarn"


### PR DESCRIPTION
## Summary
- Limit Dependabot's grouped UI dependency PRs to minor and patch updates.
- Keep the existing explicit major-version ignores for MUI/React packages.
- Prevent grouped PRs like #125 from proposing MUI 9 while @docker/docker-mui-theme still peers with MUI 5-6.

## Evidence
- #125 failed Build and Dependency audit at npm ci because @docker/docker-mui-theme@0.0.13 requires @mui/material >=5 <=6, but the grouped update proposed @mui/material@9.0.1.
- GitHub Dependabot docs state group update-types can limit grouped updates to minor/patch/major, and a group includes all SemVer levels by default.

## Verification
- ruby -e 'require yaml; YAML.load_file(.github/dependabot.yml)'
- make test-pre-push

Contributes to #65.