### PR TITLE
fix: refresh Ollama setup and runtime latest path

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -16,7 +16,8 @@ permissions:
   packages: write
 
 env:
-  RUNTIME_IMAGE: ghcr.io/${{ github.repository_owner }}/openclaw-docker-extension-runtime
+  RUNTIME_IMAGE: ghcr.io/${{ github.repository_owner }}/openclaw-docker-desktop-extension-runtime
+  LEGACY_RUNTIME_IMAGE: ghcr.io/${{ github.repository_owner }}/openclaw-docker-extension-runtime
 
 jobs:
   build-and-push:
@@ -33,7 +34,9 @@ jobs:
       - uses: docker/metadata-action@v6
         id: meta
         with:
-          images: ${{ env.RUNTIME_IMAGE }}
+          images: |
+            ${{ env.RUNTIME_IMAGE }}
+            ${{ env.LEGACY_RUNTIME_IMAGE }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=sha-,format=short
@@ -46,4 +49,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Verify published runtime image
-        run: docker buildx imagetools inspect "${RUNTIME_IMAGE}:latest"
+        run: |
+          docker buildx imagetools inspect "${RUNTIME_IMAGE}:latest"
+          docker buildx imagetools inspect "${LEGACY_RUNTIME_IMAGE}:latest"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ RELEASE_VERSION ?= $(patsubst v%,%,$(RELEASE_TAG))
 RELEASE_CHANNEL ?= stable
 REPO_OWNER ?= jcowhigjr
 REPO_NAME ?= openclaw-docker-desktop-extension
-REGISTRY_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-extension-runtime
+REGISTRY_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension-runtime
 REGISTRY_TAG ?= latest
 # For release builds, use the tagged registry image. Otherwise use the published latest.
 ifeq ($(RELEASE_TAG),)
   DEFAULT_RUNTIME_IMAGE ?= $(RUNTIME_IMAGE):$(RUNTIME_TAG)
 else
-  DEFAULT_RUNTIME_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-extension-runtime:$(RELEASE_TAG)
+  DEFAULT_RUNTIME_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension-runtime:$(RELEASE_TAG)
 endif
 RELEASE_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_VERSION)
 CHANNEL_EXTENSION_IMAGE ?= ghcr.io/$(GHCR_OWNER)/openclaw-docker-desktop-extension:$(RELEASE_CHANNEL)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ That gives end users a one-line extension install path and gives the extension a
 
 When the runtime image points at a published GHCR channel tag such as `stable` or `beta`, the extension can check for a newer runtime image on open and again before launch.
 
-The standalone runtime publish workflow also refreshes `ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest` on a daily schedule and can still be run manually with `workflow_dispatch`. That scheduled rebuild is how the wrapper picks up new `ghcr.io/openclaw/openclaw:latest` content when this repo has no file changes, so upstream OpenClaw updates become available after the next scheduled runtime rebuild and GHCR push, not instantly at the moment upstream publishes them.
+The standalone runtime publish workflow also refreshes `ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:latest` on a daily schedule and can still be run manually with `workflow_dispatch`. It also publishes the older `ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest` alias for existing local installs. That scheduled rebuild is how the wrapper picks up new `ghcr.io/openclaw/openclaw:latest` content when this repo has no file changes, so upstream OpenClaw updates become available after the next scheduled runtime rebuild and GHCR push, not instantly at the moment upstream publishes them.
 
 The current MVP update policies are:
 

--- a/scripts/test-extension-metadata.sh
+++ b/scripts/test-extension-metadata.sh
@@ -4,6 +4,7 @@ set -eu
 
 dockerfile="${1:-Dockerfile}"
 workflow="${2:-.github/workflows/publish.yml}"
+runtime_workflow="${3:-.github/workflows/publish-runtime.yml}"
 
 require_file_contains() {
   file="$1"
@@ -33,5 +34,8 @@ require_file_contains "$workflow" 'password: ${{ secrets.DOCKERHUB_TOKEN }}' "Do
 require_file_contains "$workflow" 'type=raw,value=${{ env.RELEASE_VERSION }}' "semver image tag alias"
 require_file_contains "$workflow" 'platforms: linux/arm64,linux/amd64' "multi-platform release build"
 require_file_contains "$workflow" 'VITE_DEFAULT_RUNTIME_IMAGE=${{ env.REGISTRY }}/${{ env.RUNTIME_IMAGE_NAME }}:${{ env.RELEASE_VERSION }}' "semver runtime default"
+require_file_contains "$runtime_workflow" 'openclaw-docker-desktop-extension-runtime' "canonical scheduled runtime image target"
+require_file_contains "$runtime_workflow" 'openclaw-docker-extension-runtime' "legacy scheduled runtime alias"
+require_file_contains "$runtime_workflow" '${{ env.LEGACY_RUNTIME_IMAGE }}' "legacy scheduled runtime metadata image"
 
 echo "extension metadata checks passed"

--- a/ui/src/App.diag.test.tsx
+++ b/ui/src/App.diag.test.tsx
@@ -42,4 +42,21 @@ describe('runDetect diagnostics', () => {
     expect(terminal?.attrs?.selectedInDetectedList).toBe(false);
     expect(out.selectedOllamaModel).not.toBe('gone:latest');
   });
+
+  it('treats a missing OpenClaw model config path as unconfigured, not unreachable', async () => {
+    const run = runnerMock({
+      tags: { stdout: JSON.stringify({ models: [{ name: 'gemma4:latest' }] }) },
+      config: new Error(
+        'Config path not found: agents.defaults.model.primary. Run openclaw config validate to inspect config shape.',
+      ),
+    });
+
+    const out = await runDetect({ run, selectedOllamaModel: '' });
+
+    expect(out.severity).toBe('success');
+    expect(out.models).toEqual([{ name: 'gemma4:latest' }]);
+    expect(out.configuredOllamaModel).toBe('');
+    expect(out.selectedOllamaModel).toBe('gemma4:latest');
+    expect(out.status).toBe('Detected 1 host Ollama model.');
+  });
 });

