### PR TITLE
feat(#130): right-sized observability & actionable diagnostics

### DIFF
--- a/ui/src/App.diag.test.tsx
+++ b/ui/src/App.diag.test.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { readDiagEvents, resetDiagEvents } from './diag/events';
+import { runDetect } from './ollamaDetect';
+
+afterEach(() => resetDiagEvents());
+
+function runnerMock(responses: { tags: { stdout?: string } | Error; config: { stdout?: string } | Error }) {
+  return vi.fn(async (_cmd: string, args: string[]) => {
+    const target = args.some((arg) => arg.includes('/api/tags')) ? responses.tags : responses.config;
+    if (target instanceof Error) {
+      throw target;
+    }
+    return target;
+  });
+}
+
+describe('runDetect diagnostics', () => {
+  it('emits OLM-003 when the tags fetch is unreachable', async () => {
+    const run = runnerMock({ tags: new Error('curl: (7) connection refused'), config: { stdout: '' } });
+    const out = await runDetect({ run, selectedOllamaModel: '' });
+    expect(out.code).toBe('OLM-003');
+    expect(readDiagEvents().some((event) => event.code === 'OLM-003')).toBe(true);
+  });
+
+  it('emits OLM-004 for an empty tags body and clears selection', async () => {
+    const run = runnerMock({ tags: { stdout: '' }, config: { stdout: '' } });
+    const out = await runDetect({ run, selectedOllamaModel: 'llama3.2:latest' });
+    expect(out.code).toBe('OLM-004');
+    expect(out.selectedOllamaModel).toBe('');
+  });
+
+  it('flags a successful-but-stale selection via an invariant snapshot on ok', async () => {
+    const run = runnerMock({
+      tags: { stdout: JSON.stringify({ models: [{ name: 'qwen3.5:latest' }] }) },
+      config: { stdout: '' },
+    });
+    const out = await runDetect({ run, selectedOllamaModel: 'gone:latest' });
+    const terminal = readDiagEvents().at(-1);
+    expect(terminal?.attrs?.selectedInDetectedList).toBe(false);
+    expect(out.selectedOllamaModel).not.toBe('gone:latest');
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,7 +34,10 @@ import {
 import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
-import { resetDiagEvents } from './diag/events';
+import { buildDiagnosticsBundle } from './diag/bundle';
+import { readDiagEvents, resetDiagEvents } from './diag/events';
+import { captureOllamaSnapshot } from './diag/snapshot';
+import { traceAction, type StepFn } from './diag/trace';
 import { useDiagLogText } from './diag/useDiagEvents';
 import { buildRuntimeHelperArgs } from './dockerExec';
 import { readGatewayTokenWithRetry } from './tokenRetry';
@@ -228,72 +231,127 @@ export function App() {
     return parseDockerPublishedPortConflicts(asText(result.stdout), config.port, CONTAINER_NAME);
   }, [asText, config.port, ddClient]);
 
+  const currentOllamaState = useCallback(() => ({
+    phase,
+    busy,
+    ollamaChecking,
+    ollamaStatus,
+    ollamaAlertSeverity,
+    selectedOllamaModel,
+    configuredOllamaModel,
+    models: ollamaModels,
+    actionSeq: 0,
+    appliedSeq: 0,
+  }), [
+    busy,
+    configuredOllamaModel,
+    ollamaAlertSeverity,
+    ollamaChecking,
+    ollamaModels,
+    ollamaStatus,
+    phase,
+    selectedOllamaModel,
+  ]);
+
+  const copyDiagnostics = useCallback(async () => {
+    setError('');
+    let health: string | undefined;
+    try {
+      const container = await findContainer();
+      health = container?.status;
+    } catch {
+      health = undefined;
+    }
+
+    const bundle = buildDiagnosticsBundle(
+      {
+        extensionVersion: 'unknown',
+        runtimeImage: config.image,
+        dockerDesktop: 'unknown',
+        os: navigator.platform,
+      },
+      readDiagEvents(),
+      captureOllamaSnapshot(currentOllamaState()),
+      health,
+    );
+
+    try {
+      await navigator.clipboard.writeText(bundle);
+      setMessage('Diagnostics copied to clipboard.');
+    } catch {
+      setError('Could not copy diagnostics to clipboard.');
+    }
+  }, [config.image, currentOllamaState, findContainer]);
+
   const checkRequirements = useCallback(async () => {
     setRequirementsChecking(true);
     setRequirementsStatus('');
     setRequirementsSeverity('info');
     setError('');
     try {
-      const version = (await ddClient.docker.cli.exec('version', ['--format', '{{.Server.Version}}'])) as CliExecResult;
-      const dockerVersion = asText(version.stdout).trim();
-      if (!dockerVersion) {
-        throw new Error('Docker Desktop responded, but the Docker Engine version was empty.');
-      }
+      await traceAction('requirements.check', async ({ step }) => {
+        const version = (await ddClient.docker.cli.exec('version', ['--format', '{{.Server.Version}}'])) as CliExecResult;
+        const dockerVersion = asText(version.stdout).trim();
+        if (!dockerVersion) {
+          step('docker_version', 'error');
+          throw new Error('Docker Desktop responded, but the Docker Engine version was empty.');
+        }
+        step('docker_version', 'ok', { attrs: { dockerVersion } });
 
-      const conflicts = await findPortConflicts();
-      if (conflicts.length > 0) {
-        appendDebug(`requirements check found port conflict on ${config.port}`);
-        setRequirementsSeverity('warning');
-        setRequirementsStatus(
-          `Docker is ready, but host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port or stop the other container before starting OpenClaw.`,
-        );
-        return;
-      }
+        const conflicts = await findPortConflicts();
+        if (conflicts.length > 0) {
+          step('port_check', 'warning', { attrs: { hostPort: config.port } });
+          setRequirementsSeverity('warning');
+          setRequirementsStatus(
+            `Docker is ready, but host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port or stop the other container before starting OpenClaw.`,
+          );
+          return;
+        }
+        step('port_check', 'ok', { attrs: { hostPort: config.port } });
 
-      if (phase === 'running') {
-        const container = await findContainer();
-        if (container?.state === 'running') {
-          try {
-            await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
-            const ollamaStatus = formatOllamaRequirementStatus({
-              hostPort: config.port,
-              configuredOllamaModel,
-              ollamaReachable: true,
-            });
-            setRequirementsSeverity(ollamaStatus.severity);
-            appendDebug(ollamaStatus.debug);
-            setRequirementsStatus(ollamaStatus.status);
-            return;
-          } catch (err) {
-            const text = formatUnknownError(err);
-            appendDebug(`requirements Ollama check failed: ${text}`);
-            const ollamaStatus = formatOllamaRequirementStatus({
-              hostPort: config.port,
-              configuredOllamaModel,
-              ollamaReachable: false,
-            });
-            setRequirementsSeverity(ollamaStatus.severity);
-            appendDebug(ollamaStatus.debug);
-            setRequirementsStatus(ollamaStatus.status);
-            return;
+        if (phase === 'running') {
+          const container = await findContainer();
+          if (container?.state === 'running') {
+            try {
+              await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
+              const ollamaStatus = formatOllamaRequirementStatus({
+                hostPort: config.port,
+                configuredOllamaModel,
+                ollamaReachable: true,
+              });
+              step('ollama_check', 'ok');
+              setRequirementsSeverity(ollamaStatus.severity);
+              setRequirementsStatus(ollamaStatus.status);
+              return;
+            } catch (err) {
+              const text = formatUnknownError(err);
+              const ollamaStatus = formatOllamaRequirementStatus({
+                hostPort: config.port,
+                configuredOllamaModel,
+                ollamaReachable: false,
+              });
+              step('ollama_check', 'warning', { error: { message: text } });
+              setRequirementsSeverity(ollamaStatus.severity);
+              setRequirementsStatus(ollamaStatus.status);
+              return;
+            }
           }
         }
-      }
 
-      setRequirementsSeverity('success');
-      appendDebug(`requirements check passed: Docker is ready and host port ${config.port} is available`);
-      setRequirementsStatus(
-        `Docker is ready and host port ${config.port} is available. Ollama is only required for Local Model Setup or an ollama/<model> default.`,
-      );
+        step('complete', 'ok');
+        setRequirementsSeverity('success');
+        setRequirementsStatus(
+          `Docker is ready and host port ${config.port} is available. Ollama is only required for Local Model Setup or an ollama/<model> default.`,
+        );
+      });
     } catch (err) {
       const text = formatUnknownError(err);
-      appendDebug(`requirements check failed: ${text}`);
       setRequirementsSeverity('error');
       setRequirementsStatus(formatStartFailure(text, config.port));
     } finally {
       setRequirementsChecking(false);
     }
-  }, [appendDebug, asText, config.port, configuredOllamaModel, ddClient, findContainer, findPortConflicts, phase]);
+  }, [asText, config.port, configuredOllamaModel, ddClient, findContainer, findPortConflicts, phase]);
 
   const fetchGatewayToken = useCallback(async (containerId: string) => {
     const result = (await ddClient.docker.cli.exec('exec', [
@@ -400,19 +458,19 @@ export function App() {
     }
   }, [checkReady, findContainer, readToken]);
 
-  const runAndPoll = useCallback(async () => {
+  const runAndPoll = useCallback(async (step?: StepFn) => {
     for (let attempt = 0; attempt < 20; attempt += 1) {
-      appendDebug(`poll attempt ${attempt + 1}`);
+      step?.('poll_attempt', 'ok', { attrs: { attempt: attempt + 1 } });
       const result = await refresh();
       if (result.ready) {
-        appendDebug('host health check passed');
+        step?.('health_check', 'ok');
         break;
       }
       if (attempt < 19) {
         await new Promise((resolve) => window.setTimeout(resolve, 3000));
       }
     }
-  }, [appendDebug, refresh]);
+  }, [refresh]);
 
   const createOrStart = useCallback(async () => {
     setBusy(true);
@@ -421,59 +479,58 @@ export function App() {
     setPhase('starting');
     setStatusText('Creating OpenClaw container...');
     try {
-      const existing = await findContainer();
-      if (existing) {
-        appendDebug(`found existing container ${existing.id} (${existing.state})`);
-        await ddClient.docker.cli.exec('start', [existing.id]);
-        setStatusText('Starting existing OpenClaw container...');
-      } else {
-        const conflicts = await findPortConflicts();
-        if (conflicts.length > 0) {
-          throw new Error(
-            `Host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port in Settings or stop the other container, then try Start again.`,
-          );
+      await traceAction('container.start', async ({ step }) => {
+        const existing = await findContainer();
+        if (existing) {
+          step('find_existing', 'ok', { attrs: { state: existing.state } });
+          await ddClient.docker.cli.exec('start', [existing.id]);
+          step('docker_start', 'ok');
+          setStatusText('Starting existing OpenClaw container...');
+        } else {
+          const conflicts = await findPortConflicts();
+          if (conflicts.length > 0) {
+            step('port_check', 'error', { code: 'START-001', attrs: { hostPort: config.port } });
+            throw new Error(
+              `Host port ${config.port} is already published by ${conflicts.map((conflict) => conflict.name || conflict.id).join(', ')}. Change the Host Port in Settings or stop the other container, then try Start again.`,
+            );
+          }
+
+          step('docker_run', 'ok', { attrs: { image: config.image } });
+          const result = (await ddClient.docker.cli.exec('run', buildRuntimeRunArgs({
+            containerName: CONTAINER_NAME,
+            image: config.image,
+            volumeName: VOLUME_NAME,
+            hostPort: config.port,
+            bridgePort: BRIDGE_PORT,
+            labels: LABELS,
+          }))) as CliExecResult;
+          const stdout = asText(result.stdout).trim();
+          const stderr = asText(result.stderr).trim();
+
+          await new Promise((resolve) => window.setTimeout(resolve, 1500));
+          const created = await findContainer();
+          if (!created) {
+            step('verify_created', 'error', { error: { message: stderr || stdout || 'container missing' } });
+            throw new Error(
+              stderr ||
+                stdout ||
+                'Docker reported success, but no OpenClaw service container was created.',
+            );
+          }
+          step('verify_created', 'ok');
         }
 
-        appendDebug(`creating container ${CONTAINER_NAME} from ${config.image}`);
-        const result = (await ddClient.docker.cli.exec('run', buildRuntimeRunArgs({
-          containerName: CONTAINER_NAME,
-          image: config.image,
-          volumeName: VOLUME_NAME,
-          hostPort: config.port,
-          bridgePort: BRIDGE_PORT,
-          labels: LABELS,
-        }))) as CliExecResult;
-        const stdout = asText(result.stdout).trim();
-        const stderr = asText(result.stderr).trim();
-        appendDebug(`docker run stdout: ${stdout || '<empty>'}`);
-        if (stderr) {
-          appendDebug(`docker run stderr: ${stderr}`);
-        }
-
-        await new Promise((resolve) => window.setTimeout(resolve, 1500));
-        const created = await findContainer();
-        if (!created) {
-          const ps = (await ddClient.docker.cli.exec('ps', ['-a'])) as CliExecResult;
-          appendDebug(`docker ps -a:\n${asText(ps.stdout).trim()}`);
-          throw new Error(
-            stderr ||
-              stdout ||
-              'Docker reported success, but no OpenClaw service container was created.',
-          );
-        }
-      }
-
-      setMessage('OpenClaw setup started. The first launch can take a minute while socat is installed.');
-      await runAndPoll();
+        setMessage('OpenClaw setup started. The first launch can take a minute while socat is installed.');
+        await runAndPoll(step);
+      });
     } catch (err) {
       setPhase('error');
       const text = formatStartFailure(formatUnknownError(err), config.port);
-      appendDebug(`create/start failed: ${text}`);
       setError(text);
     } finally {
       setBusy(false);
     }
-  }, [appendDebug, asText, config.image, config.port, ddClient, findContainer, findPortConflicts, runAndPoll]);
+  }, [asText, config.image, config.port, ddClient, findContainer, findPortConflicts, runAndPoll]);
 
   const stop = useCallback(async () => {
     setBusy(true);
@@ -497,21 +554,24 @@ export function App() {
     setBusy(true);
     setError('');
     try {
-      const container = await findContainer();
-      if (container) {
-        await ddClient.docker.cli.exec('restart', [container.id]);
-        await runAndPoll();
-      } else {
-        await createOrStart();
-      }
+      await traceAction('container.restart', async ({ step }) => {
+        const container = await findContainer();
+        if (container) {
+          await ddClient.docker.cli.exec('restart', [container.id]);
+          step('docker_restart', 'ok');
+          await runAndPoll(step);
+        } else {
+          step('container_missing', 'warning');
+          await createOrStart();
+        }
+      });
     } catch (err) {
       const text = formatUnknownError(err);
-      appendDebug(`restart failed: ${text}`);
       setError(text);
     } finally {
       setBusy(false);
     }
-  }, [appendDebug, createOrStart, ddClient, findContainer, runAndPoll]);
+  }, [createOrStart, ddClient, findContainer, runAndPoll]);
 
   const remove = useCallback(async () => {
     setBusy(true);
@@ -1215,17 +1275,27 @@ export function App() {
             <Stack spacing={1.5}>
               <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
                 <Typography variant="h5">Debug Output</Typography>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  onClick={() => {
-                    setDebugLog('');
-                    resetDiagEvents();
-                  }}
-                  disabled={!debugLog && !diagLogText}
-                >
-                  Clear Debug
-                </Button>
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<ContentCopyIcon />}
+                    onClick={() => void copyDiagnostics()}
+                  >
+                    Copy Diagnostics
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => {
+                      setDebugLog('');
+                      resetDiagEvents();
+                    }}
+                    disabled={!debugLog && !diagLogText}
+                  >
+                    Clear Debug
+                  </Button>
+                </Stack>
               </Stack>
               <TextField
                 value={diagLogText}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,11 +29,9 @@ import { getDDClient, isDemoMode } from './dockerDesktopClient';
 import {
   buildOllamaTagsFetchArgs,
   chooseRecommendedOllamaModel,
-  isConfigPathMissing,
-  normalizeOllamaModelName,
-  parseOllamaTags,
   type OllamaModel,
 } from './ollamaSetup';
+import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
 import { buildRuntimeHelperArgs } from './dockerExec';
@@ -584,89 +582,20 @@ export function App() {
         throw new Error('Start OpenClaw before detecting local Ollama models.');
       }
 
-      const result = (await ddClient.docker.cli.exec('exec', [
-        container.id,
-        ...buildOllamaTagsFetchArgs(),
-      ])) as CliExecResult;
-      const stderr = asText(result.stderr).trim();
-      if (stderr) {
-        appendDebug(`ollama detect stderr: ${stderr}`);
-      }
+      const output = await runDetect({
+        run: async (cmd, args) => (await ddClient.docker.cli.exec(cmd, args)) as CliExecResult,
+        containerId: container.id,
+        selectedOllamaModel,
+        phase,
+      });
 
-      const tags = parseOllamaTags(asText(result.stdout));
-      if (!tags.ok) {
-        // The tags fetch succeeded at the transport level but the body was not a
-        // readable model list. Surface that distinctly from "no models installed",
-        // and clear stale selection so Apply cannot run against a vanished model.
-        appendDebug(`ollama detect: unreadable /api/tags response (${tags.reason})`);
-        setOllamaModels([]);
-        setConfiguredOllamaModel('');
-        setSelectedOllamaModel('');
-        setOllamaAlertSeverity('warning');
-        let unreadableStatus: string;
-        switch (tags.reason) {
-          case 'empty':
-            unreadableStatus =
-              'Host Ollama returned an empty response. Confirm Ollama is serving the model API and try again.';
-            break;
-          case 'invalid':
-            unreadableStatus = 'Host Ollama returned an unexpected response that could not be read as a model list.';
-            break;
-          default:
-            unreadableStatus = ((reason: never) => `Host Ollama returned an unreadable response (${reason}).`)(
-              tags.reason,
-            );
-        }
-        setOllamaStatus(unreadableStatus);
-        return;
-      }
-      const models = tags.models;
-
-      // Reading the configured model is best-effort: on a fresh install the path
-      // is unset and `config get` exits non-zero. That must not abort detection
-      // or be reported as an Ollama reachability failure.
-      let currentModel = '';
-      let modelReadWarning = '';
-      try {
-        const currentModelResult = (await ddClient.docker.cli.exec('exec', [
-          container.id,
-          'node',
-          'openclaw.mjs',
-          'config',
-          'get',
-          'agents.defaults.model.primary',
-        ])) as CliExecResult;
-        currentModel = normalizeOllamaModelName(asText(currentModelResult.stdout));
-      } catch (modelErr) {
-        const modelText = formatUnknownError(modelErr);
-        if (isConfigPathMissing(modelText)) {
-          appendDebug('ollama detect: no model configured yet (agents.defaults.model.primary unset)');
-        } else {
-          // Unexpected read failure (e.g. malformed config, permission error):
-          // models are still valid, but surface it rather than silently succeed.
-          modelReadWarning = modelText;
-          appendDebug(`ollama detect: could not read configured model: ${modelText}`);
-        }
-      }
-
-      setOllamaModels(models);
-      setConfiguredOllamaModel(currentModel);
-      setSelectedOllamaModel((current) => current || currentModel || chooseRecommendedOllamaModel(models));
-
-      const baseStatus =
-        models.length > 0
-          ? `Detected ${models.length} host Ollama model${models.length === 1 ? '' : 's'}${currentModel ? `; configured model is ${currentModel}.` : '.'}`
-          : 'Host Ollama responded, but no models were installed.';
-      if (modelReadWarning) {
-        setOllamaAlertSeverity('warning');
-        setOllamaStatus(`${baseStatus} Could not read the currently configured model: ${modelReadWarning}`);
-      } else {
-        setOllamaAlertSeverity(models.length > 0 ? 'success' : 'info');
-        setOllamaStatus(baseStatus);
-      }
+      setOllamaModels(output.models);
+      setConfiguredOllamaModel(output.configuredOllamaModel);
+      setSelectedOllamaModel(output.selectedOllamaModel);
+      setOllamaAlertSeverity(output.severity);
+      setOllamaStatus(output.status);
     } catch (err) {
       const text = formatUnknownError(err);
-      appendDebug(`ollama detect failed: ${text}`);
       setOllamaModels([]);
       setConfiguredOllamaModel('');
       setSelectedOllamaModel('');
@@ -675,7 +604,7 @@ export function App() {
     } finally {
       setOllamaChecking(false);
     }
-  }, [appendDebug, asText, ddClient, findContainer]);
+  }, [ddClient, findContainer, phase, selectedOllamaModel]);
 
   const detectExecutionMode = useCallback(async () => {
     setExecutionModeChecking(true);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -34,6 +34,8 @@ import {
 import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
+import { resetDiagEvents } from './diag/events';
+import { useDiagLogText } from './diag/useDiagEvents';
 import { buildRuntimeHelperArgs } from './dockerExec';
 import { readGatewayTokenWithRetry } from './tokenRetry';
 import {
@@ -146,6 +148,7 @@ export function App() {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [debugLog, setDebugLog] = useState('');
+  const diagLogText = useDiagLogText();
   const [requirementsChecking, setRequirementsChecking] = useState(false);
   const [requirementsStatus, setRequirementsStatus] = useState('');
   const [requirementsSeverity, setRequirementsSeverity] = useState<AlertColor>('info');
@@ -1215,14 +1218,17 @@ export function App() {
                 <Button
                   variant="outlined"
                   size="small"
-                  onClick={() => setDebugLog('')}
-                  disabled={!debugLog}
+                  onClick={() => {
+                    setDebugLog('');
+                    resetDiagEvents();
+                  }}
+                  disabled={!debugLog && !diagLogText}
                 >
                   Clear Debug
                 </Button>
               </Stack>
               <TextField
-                value={debugLog}
+                value={diagLogText}
                 multiline
                 minRows={8}
                 fullWidth

--- a/ui/src/diag/bundle.test.ts
+++ b/ui/src/diag/bundle.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import { buildDiagnosticsBundle } from './bundle';
+import { DIAG_SCHEMA_VERSION, type DiagEvent } from './events';
+
+const env = {
+  extensionVersion: '0.3.5',
+  runtimeImage: 'ghcr.io/x:latest',
+  dockerDesktop: '29.5.0',
+  os: 'darwin/arm64',
+};
+const events: DiagEvent[] = [
+  {
+    schema: DIAG_SCHEMA_VERSION,
+    ts: 0,
+    runId: 'r',
+    action: 'ollama.detect',
+    step: 'tags_fetch',
+    outcome: 'error',
+    code: 'OLM-003',
+  },
+];
+
+describe('buildDiagnosticsBundle', () => {
+  it('produces deterministic redacted markdown with versions, events, snapshot', () => {
+    const md = buildDiagnosticsBundle(env, events, { phase: 'running', selectedOllamaModel: '' }, 'Up 3 minutes');
+    expect(md).toContain('## Diagnostics');
+    expect(md).toContain('extensionVersion: 0.3.5');
+    expect(md).toContain('OLM-003');
+    expect(md).toContain('Up 3 minutes');
+  });
+
+  it('degrades gracefully when container health is unavailable', () => {
+    const md = buildDiagnosticsBundle(env, events, {}, undefined);
+    expect(md).toContain('container health: unavailable');
+  });
+
+  it('redacts secrets in event/snapshot text', () => {
+    const md = buildDiagnosticsBundle(env, events, { ollamaStatus: 'token=SAMPLE-VALUE' }, undefined);
+    expect(md).toContain('token=[REDACTED]');
+    expect(md).not.toContain('SAMPLE-VALUE');
+  });
+});

--- a/ui/src/diag/bundle.ts
+++ b/ui/src/diag/bundle.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import type { DiagEvent } from './events';
+import { redact } from './redact';
+
+export type DiagEnv = {
+  extensionVersion: string;
+  runtimeImage: string;
+  dockerDesktop: string;
+  os: string;
+};
+
+export function buildDiagnosticsBundle(
+  env: DiagEnv,
+  events: readonly DiagEvent[],
+  snapshot: Record<string, unknown>,
+  containerHealth: string | undefined,
+): string {
+  const versions = Object.entries(env)
+    .map(([key, value]) => `- ${key}: ${value}`)
+    .join('\n');
+  const snap = Object.entries(snapshot)
+    .map(([key, value]) => `- ${key}: ${redact(String(value))}`)
+    .join('\n');
+  const lines = events
+    .map((event) => {
+      const label = `${event.action}${event.step ? `:${event.step}` : ''}`;
+      const code = event.code ? ` [${event.code}]` : '';
+      const error = event.error ? ` - ${redact(event.error.message)}` : '';
+      return `- [${new Date(event.ts).toISOString()}] ${label} ${event.outcome}${code}${error}`;
+    })
+    .join('\n');
+
+  return [
+    '## Diagnostics',
+    '',
+    '### Versions',
+    versions,
+    '',
+    '### Container health',
+    `container health: ${containerHealth ? redact(containerHealth) : 'unavailable'}`,
+    '',
+    '### State snapshot',
+    snap || '- (none)',
+    '',
+    '### Recent events',
+    lines || '- (none)',
+    '',
+  ].join('\n');
+}

--- a/ui/src/diag/errorCodes.test.ts
+++ b/ui/src/diag/errorCodes.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import { classifyError, classifyOllamaTags, getRemedy } from './errorCodes';
+
+describe('error code registry', () => {
+  it('classifies discriminated tags results into stable codes', () => {
+    expect(classifyOllamaTags({ ok: false, reason: 'empty' }).code).toBe('OLM-004');
+    expect(classifyOllamaTags({ ok: false, reason: 'invalid' }).code).toBe('OLM-005');
+    expect(classifyOllamaTags({ ok: true, models: [] }).code).toBeUndefined();
+  });
+
+  it('classifies an unset config path as informational OLM-001', () => {
+    expect(classifyError('ollama.config_get', 'Config path not found: agents.defaults.model.primary').code).toBe(
+      'OLM-001',
+    );
+  });
+
+  it('falls back to GEN-000 for unmapped failures and always yields a remedy', () => {
+    const c = classifyError('ollama.detect', 'totally unexpected explosion');
+    expect(c.code).toBe('GEN-000');
+    expect(getRemedy(c.code)).toMatch(/copy diagnostics/i);
+  });
+
+  it('exposes a remedy for every registered code', () => {
+    for (const code of ['OLM-001', 'OLM-002', 'OLM-003', 'OLM-004', 'OLM-005', 'GEN-000']) {
+      expect(getRemedy(code)).toBeTruthy();
+    }
+  });
+});

--- a/ui/src/diag/errorCodes.test.ts
+++ b/ui/src/diag/errorCodes.test.ts
@@ -24,8 +24,19 @@ describe('error code registry', () => {
   });
 
   it('exposes a remedy for every registered code', () => {
-    for (const code of ['OLM-001', 'OLM-002', 'OLM-003', 'OLM-004', 'OLM-005', 'GEN-000']) {
+    for (const code of [
+      'OLM-001',
+      'OLM-002',
+      'OLM-003',
+      'OLM-004',
+      'OLM-005',
+      'START-001',
+      'START-002',
+      'GEN-000',
+    ]) {
       expect(getRemedy(code)).toBeTruthy();
     }
+    expect(getRemedy('START-001')).toMatch(/Host port/);
+    expect(getRemedy('START-002')).toMatch(/Docker Desktop/);
   });
 });

--- a/ui/src/diag/errorCodes.ts
+++ b/ui/src/diag/errorCodes.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { isConfigPathMissing, type OllamaTagsResult } from '../ollamaSetup';
+
+export type DiagCode = 'OLM-001' | 'OLM-002' | 'OLM-003' | 'OLM-004' | 'OLM-005' | 'GEN-000';
+
+type RegistryEntry = {
+  title: string;
+  remedy: string;
+};
+
+const REGISTRY: Record<DiagCode, RegistryEntry> = {
+  'OLM-001': {
+    title: 'No model configured yet',
+    remedy: 'Expected on a fresh install. Pick a detected model and Apply.',
+  },
+  'OLM-002': {
+    title: 'Configured-model read failed',
+    remedy: 'Check the OpenClaw config volume; re-run Detect.',
+  },
+  'OLM-003': {
+    title: 'Host Ollama unreachable',
+    remedy: 'Start Ollama on the host (port 11434), then click Detect.',
+  },
+  'OLM-004': {
+    title: 'Host Ollama returned an empty response',
+    remedy: 'Confirm Ollama is serving the model API, then Detect.',
+  },
+  'OLM-005': {
+    title: 'Host Ollama response unreadable',
+    remedy: 'The /api/tags response was not a model list. Check the Ollama version, then Detect.',
+  },
+  'GEN-000': {
+    title: 'Unexpected error',
+    remedy: 'Copy diagnostics and open a GitHub issue with the bundle.',
+  },
+};
+
+export type Classification = {
+  code?: DiagCode;
+  rawMessage: string;
+};
+
+export function classifyOllamaTags(result: OllamaTagsResult): Classification {
+  if (result.ok) {
+    return { code: undefined, rawMessage: '' };
+  }
+  return { code: result.reason === 'empty' ? 'OLM-004' : 'OLM-005', rawMessage: result.reason };
+}
+
+export function classifyError(context: string, rawMessage: string): { code: DiagCode; rawMessage: string } {
+  if (context === 'ollama.config_get') {
+    if (isConfigPathMissing(rawMessage)) {
+      return { code: 'OLM-001', rawMessage };
+    }
+    return { code: 'OLM-002', rawMessage };
+  }
+  if (context === 'ollama.tags_fetch') {
+    return { code: 'OLM-003', rawMessage };
+  }
+  return { code: 'GEN-000', rawMessage };
+}
+
+export function getRemedy(code: string): string {
+  return REGISTRY[code as DiagCode]?.remedy ?? REGISTRY['GEN-000'].remedy;
+}
+
+export function getTitle(code: string): string {
+  return REGISTRY[code as DiagCode]?.title ?? REGISTRY['GEN-000'].title;
+}

--- a/ui/src/diag/errorCodes.ts
+++ b/ui/src/diag/errorCodes.ts
@@ -2,7 +2,15 @@
 // Copyright 2025-2026 John Cowhig Jr.
 import { isConfigPathMissing, type OllamaTagsResult } from '../ollamaSetup';
 
-export type DiagCode = 'OLM-001' | 'OLM-002' | 'OLM-003' | 'OLM-004' | 'OLM-005' | 'GEN-000';
+export type DiagCode =
+  | 'OLM-001'
+  | 'OLM-002'
+  | 'OLM-003'
+  | 'OLM-004'
+  | 'OLM-005'
+  | 'START-001'
+  | 'START-002'
+  | 'GEN-000';
 
 type RegistryEntry = {
   title: string;
@@ -29,6 +37,14 @@ const REGISTRY: Record<DiagCode, RegistryEntry> = {
   'OLM-005': {
     title: 'Host Ollama response unreadable',
     remedy: 'The /api/tags response was not a model list. Check the Ollama version, then Detect.',
+  },
+  'START-001': {
+    title: 'Host port unavailable',
+    remedy: 'Host port {hostPort} is already in use. Change the Host Port in Settings or stop the other process, then try Start again.',
+  },
+  'START-002': {
+    title: 'Docker Desktop not ready',
+    remedy: 'Docker Desktop is not ready yet. Start Docker Desktop, wait until it finishes starting, then try again.',
   },
   'GEN-000': {
     title: 'Unexpected error',

--- a/ui/src/diag/events.test.ts
+++ b/ui/src/diag/events.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  DIAG_SCHEMA_VERSION,
+  appendDiagEvent,
+  formatDiagEvent,
+  readDiagEvents,
+  resetDiagEvents,
+} from './events';
+
+afterEach(() => resetDiagEvents());
+
+describe('diag events ring buffer', () => {
+  it('appends events and reads them back in order', () => {
+    appendDiagEvent({ ts: 1, runId: 'r1', action: 'a', outcome: 'ok' });
+    appendDiagEvent({ ts: 2, runId: 'r1', action: 'a', step: 's', outcome: 'error', code: 'X-1' });
+    const events = readDiagEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].schema).toBe(DIAG_SCHEMA_VERSION);
+    expect(events[1].code).toBe('X-1');
+  });
+
+  it('caps the ring at the configured limit, dropping oldest', () => {
+    for (let i = 0; i < 250; i += 1) {
+      appendDiagEvent({ ts: i, runId: 'r', action: 'a', outcome: 'ok' });
+    }
+    const events = readDiagEvents();
+    expect(events).toHaveLength(200);
+    expect(events[0].ts).toBe(50);
+    expect(events[199].ts).toBe(249);
+  });
+
+  it('formats an event as a time-prefixed line preserving the legacy shape', () => {
+    const line = formatDiagEvent(
+      {
+        schema: DIAG_SCHEMA_VERSION,
+        ts: 0,
+        runId: 'r',
+        action: 'ollama.detect',
+        step: 'tags_fetch',
+        outcome: 'error',
+        code: 'OLM-003',
+      },
+      new Date(2026, 0, 1, 9, 17, 7),
+    );
+    expect(line).toBe('[09:17:07] ollama.detect:tags_fetch error [OLM-003]');
+  });
+
+  it('reset empties the ring (test isolation)', () => {
+    appendDiagEvent({ ts: 1, runId: 'r', action: 'a', outcome: 'ok' });
+    resetDiagEvents();
+    expect(readDiagEvents()).toEqual([]);
+  });
+});

--- a/ui/src/diag/events.ts
+++ b/ui/src/diag/events.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { formatDebugEntry } from '../debugLog';
+import { exportEvent } from './export';
+
+export const DIAG_SCHEMA_VERSION = 1 as const;
+const RING_LIMIT = 200;
+
+export type DiagOutcome = 'ok' | 'warning' | 'error';
+export type DiagAttrValue = string | number | boolean | string[];
+
+export type DiagEvent = {
+  schema: typeof DIAG_SCHEMA_VERSION;
+  ts: number;
+  runId: string;
+  action: string;
+  step?: string;
+  outcome: DiagOutcome;
+  code?: string;
+  durationMs?: number;
+  attrs?: Record<string, DiagAttrValue>;
+  error?: { message: string; stack?: string };
+};
+
+export type DiagEventInput = Omit<DiagEvent, 'schema'>;
+
+let ring: DiagEvent[] = [];
+const listeners = new Set<() => void>();
+
+export function appendDiagEvent(input: DiagEventInput): DiagEvent {
+  const event: DiagEvent = { schema: DIAG_SCHEMA_VERSION, ...input };
+  ring = [...ring, event].slice(-RING_LIMIT);
+  try {
+    exportEvent(event);
+  } catch {
+    // Export is best-effort; never break the recorder.
+  }
+  listeners.forEach((listener) => listener());
+  return event;
+}
+
+export function readDiagEvents(): readonly DiagEvent[] {
+  return ring;
+}
+
+export function resetDiagEvents(): void {
+  ring = [];
+  listeners.forEach((listener) => listener());
+}
+
+export function subscribeDiagEvents(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function formatDiagEvent(event: DiagEvent, date = new Date(event.ts)): string {
+  const label = event.step ? `${event.action}:${event.step}` : event.action;
+  const code = event.code ? ` [${event.code}]` : '';
+  return formatDebugEntry(`${label} ${event.outcome}${code}`, date);
+}

--- a/ui/src/diag/export.ts
+++ b/ui/src/diag/export.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import type { DiagEvent } from './events';
+
+// Inert by default. A future paid-tier exporter can replace this implementation.
+// Contract: best-effort, async-safe, opt-in, redacted before egress, and never
+// throws into the recorder.
+export function exportEvent(_event: DiagEvent): void {
+  // no-op
+}

--- a/ui/src/diag/redact.test.ts
+++ b/ui/src/diag/redact.test.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import { redact } from './redact';
+
+describe('redact', () => {
+  it('masks bearer tokens and gateway tokens', () => {
+    expect(redact('Authorization: Bearer SAMPLE-VALUE')).toBe('Authorization: Bearer [REDACTED]');
+    expect(redact('token=SAMPLE-VALUE')).toBe('token=[REDACTED]');
+  });
+
+  it('anonymizes absolute home paths', () => {
+    expect(redact('/Users/jane/.openclaw/config.json')).toBe('/Users/~/.openclaw/config.json');
+    expect(redact('/home/bob/work')).toBe('/home/~/work');
+  });
+
+  it('leaves benign text unchanged', () => {
+    expect(redact('Detected 2 host Ollama models.')).toBe('Detected 2 host Ollama models.');
+  });
+});

--- a/ui/src/diag/redact.ts
+++ b/ui/src/diag/redact.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+export function redact(text: string): string {
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._-]+/g, 'Bearer [REDACTED]')
+    .replace(/token=[A-Za-z0-9._-]+/g, 'token=[REDACTED]')
+    .replace(/\/(Users|home)\/[^/\s]+/g, '/$1/~');
+}

--- a/ui/src/diag/resilience.test.ts
+++ b/ui/src/diag/resilience.test.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { appendDiagEvent, resetDiagEvents } from './events';
+import * as exportMod from './export';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetDiagEvents();
+});
+
+it('a throwing exporter never breaks appendDiagEvent', () => {
+  vi.spyOn(exportMod, 'exportEvent').mockImplementation(() => {
+    throw new Error('exporter down');
+  });
+  expect(() => appendDiagEvent({ ts: 1, runId: 'r', action: 'a', outcome: 'ok' })).not.toThrow();
+});

--- a/ui/src/diag/snapshot.test.ts
+++ b/ui/src/diag/snapshot.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import { captureOllamaSnapshot, hasOllamaInvariantViolation } from './snapshot';
+
+const base = {
+  phase: 'running' as const,
+  busy: false,
+  ollamaChecking: false,
+  ollamaStatus: '',
+  ollamaAlertSeverity: 'info' as const,
+  selectedOllamaModel: '',
+  configuredOllamaModel: '',
+  models: [{ name: 'llama3.2:latest' }],
+  actionSeq: 2,
+  appliedSeq: 2,
+};
+
+describe('ollama state snapshot', () => {
+  it('reports modelsCount and list membership', () => {
+    const snap = captureOllamaSnapshot({ ...base, selectedOllamaModel: 'llama3.2:latest' });
+    expect(snap.modelsCount).toBe(1);
+    expect(snap.selectedInDetectedList).toBe(true);
+  });
+
+  it('flags a selection not present in the detected list (the desync bug class)', () => {
+    const state = { ...base, selectedOllamaModel: 'gone:latest' };
+    const snap = captureOllamaSnapshot(state);
+    expect(snap.selectedInDetectedList).toBe(false);
+    expect(hasOllamaInvariantViolation(state)).toBe(true);
+  });
+
+  it('flags a stale (out-of-order) applied sequence', () => {
+    expect(hasOllamaInvariantViolation({ ...base, appliedSeq: 1, actionSeq: 3 })).toBe(true);
+  });
+
+  it('treats an empty selection with an empty list as consistent', () => {
+    expect(hasOllamaInvariantViolation({ ...base, models: [], selectedOllamaModel: '' })).toBe(false);
+  });
+});

--- a/ui/src/diag/snapshot.ts
+++ b/ui/src/diag/snapshot.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import type { OllamaModel } from '../ollamaSetup';
+import type { DiagAttrValue } from './events';
+
+export type OllamaState = {
+  phase: string;
+  busy: boolean;
+  ollamaChecking: boolean;
+  ollamaStatus: string;
+  ollamaAlertSeverity: string;
+  selectedOllamaModel: string;
+  configuredOllamaModel: string;
+  models: OllamaModel[];
+  actionSeq: number;
+  appliedSeq: number;
+};
+
+export type OllamaSnapshot = Record<string, DiagAttrValue>;
+
+export function captureOllamaSnapshot(state: OllamaState): OllamaSnapshot {
+  const names = state.models.map((model) => model.name);
+  return {
+    phase: state.phase,
+    busy: state.busy,
+    ollamaChecking: state.ollamaChecking,
+    ollamaStatus: state.ollamaStatus,
+    ollamaAlertSeverity: state.ollamaAlertSeverity,
+    selectedOllamaModel: state.selectedOllamaModel,
+    configuredOllamaModel: state.configuredOllamaModel,
+    modelsCount: names.length,
+    selectedInDetectedList: state.selectedOllamaModel !== '' && names.includes(state.selectedOllamaModel),
+    configuredInDetectedList: state.configuredOllamaModel !== '' && names.includes(state.configuredOllamaModel),
+    actionSeq: state.actionSeq,
+    appliedSeq: state.appliedSeq,
+  };
+}
+
+export function hasOllamaInvariantViolation(state: OllamaState): boolean {
+  const names = state.models.map((model) => model.name);
+  const selectedDangling = state.selectedOllamaModel !== '' && !names.includes(state.selectedOllamaModel);
+  const staleApply = state.appliedSeq < state.actionSeq;
+  return selectedDangling || staleApply;
+}

--- a/ui/src/diag/trace.test.ts
+++ b/ui/src/diag/trace.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readDiagEvents, resetDiagEvents } from './events';
+import { nextActionSeq, traceAction } from './trace';
+
+afterEach(() => resetDiagEvents());
+
+describe('traceAction', () => {
+  it('emits ordered step events sharing one runId and a terminal outcome', async () => {
+    await traceAction('ollama.detect', async ({ step }) => {
+      step('tags_fetch', 'ok');
+      step('config_get', 'ok');
+    });
+    const events = readDiagEvents();
+    const runIds = new Set(events.map((event) => event.runId));
+    expect(runIds.size).toBe(1);
+    expect(events.map((event) => event.step ?? event.action)).toEqual([
+      'tags_fetch',
+      'config_get',
+      'ollama.detect',
+    ]);
+    const terminal = events[events.length - 1];
+    expect(terminal.outcome).toBe('ok');
+    expect(typeof terminal.durationMs).toBe('number');
+  });
+
+  it('records an error terminal outcome when the body throws and rethrows', async () => {
+    await expect(
+      traceAction('ollama.detect', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+    const terminal = readDiagEvents().at(-1);
+    expect(terminal?.outcome).toBe('error');
+    expect(terminal?.error?.message).toContain('boom');
+  });
+
+  it('mints monotonically increasing action sequence numbers', () => {
+    const a = nextActionSeq();
+    const b = nextActionSeq();
+    expect(b).toBe(a + 1);
+  });
+});

--- a/ui/src/diag/trace.ts
+++ b/ui/src/diag/trace.ts
@@ -27,6 +27,7 @@ export type TraceContext = {
   runId: string;
   actionSeq: number;
   step: StepFn;
+  setTerminalAttrs: (attrs: Record<string, DiagAttrValue>) => void;
 };
 
 function toErrorPayload(error: unknown): { message: string; stack?: string } {
@@ -43,6 +44,7 @@ export async function traceAction<T>(
   const runId = makeRunId();
   const seq = nextActionSeq();
   const started = Date.now();
+  let terminalAttrs: Record<string, DiagAttrValue> = {};
   const step: StepFn = (name, outcome, extra = {}) => {
     appendDiagEvent({
       ts: Date.now(),
@@ -57,14 +59,21 @@ export async function traceAction<T>(
   };
 
   try {
-    const result = await body({ runId, actionSeq: seq, step });
+    const result = await body({
+      runId,
+      actionSeq: seq,
+      step,
+      setTerminalAttrs: (attrs) => {
+        terminalAttrs = attrs;
+      },
+    });
     appendDiagEvent({
       ts: Date.now(),
       runId,
       action,
       outcome: 'ok',
       durationMs: Date.now() - started,
-      attrs: { actionSeq: seq },
+      attrs: { actionSeq: seq, ...terminalAttrs },
     });
     return result;
   } catch (error) {
@@ -74,7 +83,7 @@ export async function traceAction<T>(
       action,
       outcome: 'error',
       durationMs: Date.now() - started,
-      attrs: { actionSeq: seq },
+      attrs: { actionSeq: seq, ...terminalAttrs },
       error: toErrorPayload(error),
     });
     throw error;

--- a/ui/src/diag/trace.ts
+++ b/ui/src/diag/trace.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { appendDiagEvent, type DiagAttrValue, type DiagOutcome } from './events';
+
+let actionSeq = 0;
+
+export function nextActionSeq(): number {
+  actionSeq += 1;
+  return actionSeq;
+}
+
+function makeRunId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export type StepFn = (
+  step: string,
+  outcome: DiagOutcome,
+  extra?: {
+    code?: string;
+    attrs?: Record<string, DiagAttrValue>;
+    error?: { message: string; stack?: string };
+  },
+) => void;
+
+export type TraceContext = {
+  runId: string;
+  actionSeq: number;
+  step: StepFn;
+};
+
+function toErrorPayload(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) {
+    return { message: error.message, stack: error.stack };
+  }
+  return { message: String(error) };
+}
+
+export async function traceAction<T>(
+  action: string,
+  body: (context: TraceContext) => Promise<T> | T,
+): Promise<T> {
+  const runId = makeRunId();
+  const seq = nextActionSeq();
+  const started = Date.now();
+  const step: StepFn = (name, outcome, extra = {}) => {
+    appendDiagEvent({
+      ts: Date.now(),
+      runId,
+      action,
+      step: name,
+      outcome,
+      attrs: { actionSeq: seq, ...extra.attrs },
+      code: extra.code,
+      error: extra.error,
+    });
+  };
+
+  try {
+    const result = await body({ runId, actionSeq: seq, step });
+    appendDiagEvent({
+      ts: Date.now(),
+      runId,
+      action,
+      outcome: 'ok',
+      durationMs: Date.now() - started,
+      attrs: { actionSeq: seq },
+    });
+    return result;
+  } catch (error) {
+    appendDiagEvent({
+      ts: Date.now(),
+      runId,
+      action,
+      outcome: 'error',
+      durationMs: Date.now() - started,
+      attrs: { actionSeq: seq },
+      error: toErrorPayload(error),
+    });
+    throw error;
+  }
+}

--- a/ui/src/diag/useDiagEvents.test.ts
+++ b/ui/src/diag/useDiagEvents.test.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, expect, it } from 'vitest';
+
+import { appendDiagEvent, resetDiagEvents } from './events';
+import { getDiagLogText } from './useDiagEvents';
+
+afterEach(() => resetDiagEvents());
+
+it('renders the ring as a newline-joined, time-prefixed log', () => {
+  appendDiagEvent({
+    ts: new Date(2026, 0, 1, 9, 17, 7).getTime(),
+    runId: 'r',
+    action: 'ollama.detect',
+    step: 'tags_fetch',
+    outcome: 'error',
+    code: 'OLM-003',
+  });
+  expect(getDiagLogText()).toContain('] ollama.detect:tags_fetch error [OLM-003]');
+});

--- a/ui/src/diag/useDiagEvents.ts
+++ b/ui/src/diag/useDiagEvents.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { useSyncExternalStore } from 'react';
+
+import { formatDiagEvent, readDiagEvents, subscribeDiagEvents } from './events';
+
+export function getDiagLogText(): string {
+  return readDiagEvents().map((event) => formatDiagEvent(event)).join('\n');
+}
+
+export function useDiagLogText(): string {
+  return useSyncExternalStore(subscribeDiagEvents, getDiagLogText, getDiagLogText);
+}

--- a/ui/src/ollamaDetect.concurrency.test.ts
+++ b/ui/src/ollamaDetect.concurrency.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { readDiagEvents, resetDiagEvents } from './diag/events';
+import { runDetect } from './ollamaDetect';
+
+afterEach(() => resetDiagEvents());
+
+it('assigns increasing action sequence numbers to overlapping detects', async () => {
+  const slow = (ms: number, stdout: string) =>
+    vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      return { stdout };
+    });
+  const a = runDetect({
+    run: slow(30, JSON.stringify({ models: [{ name: 'a:latest' }] })),
+    selectedOllamaModel: '',
+  });
+  const b = runDetect({
+    run: slow(5, JSON.stringify({ models: [{ name: 'b:latest' }] })),
+    selectedOllamaModel: '',
+  });
+  await Promise.all([a, b]);
+  const terminalCount = readDiagEvents().filter(
+    (event) => event.action === 'ollama.detect' && event.outcome === 'ok' && event.step === undefined,
+  ).length;
+  expect(terminalCount).toBe(2);
+});

--- a/ui/src/ollamaDetect.ts
+++ b/ui/src/ollamaDetect.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import {
+  buildOllamaTagsFetchArgs,
+  chooseRecommendedOllamaModel,
+  normalizeOllamaModelName,
+  parseOllamaTags,
+  type OllamaModel,
+} from './ollamaSetup';
+import { classifyError, classifyOllamaTags, getRemedy, getTitle } from './diag/errorCodes';
+import { captureOllamaSnapshot, hasOllamaInvariantViolation } from './diag/snapshot';
+import { traceAction } from './diag/trace';
+
+type CommandResult = { stdout?: string; stderr?: string };
+type CommandRunner = (cmd: string, args: string[]) => Promise<CommandResult>;
+
+export type DetectInput = {
+  run: CommandRunner;
+  containerId?: string;
+  selectedOllamaModel?: string;
+  phase?: string;
+};
+
+export type DetectOutput = {
+  models: OllamaModel[];
+  configuredOllamaModel: string;
+  selectedOllamaModel: string;
+  severity: 'success' | 'info' | 'warning' | 'error';
+  status: string;
+  code?: string;
+};
+
+const asText = (value: unknown) => (typeof value === 'string' ? value : '');
+
+export async function runDetect(input: DetectInput): Promise<DetectOutput> {
+  const containerId = input.containerId ?? 'test-container';
+  const initialSelected = input.selectedOllamaModel ?? '';
+
+  return traceAction('ollama.detect', async ({ step, actionSeq, setTerminalAttrs }) => {
+    const finalize = (params: {
+      models: OllamaModel[];
+      configured: string;
+      selected: string;
+      severity: DetectOutput['severity'];
+      status: string;
+      code?: string;
+    }): DetectOutput => {
+      let selected = params.selected;
+      if (selected !== '' && !params.models.some((model) => model.name === selected)) {
+        selected = '';
+      }
+
+      const state = {
+        phase: input.phase ?? 'running',
+        busy: false,
+        ollamaChecking: false,
+        ollamaStatus: params.status,
+        ollamaAlertSeverity: params.severity,
+        selectedOllamaModel: selected,
+        configuredOllamaModel: params.configured,
+        models: params.models,
+        actionSeq,
+        appliedSeq: actionSeq,
+      };
+      const snapshot = captureOllamaSnapshot(state);
+      setTerminalAttrs(snapshot);
+      if (params.severity !== 'success' || hasOllamaInvariantViolation(state)) {
+        step('snapshot', params.severity === 'error' ? 'error' : 'warning', { attrs: snapshot });
+      }
+
+      return {
+        models: params.models,
+        configuredOllamaModel: params.configured,
+        selectedOllamaModel: selected,
+        severity: params.severity,
+        status: params.status,
+        code: params.code,
+      };
+    };
+
+    let tagsStdout: string;
+    try {
+      const result = await input.run('exec', [containerId, ...buildOllamaTagsFetchArgs()]);
+      tagsStdout = asText(result.stdout);
+      step('tags_fetch', 'ok');
+    } catch (error) {
+      const raw = error instanceof Error ? error.message : String(error);
+      const classification = classifyError('ollama.tags_fetch', raw);
+      step('tags_fetch', 'error', { code: classification.code, error: { message: raw } });
+      return finalize({
+        models: [],
+        configured: '',
+        selected: '',
+        severity: 'error',
+        status: `Could not reach host Ollama from OpenClaw: ${raw} [${classification.code}] ${getRemedy(
+          classification.code,
+        )}`,
+        code: classification.code,
+      });
+    }
+
+    const tags = parseOllamaTags(tagsStdout);
+    if (!tags.ok) {
+      const classification = classifyOllamaTags(tags);
+      const code = classification.code ?? 'OLM-005';
+      step('tags_parse', 'warning', { code });
+      return finalize({
+        models: [],
+        configured: '',
+        selected: '',
+        severity: 'warning',
+        status: `${getTitle(code)} [${code}] ${getRemedy(code)}`,
+        code,
+      });
+    }
+
+    const models = tags.models;
+    let configured = '';
+    try {
+      const result = await input.run('exec', [
+        containerId,
+        'node',
+        'openclaw.mjs',
+        'config',
+        'get',
+        'agents.defaults.model.primary',
+      ]);
+      configured = normalizeOllamaModelName(asText(result.stdout));
+      step('config_get', 'ok');
+    } catch (error) {
+      const raw = error instanceof Error ? error.message : String(error);
+      const classification = classifyError('ollama.config_get', raw);
+      step('config_get', classification.code === 'OLM-001' ? 'ok' : 'warning', {
+        code: classification.code,
+        error: { message: raw },
+      });
+    }
+
+    const selected = initialSelected || configured || chooseRecommendedOllamaModel(models);
+    return finalize({
+      models,
+      configured,
+      selected,
+      severity: models.length > 0 ? 'success' : 'info',
+      status:
+        models.length > 0
+          ? `Detected ${models.length} host Ollama model${models.length === 1 ? '' : 's'}.`
+          : 'Host Ollama responded, but no models were installed.',
+    });
+  });
+}

--- a/ui/src/requirementChecks.ts
+++ b/ui/src/requirementChecks.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2025-2026 John Cowhig Jr.
+import { getRemedy } from './diag/errorCodes';
+
 export type PortConflict = {
   id: string;
   name: string;
@@ -65,11 +67,11 @@ export function parseDockerPublishedPortConflicts(
 
 export function formatStartFailure(message: string, hostPort: number): string {
   if (/port is already allocated|bind for .* failed|address already in use/i.test(message)) {
-    return `Host port ${hostPort} is already in use. Change the Host Port in Settings or stop the other process, then try Start again.`;
+    return getRemedy('START-001').replace('{hostPort}', String(hostPort));
   }
 
   if (/cannot connect to the docker daemon|docker daemon is not running|is the docker daemon running/i.test(message)) {
-    return 'Docker Desktop is not ready yet. Start Docker Desktop, wait until it finishes starting, then try again.';
+    return getRemedy('START-002');
   }
 
   return message;


### PR DESCRIPTION
Closes #130.

## Summary

Implements the approved #130 observability/actionable-diagnostics slice:

- Adds a zero-runtime-dependency structured diagnostics ring buffer with `DiagEvent`, `runId`, `actionSeq`, and formatted Debug Output rendering.
- Adds `traceAction`, stable error-code/remedy registry, Ollama state snapshots, redaction, diagnostics bundle builder, and inert export seam.
- Extracts Ollama detect into a testable `runDetect` core and instruments it with codes, trace steps, and invariant snapshots.
- Adds Copy Diagnostics in the Debug Output panel.
- Migrates requirements check, start, restart, and Ollama detect off the old flat debug append path.

## Verification

Local pre-push gate passed:

```text
Test Files  22 passed (22)
Tests       76 passed (76)
UI build    passed
runtime bridge checks passed
extension metadata checks passed
release dry-run/helper checks passed
secret scan: no leaks found
local security checks passed
```

Focused verification also passed during TDD:

```text
src/diag/events.test.ts                     4 passed
src/diag/trace.test.ts                      3 passed
src/diag/errorCodes.test.ts                 4 passed
src/diag/snapshot.test.ts                   4 passed
src/diag/redact.test.ts                     3 passed
src/diag/bundle.test.ts                     3 passed
src/App.diag.test.tsx                       3 passed
src/ollamaDetect.concurrency.test.ts        1 passed
src/diag/resilience.test.ts                 1 passed
src/diag/useDiagEvents.test.ts              1 passed
```

Browser smoke on local demo (`http://127.0.0.1:4174/?demo=1`):

- Debug Output renders diagnostic ring events.
- Copy Diagnostics button is visible.
- Copy Diagnostics writes a diagnostics bundle to clipboard when browser permission allows it.
- Clipboard failure path is contained and displays an error instead of throwing.

Screenshot evidence: `/Users/temp/.codex/artifacts/openclaw-observability-debug-panel-final.png`

## Adversarial review request

Please attack these areas rather than rubber-stamp:

1. `runDetect` finalize/clear logic: stale selected model clearing, terminal snapshot attrs, and code/status mapping for success, empty, invalid, config missing, and unreachable paths.
2. Error classifier drift: `OLM-*`, `START-*`, and fallback `GEN-000`; verify remedies stay stable and do not obscure real failures.
3. Redaction completeness: bearer tokens, `token=...`, home paths, event errors, snapshots, and container-health text.
4. Concurrency/action sequencing: overlapping detects, terminal event ordering, and whether the current snapshot/actionSeq approach is sufficient for UI-level stale-result visibility.
5. Migration boundary: confirm migrated flows no longer use old `appendDebug`, while unrelated flows were not accidentally refactored.
