### PR TITLE
fix(ui): distinguish unreadable /api/tags response from empty model list (#132)

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -593,7 +593,22 @@ export function App() {
         appendDebug(`ollama detect stderr: ${stderr}`);
       }
 
-      const models = parseOllamaTags(asText(result.stdout));
+      const tags = parseOllamaTags(asText(result.stdout));
+      if (!tags.ok) {
+        // The tags fetch succeeded at the transport level but the body was not a
+        // readable model list. Surface that distinctly from "no models installed".
+        appendDebug(`ollama detect: unreadable /api/tags response (${tags.reason})`);
+        setOllamaModels([]);
+        setConfiguredOllamaModel('');
+        setOllamaAlertSeverity('warning');
+        setOllamaStatus(
+          tags.reason === 'empty'
+            ? 'Host Ollama returned an empty response. Confirm Ollama is serving the model API and try again.'
+            : 'Host Ollama returned an unexpected response that could not be read as a model list.',
+        );
+        return;
+      }
+      const models = tags.models;
 
       // Reading the configured model is best-effort: on a fresh install the path
       // is unset and `config get` exits non-zero. That must not abort detection

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -596,16 +596,28 @@ export function App() {
       const tags = parseOllamaTags(asText(result.stdout));
       if (!tags.ok) {
         // The tags fetch succeeded at the transport level but the body was not a
-        // readable model list. Surface that distinctly from "no models installed".
+        // readable model list. Surface that distinctly from "no models installed",
+        // and clear stale selection so Apply cannot run against a vanished model.
         appendDebug(`ollama detect: unreadable /api/tags response (${tags.reason})`);
         setOllamaModels([]);
         setConfiguredOllamaModel('');
+        setSelectedOllamaModel('');
         setOllamaAlertSeverity('warning');
-        setOllamaStatus(
-          tags.reason === 'empty'
-            ? 'Host Ollama returned an empty response. Confirm Ollama is serving the model API and try again.'
-            : 'Host Ollama returned an unexpected response that could not be read as a model list.',
-        );
+        let unreadableStatus: string;
+        switch (tags.reason) {
+          case 'empty':
+            unreadableStatus =
+              'Host Ollama returned an empty response. Confirm Ollama is serving the model API and try again.';
+            break;
+          case 'invalid':
+            unreadableStatus = 'Host Ollama returned an unexpected response that could not be read as a model list.';
+            break;
+          default:
+            unreadableStatus = ((reason: never) => `Host Ollama returned an unreadable response (${reason}).`)(
+              tags.reason,
+            );
+        }
+        setOllamaStatus(unreadableStatus);
         return;
       }
       const models = tags.models;
@@ -656,6 +668,8 @@ export function App() {
       const text = formatUnknownError(err);
       appendDebug(`ollama detect failed: ${text}`);
       setOllamaModels([]);
+      setConfiguredOllamaModel('');
+      setSelectedOllamaModel('');
       setOllamaAlertSeverity('error');
       setOllamaStatus(`Could not reach host Ollama from OpenClaw: ${text}`);
     } finally {

--- a/ui/src/dockerDesktopDemoClient.ts
+++ b/ui/src/dockerDesktopDemoClient.ts
@@ -48,6 +48,18 @@ export function createDemoDDClient(): DemoDockerDesktopClient {
       return { stdout: '', stderr: '' };
     }
 
+    if (command === 'exec' && args.some((arg) => arg.includes('/api/tags'))) {
+      return {
+        stdout: JSON.stringify({
+          models: [
+            { name: 'llama3.2:latest', size: 2019393189 },
+            { name: 'qwen3.5:latest', size: 6594474711 },
+          ],
+        }),
+        stderr: '',
+      };
+    }
+
     if (command === 'exec' && args.includes('agents.defaults.model.primary')) {
       return { stdout: 'llama3.2:latest\n', stderr: '' };
     }

--- a/ui/src/dockerDesktopDemoClient.ts
+++ b/ui/src/dockerDesktopDemoClient.ts
@@ -48,7 +48,7 @@ export function createDemoDDClient(): DemoDockerDesktopClient {
       return { stdout: '', stderr: '' };
     }
 
-    if (command === 'exec' && args.some((arg) => arg.includes('/api/tags'))) {
+    if (command === 'exec' && args.some((arg) => arg.endsWith('/api/tags'))) {
       return {
         stdout: JSON.stringify({
           models: [

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -17,7 +17,7 @@ import {
 
 describe('ollamaSetup helpers', () => {
   it('parses installed Ollama models from the host tags API', () => {
-    const models = parseOllamaTags(
+    const result = parseOllamaTags(
       JSON.stringify({
         models: [
           { name: 'qwen3.5:latest', size: 6594474711 },
@@ -27,15 +27,28 @@ describe('ollamaSetup helpers', () => {
       }),
     );
 
-    expect(models).toEqual([
-      { name: 'qwen3.5:latest', size: 6594474711 },
-      { name: 'gemma4-fast:latest', size: 9608350718 },
-    ]);
+    expect(result).toEqual({
+      ok: true,
+      models: [
+        { name: 'qwen3.5:latest', size: 6594474711 },
+        { name: 'gemma4-fast:latest', size: 9608350718 },
+      ],
+    });
   });
 
-  it('treats invalid Ollama tags output as no detected models', () => {
-    expect(parseOllamaTags('<html>not json</html>')).toEqual([]);
-    expect(parseOllamaTags('ollama request timed out')).toEqual([]);
+  it('treats a valid response with zero models as a successful empty list', () => {
+    expect(parseOllamaTags(JSON.stringify({ models: [] }))).toEqual({ ok: true, models: [] });
+  });
+
+  it('flags an unparseable tags body as invalid, distinct from an empty list', () => {
+    expect(parseOllamaTags('<html>not json</html>')).toEqual({ ok: false, reason: 'invalid' });
+    expect(parseOllamaTags('ollama request timed out')).toEqual({ ok: false, reason: 'invalid' });
+    expect(parseOllamaTags(JSON.stringify({ models: 'nope' }))).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('flags an empty tags body distinctly from a parse failure', () => {
+    expect(parseOllamaTags('')).toEqual({ ok: false, reason: 'empty' });
+    expect(parseOllamaTags('   \n')).toEqual({ ok: false, reason: 'empty' });
   });
 
   it('detects an unset config path from openclaw config get output', () => {

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -44,6 +44,8 @@ describe('ollamaSetup helpers', () => {
     expect(parseOllamaTags('<html>not json</html>')).toEqual({ ok: false, reason: 'invalid' });
     expect(parseOllamaTags('ollama request timed out')).toEqual({ ok: false, reason: 'invalid' });
     expect(parseOllamaTags(JSON.stringify({ models: 'nope' }))).toEqual({ ok: false, reason: 'invalid' });
+    expect(parseOllamaTags('\uFEFF{}')).toEqual({ ok: false, reason: 'invalid' });
+    expect(parseOllamaTags('{"models": [')).toEqual({ ok: false, reason: 'invalid' });
   });
 
   it('flags an empty tags body distinctly from a parse failure', () => {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -27,20 +27,28 @@ type OllamaTagsResponse = {
   }>;
 };
 
-export function parseOllamaTags(stdout: string): OllamaModel[] {
+// Result of parsing an Ollama /api/tags body. A valid response with zero
+// models (`ok: true, models: []`) is deliberately distinct from a missing body
+// (`reason: 'empty'`) or an unparseable/wrong-shape body (`reason: 'invalid'`),
+// so callers can avoid reporting a corrupt response as "no models installed".
+export type OllamaTagsResult =
+  | { ok: true; models: OllamaModel[] }
+  | { ok: false; reason: 'empty' | 'invalid' };
+
+export function parseOllamaTags(stdout: string): OllamaTagsResult {
   if (!stdout.trim()) {
-    return [];
+    return { ok: false, reason: 'empty' };
   }
 
   let payload: OllamaTagsResponse;
   try {
     payload = JSON.parse(stdout) as OllamaTagsResponse;
   } catch {
-    return [];
+    return { ok: false, reason: 'invalid' };
   }
 
   if (!Array.isArray(payload.models)) {
-    return [];
+    return { ok: false, reason: 'invalid' };
   }
 
   const models: OllamaModel[] = [];
@@ -58,7 +66,7 @@ export function parseOllamaTags(stdout: string): OllamaModel[] {
     models.push(model);
   }
 
-  return models;
+  return { ok: true, models };
 }
 
 export function buildOllamaProviderPatch(model: string): JsonObject {


### PR DESCRIPTION
Closes #132. **Stacked on #131** (base = `fix/ollama-detect-config-path`) — review/merge #131 first.

## Problem

`parseOllamaTags` returned `[]` on parse-failure, wrong-shape, *and* empty body alike. A corrupt `/api/tags` response (HTML error page, proxy interstitial, truncated body) was therefore indistinguishable from a host with zero models — both showed "Host Ollama responded, but no models were installed."

## Change

- `parseOllamaTags` now returns a discriminated `OllamaTagsResult`:
  `{ ok: true, models } | { ok: false, reason: 'empty' | 'invalid' }`. Valid-but-empty stays `ok:true` (info), distinct from missing body (`empty`) and unparseable/wrong-shape (`invalid`).
- `detectOllamaModels` surfaces a non-ok result as a `warning` with a clear message and early-returns; the `finally` still clears the checking state (no stuck spinner).
- Demo client returns valid `/api/tags` JSON so demo mode lists models instead of tripping the new `invalid` path.
- Tests: models / valid-empty / invalid / empty-body.

## Test artifacts

- `npx tsc --noEmit` — clean.
- `npx vitest run` — **49 passed (12 files)**.
- `npm run build` — ok (`build/assets/index-*.js`, gzip ~124.75 kB).

## Acceptance criteria (from #132)

- [x] Non-empty unparseable body reported distinctly (`warning`), not "no models installed".
- [x] Valid response with zero models still shows the info "no models installed" state.
- [x] `parseOllamaTags` distinguishes parse-failure from empty list (discriminated result).
- [x] Unit tests cover valid+models, valid+empty, invalid/non-JSON body (+ empty body).
- [x] No regression to #129 detection; full suite + typecheck + build green.

## Adversarial review request

Higher-risk areas to attack:
1. **Discriminated-union exhaustiveness** in `detectOllamaModels` — is every `reason` handled, and does the early-return leave any state half-set (models vs configured model vs severity)?
2. **`empty` vs `invalid` classification** — is blank stdout correctly `empty` while a whitespace-only or BOM-prefixed body is handled sanely? Any body that should be `invalid` but slips to `empty` or vice versa?
3. **Demo-mode coupling** — the new `/api/tags` arg match (`arg.includes('/api/tags')`) vs the generic `exec` fallthrough; could it shadow or be shadowed by other demo exec calls?
4. **Stacking on #131** — interaction with the #131 warning path: can both the model-read warning and a tags warning contend for `ollamaStatus`/severity?