--- a/ui/src/App.state.test.ts
+++ b/ui/src/App.state.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import { ollamaApplyButtonLabel } from './ollamaUiState';
+
+describe('App local model state labels', () => {
+  it('does not report an empty Ollama selection as already applied', () => {
+    expect(ollamaApplyButtonLabel('', false)).toBe('Choose Model');
+  });
+
+  it('distinguishes changed and applied Ollama selections', () => {
+    expect(ollamaApplyButtonLabel('gemma4:latest', true)).toBe('Apply and Restart');
+    expect(ollamaApplyButtonLabel('gemma4:latest', false)).toBe('Already Applied');
+  });
+});

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -31,6 +31,7 @@ import {
   chooseRecommendedOllamaModel,
   type OllamaModel,
 } from './ollamaSetup';
+import { ollamaApplyButtonLabel } from './ollamaUiState';
 import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
@@ -85,7 +86,7 @@ const OLLAMA_BANNER_DISMISS_KEY = 'openclaw-docker-extension-ollama-banner-dismi
 const CONTAINER_NAME = 'openclaw-docker-extension-service';
 const VOLUME_NAME = 'openclaw-docker-extension-home';
 const BRIDGE_PORT = 18790;
-const DEFAULT_RUNTIME_IMAGE = (import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest') as string;
+const DEFAULT_RUNTIME_IMAGE = (import.meta.env.VITE_DEFAULT_RUNTIME_IMAGE || 'ghcr.io/jcowhigjr/openclaw-docker-desktop-extension-runtime:latest') as string;
 const UPDATE_CHECK_INTERVAL_MS = 30 * 60 * 1000;
 const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,
@@ -113,7 +114,10 @@ function loadConfig(): ExtensionConfig {
         if (stored === 'ghcr.io/openclaw/openclaw:latest') {
           return DEFAULT_CONFIG.image;
         }
-        if (stored === 'openclaw-docker-extension-runtime:dev') {
+        if (
+          stored === 'openclaw-docker-extension-runtime:dev' ||
+          stored === 'ghcr.io/jcowhigjr/openclaw-docker-extension-runtime:latest'
+        ) {
           return DEFAULT_CONFIG.image;
         }
         return stored;
@@ -1166,7 +1170,7 @@ export function App() {
                   onClick={() => void applyOllamaSetup()}
                   disabled={busy || phase !== 'running' || !selectedOllamaChanged}
                 >
-                  {selectedOllamaChanged ? 'Apply and Restart' : 'Already Applied'}
+                  {ollamaApplyButtonLabel(selectedOllamaModel, selectedOllamaChanged)}
                 </Button>
               </Stack>
               <TextField

--- a/ui/src/ollamaUiState.ts
+++ b/ui/src/ollamaUiState.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+export function ollamaApplyButtonLabel(selectedModel: string, selectedChanged: boolean): string {
+  if (!selectedModel.trim()) {
+    return 'Choose Model';
+  }
+
+  return selectedChanged ? 'Apply and Restart' : 'Already Applied';
+}


### PR DESCRIPTION
## Summary
- Treat the newer OpenClaw `Config path not found: agents.defaults.model.primary. Run ...` output as an unconfigured Ollama state in regression coverage.
- Fix the Local Model Setup button label so an empty selection says `Choose Model` instead of `Already Applied`.
- Align scheduled upstream runtime rebuilds with the canonical `openclaw-docker-desktop-extension-runtime:latest` image while preserving the legacy latest alias.

## Live diagnosis
- Installed dev extension/runtime were stale: UI image from 2026-05-25 and runtime wrapper from OpenClaw 2026.3.31.
- Rebuilt local runtime from fresh `ghcr.io/openclaw/openclaw:latest` → OpenClaw 2026.6.1.
- Recreated `openclaw-docker-extension-service` from the rebuilt runtime while preserving `openclaw-docker-extension-home`.
- Host Ollama is reachable from inside the container and exposes 7 models.
- Applied `gemma4:latest`; `openclaw models status --json` resolves `ollama/gemma4:latest` with no missing providers.

## Verification
- `cd ui && npx vitest run src/App.diag.test.tsx src/App.state.test.ts src/runtimeUpdate.test.ts && npm run build`
- `make test-pre-push`
- Pre-push hook reran `make test-pre-push` during `git push` and passed.
- Live Docker trace: `/healthz` live, `openclaw config validate` valid, `models status` default/resolved model `ollama/gemma4:latest`.
- Browser demo smoke screenshot: `/Users/temp/.codex/artifacts/openclaw-ollama-refreshed-demo.png`