### PR TITLE
fix(ui): tolerate unset model path in Ollama detect (#129)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -161,7 +161,7 @@ export function App() {
   const [configuredOllamaModel, setConfiguredOllamaModel] = useState('');
   const [ollamaChecking, setOllamaChecking] = useState(false);
   const [ollamaStatus, setOllamaStatus] = useState('');
-  const [ollamaAlertSeverity, setOllamaAlertSeverity] = useState<'success' | 'info' | 'error'>('info');
+  const [ollamaAlertSeverity, setOllamaAlertSeverity] = useState<'success' | 'info' | 'warning' | 'error'>('info');
   const [ollamaBannerDismissed, setOllamaBannerDismissed] = useState(
     () => window.localStorage.getItem(OLLAMA_BANNER_DISMISS_KEY) === 'true',
   );
@@ -599,6 +599,7 @@ export function App() {
       // is unset and `config get` exits non-zero. That must not abort detection
       // or be reported as an Ollama reachability failure.
       let currentModel = '';
+      let modelReadWarning = '';
       try {
         const currentModelResult = (await ddClient.docker.cli.exec('exec', [
           container.id,
@@ -614,6 +615,9 @@ export function App() {
         if (isConfigPathMissing(modelText)) {
           appendDebug('ollama detect: no model configured yet (agents.defaults.model.primary unset)');
         } else {
+          // Unexpected read failure (e.g. malformed config, permission error):
+          // models are still valid, but surface it rather than silently succeed.
+          modelReadWarning = modelText;
           appendDebug(`ollama detect: could not read configured model: ${modelText}`);
         }
       }
@@ -621,12 +625,18 @@ export function App() {
       setOllamaModels(models);
       setConfiguredOllamaModel(currentModel);
       setSelectedOllamaModel((current) => current || currentModel || chooseRecommendedOllamaModel(models));
-      setOllamaAlertSeverity(models.length > 0 ? 'success' : 'info');
-      setOllamaStatus(
+
+      const baseStatus =
         models.length > 0
           ? `Detected ${models.length} host Ollama model${models.length === 1 ? '' : 's'}${currentModel ? `; configured model is ${currentModel}.` : '.'}`
-          : 'Host Ollama responded, but no models were installed.',
-      );
+          : 'Host Ollama responded, but no models were installed.';
+      if (modelReadWarning) {
+        setOllamaAlertSeverity('warning');
+        setOllamaStatus(`${baseStatus} Could not read the currently configured model: ${modelReadWarning}`);
+      } else {
+        setOllamaAlertSeverity(models.length > 0 ? 'success' : 'info');
+        setOllamaStatus(baseStatus);
+      }
     } catch (err) {
       const text = formatUnknownError(err);
       appendDebug(`ollama detect failed: ${text}`);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,7 @@ import { getDDClient, isDemoMode } from './dockerDesktopClient';
 import {
   buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
+  isConfigPathMissing,
   normalizeOllamaModelName,
   parseOllamaTags,
   type OllamaModel,
@@ -593,15 +594,30 @@ export function App() {
       }
 
       const models = parseOllamaTags(asText(result.stdout));
-      const currentModelResult = (await ddClient.docker.cli.exec('exec', [
-        container.id,
-        'node',
-        'openclaw.mjs',
-        'config',
-        'get',
-        'agents.defaults.model.primary',
-      ])) as CliExecResult;
-      const currentModel = normalizeOllamaModelName(asText(currentModelResult.stdout));
+
+      // Reading the configured model is best-effort: on a fresh install the path
+      // is unset and `config get` exits non-zero. That must not abort detection
+      // or be reported as an Ollama reachability failure.
+      let currentModel = '';
+      try {
+        const currentModelResult = (await ddClient.docker.cli.exec('exec', [
+          container.id,
+          'node',
+          'openclaw.mjs',
+          'config',
+          'get',
+          'agents.defaults.model.primary',
+        ])) as CliExecResult;
+        currentModel = normalizeOllamaModelName(asText(currentModelResult.stdout));
+      } catch (modelErr) {
+        const modelText = formatUnknownError(modelErr);
+        if (isConfigPathMissing(modelText)) {
+          appendDebug('ollama detect: no model configured yet (agents.defaults.model.primary unset)');
+        } else {
+          appendDebug(`ollama detect: could not read configured model: ${modelText}`);
+        }
+      }
+
       setOllamaModels(models);
       setConfiguredOllamaModel(currentModel);
       setSelectedOllamaModel((current) => current || currentModel || chooseRecommendedOllamaModel(models));

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -9,6 +9,7 @@ import {
   buildOllamaProviderPatch,
   buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
+  isConfigPathMissing,
   mergeOllamaProviderConfig,
   normalizeOllamaModelName,
   parseOllamaTags,
@@ -35,6 +36,21 @@ describe('ollamaSetup helpers', () => {
   it('treats invalid Ollama tags output as no detected models', () => {
     expect(parseOllamaTags('<html>not json</html>')).toEqual([]);
     expect(parseOllamaTags('ollama request timed out')).toEqual([]);
+  });
+
+  it('detects an unset config path from openclaw config get output', () => {
+    expect(isConfigPathMissing('Config path not found: agents.defaults.model.primary')).toBe(true);
+    expect(isConfigPathMissing('  Config path not found: agents.defaults.model.primary\n')).toBe(true);
+  });
+
+  it('does not treat a configured model or empty output as a missing path', () => {
+    expect(isConfigPathMissing('ollama/qwen3.5:latest')).toBe(false);
+    expect(isConfigPathMissing('')).toBe(false);
+    expect(isConfigPathMissing('some unrelated error')).toBe(false);
+  });
+
+  it('keeps an unconfigured model name empty when normalized', () => {
+    expect(normalizeOllamaModelName('')).toBe('');
   });
 
   it('builds a native Ollama provider patch for OpenClaw', () => {

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -43,6 +43,11 @@ describe('ollamaSetup helpers', () => {
     expect(isConfigPathMissing('  Config path not found: agents.defaults.model.primary\n')).toBe(true);
   });
 
+  it('matches the config-path-missing message regardless of casing', () => {
+    expect(isConfigPathMissing('config path not found: agents.defaults.model.primary')).toBe(true);
+    expect(isConfigPathMissing('Error: CONFIG PATH NOT FOUND')).toBe(true);
+  });
+
   it('does not treat a configured model or empty output as a missing path', () => {
     expect(isConfigPathMissing('ollama/qwen3.5:latest')).toBe(false);
     expect(isConfigPathMissing('')).toBe(false);

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -149,7 +149,7 @@ export function normalizeOllamaModelName(model: string): string {
 // is not set yet (fresh install with no model configured). That is an expected
 // state, not an Ollama reachability failure.
 export function isConfigPathMissing(text: string): boolean {
-  return text.includes('Config path not found');
+  return text.toLowerCase().includes('config path not found');
 }
 
 function isJsonObject(value: unknown): value is JsonObject {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -145,6 +145,13 @@ export function normalizeOllamaModelName(model: string): string {
   return trimmed.startsWith('ollama/') ? trimmed.slice('ollama/'.length) : trimmed;
 }
 
+// `openclaw config get` exits non-zero with this message when the requested path
+// is not set yet (fresh install with no model configured). That is an expected
+// state, not an Ollama reachability failure.
+export function isConfigPathMissing(text: string): boolean {
+  return text.includes('Config path not found');
+}
+
 function isJsonObject(value: unknown): value is JsonObject {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }


### PR DESCRIPTION
Closes #129.

## Problem

`detectOllamaModels` ran two chained execs: a curl to `host.docker.internal:11434/api/tags` (reachability) and `openclaw config get agents.defaults.model.primary` (current model). On a fresh install the config path is unset, so `config get` exits non-zero, the exec throws, and the whole detect block aborted **before** `setOllamaModels(models)` — leaving the dropdown empty and mislabeling a config-read failure as "Could not reach host Ollama". Ollama reachability was never the issue.

## Change

- `ui/src/ollamaSetup.ts` — new `isConfigPathMissing()` classifier.
- `ui/src/App.tsx` (`detectOllamaModels`) — model-read exec wrapped in its own try/catch; unset path → empty model + info debug line, no throw. Models populate regardless. Outer "Could not reach host Ollama" now only fires on a genuine tags-fetch/exec failure.
- `ui/src/ollamaSetup.test.ts` — classifier + empty-model normalization tests.

## Test artifacts

**Typecheck** (`npx tsc --noEmit`): clean, no output.

**Unit tests** (`npx vitest run`):
```
 Test Files  12 passed (12)
      Tests  46 passed (46)
   Duration  332ms
```

New `ollamaSetup` cases:
```
 RUN  v4.1.7
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Production build** (`npm run build`):
```
✓ 914 modules transformed.
build/index.html                  0.38 kB │ gzip:   0.26 kB
build/assets/index-Cqm2i29R.js  398.76 kB │ gzip: 124.50 kB
✓ built in 142ms
```

## Adversarial review request

Please attack these higher-risk / high-use areas rather than rubber-stamp:

1. **`detectOllamaModels` error partitioning** (`ui/src/App.tsx`) — the core behavior change. Does the inner try/catch correctly let *only* a real tags-fetch/container failure reach the outer "Could not reach host Ollama" path? Any error that should still surface but is now swallowed? Consider: container running but `openclaw.mjs` missing, malformed stdout, exec timeout, non-`config-path` non-zero exit.
2. **`isConfigPathMissing` (substring match)** — `text.includes('Config path not found')` is intentionally loose. Risk of false positives masking unrelated errors that happen to contain that phrase? Should it anchor to the path name? Argue both sides.
3. **Empty-model semantics downstream** — `currentModel = ''` now flows into `setSelectedOllamaModel((cur) => cur || currentModel || chooseRecommendedOllamaModel(models))` and the status string. Verify no path treats `''` as a valid configured model or writes it back to config.
4. **Detect is a high-use entry point** — first thing users click in Local Model Setup. Confirm the change can't leave the UI in a stuck/checking state (the `finally { setOllamaChecking(false) }` still covers the new branch).

Out of scope, tracked separately: structured per-step tracing — #130.