### PR TITLE
feat(ui): scaffold first-run provider onboarding state

### DIFF
--- a/openspec/changes/add-first-run-provider-onboarding/.openspec.yaml
+++ b/openspec/changes/add-first-run-provider-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/add-first-run-provider-onboarding/design.md
+++ b/openspec/changes/add-first-run-provider-onboarding/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The extension never writes `anthropic` config — that default is baked into the OpenClaw runtime image. The extension only writes provider config when the user manually completes Local Model Setup (`ui/src/ollamaSetup.ts`). So a fresh container starts with OpenClaw's hosted-`anthropic` default, and the first chat fails with `No API key found for provider "anthropic"`.
+
+Current UI relevant code:
+- Quick Start card: `ui/src/App.tsx:928-947` (static steps, no gating).
+- Ollama detection + apply already exist: `detectOllamaModels()` (`ui/src/App.tsx:641`), `runDetect()` (`ui/src/ollamaDetect.ts`), `applyOllamaSetup()` / `buildOllamaProviderPatch()` (`ui/src/ollamaSetup.ts`).
+- Config persistence: `ExtensionConfig` + `loadConfig()`/`persistConfig()` in `ui/src/App.tsx:100`.
+
+Constraint (README): bundling a local inference runtime is out of scope; the supported free path is host Ollama. The detection/apply plumbing already exists and is reused — this change is mostly UI/state orchestration, not new infra.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the provider choice explicit on first run (fork: Free local vs Hosted).
+- Auto-detect host Ollama and pre-select/one-click the free path when a model exists.
+- Replace the silent hosted-`anthropic` fallback with a clear gated state.
+- Give actionable remediation when the free path has no usable model.
+- Persist the choice so onboarding doesn't re-prompt.
+
+**Non-Goals:**
+- Bundling a local model/inference runtime.
+- Writing or validating an Anthropic key beyond capturing it / pointing at OpenClaw's `.env` path (hosted path stays thin).
+- Propagating the Ollama auth profile to non-`main` agents (tracked as a separate change).
+
+## Decisions
+
+**1. Onboarding as a gated UI step driven by persisted state, not a new backend.**
+Add a `providerChoice` field to `ExtensionConfig` (`'unset' | 'ollama' | 'anthropic'`). `loadConfig()` defaults to `'unset'`. The onboarding card renders while `providerChoice === 'unset'` (or when free-local chosen but no model applied). Rationale: reuses existing detect/apply paths; no runtime image changes; reversible via a "change provider" reset.
+- Alternative considered: write a free default automatically with no prompt. Rejected — hides the hosted option and can apply a model the user didn't want; the chosen "fork + auto-detect" keeps the common case one click while staying explicit.
+
+**2. Auto-detect drives pre-selection, not silent apply.**
+On first-run mount, run the existing Ollama detection. If ≥1 model, pre-select Free local and show a one-click "Use <model>" (apply = existing `applyOllamaSetup`). Apply is still an explicit click. Rationale: "Both: fork + auto-detect" decision — one action in the common case, no surprise writes.
+
+**3. Chat gating via UI state, not by inspecting OpenClaw's resolved provider.**
+Gate the "Open Control UI / chat" affordance on `providerChoice !== 'unset'` AND (for ollama) a model applied. We do not try to read OpenClaw's effective provider to decide the gate. Rationale: simpler, deterministic, avoids race with gateway config caching. Trade-off: a user who configures a provider entirely outside the extension still sees the gate until they dismiss it — mitigated by a "I've configured this elsewhere / skip" escape.
+
+**4. Hosted path stays thin.**
+Hosted selection captures the key and points the user at OpenClaw's `.env` (`/home/node/.openclaw/.env`) per README, or defers to OpenClaw's own onboarding. We do not build full anthropic auth management here. Rationale: scope control; the free path is the focus of #141.
+
+**5. New state module for testability.**
+Add `ui/src/firstRunOnboarding.ts` (pure helpers: derive onboarding phase from config + detection result, button labels, gating predicate) with unit tests, mirroring existing `ollamaUiState.ts` / `runtimeUpdate.ts` pattern. Keeps `App.tsx` wiring thin and the logic tested.
+
+## Risks / Trade-offs
+
+- **Existing users get re-prompted** (no `providerChoice` persisted yet) → migrate in `loadConfig()`: if an Ollama default or other provider config already exists, treat `providerChoice` as resolved so upgraders aren't re-onboarded.
+- **Detection latency on first mount** could delay pre-selection → run detection async; render the fork immediately, fill in pre-selection when detection returns.
+- **Gating could block a legitimately-configured user** → always provide a visible "skip / I configured this elsewhere" action that sets `providerChoice` resolved.
+- **Pre-selecting Ollama picks the wrong model** → use existing `chooseRecommendedOllamaModel()` and show the model name in the action so the choice is visible before apply.
+
+## Migration Plan
+
+- Additive config field with a safe default; `loadConfig()` infers resolved state for existing installs (no forced re-onboarding).
+- No runtime image change, no branch-protection/CI impact.
+- Rollback: remove the onboarding gate render and the config field reverts to unused; prior behavior (silent anthropic default) returns.
+
+## Open Questions
+
+- Exact copy/links for the hosted path (do we link OpenClaw onboarding docs vs inline `.env` instructions?).
+- Should "skip" be prominent or tucked away to avoid users bypassing the free path by accident?

--- a/openspec/changes/add-first-run-provider-onboarding/proposal.md
+++ b/openspec/changes/add-first-run-provider-onboarding/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A fresh extension install defaults to the hosted `anthropic` provider, so the first chat fails with `No API key found for provider "anthropic"`. The README promises a free, easy path (~5 minutes from install to chatting), but the supported free path (host Ollama) is entirely manual and undiscoverable, and nothing tells the user that default chat is broken until they configure a provider. New users hit a cryptic error instead of a guided choice. Fixes #141.
+
+## What Changes
+
+- Add a **first-run provider onboarding** step in the extension UI that makes the provider choice explicit before the user can chat:
+  - A fork: **Free local (Ollama)** vs **Hosted (paste Anthropic key)**.
+  - When a host Ollama model is already detected, pre-select Free local and offer one-click apply so the common case is a single action.
+- **Gate first chat**: replace the silent fallback to `anthropic` with a clear "choose a provider / pick a model first" state so the user never sees the raw `No API key found` error as their first experience.
+- Improve the Free-local branch when Ollama is missing or has no model: a prominent, actionable CTA (install Ollama / `ollama pull <model>`) instead of a dead-end.
+- Persist the chosen provider so onboarding does not re-prompt on every open.
+- **Non-goal**: bundling a local inference runtime (out of scope per README); the supported free path remains host Ollama.
+
+## Capabilities
+
+### New Capabilities
+- `first-run-onboarding`: Defines the first-run provider-selection flow, the auto-detect/pre-select behavior, chat-gating until a provider is usable, and the guided remediation when the free path has no model available.
+
+### Modified Capabilities
+<!-- No existing specs in openspec/specs/; nothing to modify. -->
+
+## Impact
+
+- **UI**: `ui/src/App.tsx` (Quick Start card, chat-gating, onboarding state), `ui/src/ollamaSetup.ts` / `ui/src/ollamaDetect.ts` (reuse detection + apply), new onboarding state module + tests.
+- **Persistence**: extension localStorage config (`ExtensionConfig`) gains a provider-choice field.
+- **Behavior**: first-run default no longer silently lands on `anthropic`.
+- **Out of scope / separate change**: Ollama auth profile is written only to the `main` agent, so sub-agents (e.g. `heartbeat`) still fail — tracked as its own change.
+- **Related issues**: #141 (this), plus #139 / #140 from the same triage pass.

--- a/openspec/changes/add-first-run-provider-onboarding/specs/first-run-onboarding/spec.md
+++ b/openspec/changes/add-first-run-provider-onboarding/specs/first-run-onboarding/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: First-run provider selection
+
+On a fresh install (no provider choice persisted), the extension SHALL present a provider-selection step offering exactly two paths — Free local (Ollama) and Hosted (Anthropic API key) — before the user is directed to chat. The system SHALL NOT silently default to the hosted `anthropic` provider.
+
+#### Scenario: Fresh install shows the fork
+
+- **WHEN** the extension loads and no provider choice is persisted
+- **THEN** the onboarding presents a "Free local (Ollama)" option and a "Hosted (paste Anthropic key)" option
+- **AND** neither provider is treated as configured until the user completes one path
+
+#### Scenario: Choice is persisted
+
+- **WHEN** the user completes either onboarding path
+- **THEN** the chosen provider is saved to the extension config
+- **AND** the onboarding step is not shown again on subsequent opens unless the user resets it
+
+### Requirement: Auto-detect and pre-select the free local path
+
+When a host Ollama model is already detected during onboarding, the system SHALL pre-select the Free local path and offer a single action to apply that model as the OpenClaw default.
+
+#### Scenario: Host Ollama model present
+
+- **WHEN** onboarding runs and host Ollama is reachable with at least one installed model
+- **THEN** the Free local path is pre-selected
+- **AND** a one-click "Use <model>" action applies it as the OpenClaw default and marks onboarding complete
+
+#### Scenario: User overrides the pre-selection
+
+- **WHEN** the Free local path is pre-selected but the user chooses Hosted instead
+- **THEN** the Hosted path is followed and no Ollama default is applied
+
+### Requirement: Chat is gated until a usable provider is configured
+
+The extension SHALL NOT surface the raw `No API key found for provider "anthropic"` error as a first-run experience. Until a usable provider is configured, the UI SHALL present a clear "choose a provider / pick a model first" state.
+
+#### Scenario: No provider configured
+
+- **WHEN** the user attempts to open chat and no provider has been configured through onboarding
+- **THEN** the UI shows a clear call-to-action to complete onboarding
+- **AND** the cryptic missing-API-key error is not shown as the primary message
+
+#### Scenario: Free local selected but no model applied
+
+- **WHEN** the user selected Free local but has not yet applied a model
+- **THEN** the UI indicates a model must be selected before chatting
+
+### Requirement: Guided remediation when the free path has no model
+
+When the user chooses Free local but host Ollama is unreachable or has no installed model, the system SHALL present an actionable remediation instead of a dead-end message.
+
+#### Scenario: Ollama not reachable
+
+- **WHEN** the Free local path is chosen and host Ollama cannot be reached
+- **THEN** the UI shows an actionable CTA to install and start Ollama (with a link)
+
+#### Scenario: Ollama reachable but no models installed
+
+- **WHEN** the Free local path is chosen and host Ollama responds with zero installed models
+- **THEN** the UI shows a copyable `ollama pull <model>` command and a re-detect action

--- a/openspec/changes/add-first-run-provider-onboarding/tasks.md
+++ b/openspec/changes/add-first-run-provider-onboarding/tasks.md
@@ -1,0 +1,33 @@
+## 1. Config & state foundation
+
+- [x] 1.1 Add `providerChoice: 'unset' | 'ollama' | 'anthropic'` to `ExtensionConfig` and `DEFAULT_CONFIG` in `ui/src/App.tsx`
+- [ ] 1.2 Update `loadConfig()` to default `providerChoice` to `'unset'`, and infer a resolved choice for existing installs (e.g. an Ollama default already configured) so upgraders are not re-onboarded
+- [x] 1.3 Ensure `persistConfig()` writes the new field
+
+## 2. Pure onboarding logic module (TDD)
+
+- [x] 2.1 Create `ui/src/firstRunOnboarding.ts` with `deriveOnboardingPhase(config, detectionResult)` returning the UI phase (`fork` | `free-needs-model` | `free-ready` | `resolved`)
+- [x] 2.2 Add a `isChatGated(config, ollamaModelApplied)` predicate
+- [x] 2.3 Add button/label helpers (mirror `ollamaUiState.ts` style)
+- [x] 2.4 Write `ui/src/firstRunOnboarding.test.ts` covering each phase, the upgrader-resolved case, and the gating predicate
+
+## 3. Onboarding UI
+
+- [ ] 3.1 Render a first-run provider fork card in `App.tsx` while phase !== `resolved` (Free local vs Hosted), replacing/augmenting the static Quick Start steps at `ui/src/App.tsx:928-947`
+- [ ] 3.2 Run Ollama detection on first-run mount (reuse `detectOllamaModels`/`runDetect`); pre-select Free local and show one-click "Use <model>" (via `chooseRecommendedOllamaModel` + `applyOllamaSetup`) when a model exists
+- [ ] 3.3 Free-local remediation states: actionable CTA + ollama.com link when unreachable; copyable `ollama pull <model>` + re-detect when zero models
+- [ ] 3.4 Hosted path: capture key / point at OpenClaw `.env` per README (thin); mark `providerChoice = 'anthropic'`
+- [ ] 3.5 Add a visible "skip / I configured this elsewhere" action that resolves onboarding
+- [ ] 3.6 On completing either path, set `providerChoice` and persist
+
+## 4. Chat gating
+
+- [ ] 4.1 Gate the chat / Open Control UI affordance on `isChatGated(...)`; show the "choose a provider / pick a model first" CTA instead of letting the raw anthropic error be the first experience
+- [ ] 4.2 Add a "change provider" reset that returns to the fork
+
+## 5. Verification
+
+- [x] 5.1 Run `npm test` / vitest in `ui/` — all new and existing tests green
+- [x] 5.2 Run typecheck + lint/build (`npm run build` in `ui/`)
+- [ ] 5.3 Manual smoke: fresh config (no `providerChoice`) shows fork; Ollama-with-model gives one-click apply then unblocks chat; Ollama-without-model shows pull CTA; hosted path resolves; upgrader with existing Ollama default is NOT re-onboarded
+- [ ] 5.4 Update README onboarding section to match the new first-run flow

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -56,6 +56,7 @@ import {
   parseDockerPublishedPortConflicts,
 } from './requirementChecks';
 import { updateActionButtonSx } from './updateActionButton';
+import { parseProviderChoice, type ProviderChoice } from './firstRunOnboarding';
 
 type ContainerPhase = 'missing' | 'running' | 'stopped' | 'starting' | 'error';
 
@@ -63,6 +64,7 @@ type ExtensionConfig = {
   image: string;
   port: number;
   autoStart: boolean;
+  providerChoice: ProviderChoice;
 };
 
 type ContainerSnapshot = {
@@ -92,6 +94,7 @@ const DEFAULT_CONFIG: ExtensionConfig = {
   image: DEFAULT_RUNTIME_IMAGE,
   port: 18789,
   autoStart: true,
+  providerChoice: 'unset',
 };
 const LABELS = {
   'com.docker.extension.openclaw': 'true',
@@ -124,6 +127,7 @@ function loadConfig(): ExtensionConfig {
       })(),
       port: typeof parsed.port === 'number' && Number.isFinite(parsed.port) ? parsed.port : DEFAULT_CONFIG.port,
       autoStart: parsed.autoStart ?? DEFAULT_CONFIG.autoStart,
+      providerChoice: parseProviderChoice(parsed.providerChoice),
     };
   } catch {
     return DEFAULT_CONFIG;

--- a/ui/src/firstRunOnboarding.test.ts
+++ b/ui/src/firstRunOnboarding.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import { describe, expect, it } from 'vitest';
+
+import {
+  deriveOnboardingPhase,
+  inferProviderChoiceFromExistingState,
+  isChatGated,
+  ollamaOnboardingActionLabel,
+  parseProviderChoice,
+} from './firstRunOnboarding';
+
+describe('firstRunOnboarding', () => {
+  it('defaults unknown persisted provider choices to unset', () => {
+    expect(parseProviderChoice(undefined)).toBe('unset');
+    expect(parseProviderChoice('something-else')).toBe('unset');
+    expect(parseProviderChoice('ollama')).toBe('ollama');
+    expect(parseProviderChoice('anthropic')).toBe('anthropic');
+  });
+
+  it('keeps the persisted provider choice when already set', () => {
+    expect(inferProviderChoiceFromExistingState('anthropic', 'gemma4:latest')).toBe('anthropic');
+    expect(inferProviderChoiceFromExistingState('ollama', '')).toBe('ollama');
+  });
+
+  it('infers ollama for upgraders with an existing configured local model', () => {
+    expect(inferProviderChoiceFromExistingState('unset', 'gemma4:latest')).toBe('ollama');
+  });
+
+  it('returns fork while the provider is still unset', () => {
+    expect(
+      deriveOnboardingPhase({
+        providerChoice: 'unset',
+        configuredOllamaModel: '',
+        ollamaModels: [],
+      }),
+    ).toBe('fork');
+  });
+
+  it('returns free-ready when ollama is chosen and host models are available', () => {
+    expect(
+      deriveOnboardingPhase({
+        providerChoice: 'ollama',
+        configuredOllamaModel: '',
+        ollamaModels: [{ name: 'gemma4:latest' }],
+      }),
+    ).toBe('free-ready');
+  });
+
+  it('returns free-needs-model when ollama is chosen and no models are detected', () => {
+    expect(
+      deriveOnboardingPhase({
+        providerChoice: 'ollama',
+        configuredOllamaModel: '',
+        ollamaModels: [],
+      }),
+    ).toBe('free-needs-model');
+  });
+
+  it('treats configured ollama installs as resolved for upgraders', () => {
+    expect(
+      deriveOnboardingPhase({
+        providerChoice: 'unset',
+        configuredOllamaModel: 'gemma4:latest',
+        ollamaModels: [],
+      }),
+    ).toBe('resolved');
+  });
+
+  it('treats the hosted choice as resolved', () => {
+    expect(
+      deriveOnboardingPhase({
+        providerChoice: 'anthropic',
+        configuredOllamaModel: '',
+        ollamaModels: [],
+      }),
+    ).toBe('resolved');
+  });
+
+  it('gates chat until a provider path is usable', () => {
+    expect(isChatGated('unset', '')).toBe(true);
+    expect(isChatGated('ollama', '')).toBe(true);
+    expect(isChatGated('ollama', 'gemma4:latest')).toBe(false);
+    expect(isChatGated('anthropic', '')).toBe(false);
+  });
+
+  it('formats the ollama onboarding action label from model state', () => {
+    expect(ollamaOnboardingActionLabel('', '')).toBe('Detect Models');
+    expect(ollamaOnboardingActionLabel('gemma4:latest', '')).toBe('Use gemma4:latest');
+    expect(ollamaOnboardingActionLabel('gemma4:latest', 'gemma4:latest')).toBe(
+      'Already Using gemma4:latest',
+    );
+  });
+});

--- a/ui/src/firstRunOnboarding.ts
+++ b/ui/src/firstRunOnboarding.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
+import type { OllamaModel } from './ollamaSetup';
+
+export type ProviderChoice = 'unset' | 'ollama' | 'anthropic';
+
+export type FirstRunOnboardingPhase = 'fork' | 'free-needs-model' | 'free-ready' | 'resolved';
+
+export type FirstRunOnboardingInput = {
+  providerChoice: ProviderChoice;
+  configuredOllamaModel: string;
+  ollamaModels: OllamaModel[];
+};
+
+export function parseProviderChoice(value: unknown): ProviderChoice {
+  return value === 'ollama' || value === 'anthropic' ? value : 'unset';
+}
+
+export function inferProviderChoiceFromExistingState(
+  providerChoice: ProviderChoice,
+  configuredOllamaModel: string,
+): ProviderChoice {
+  if (providerChoice !== 'unset') {
+    return providerChoice;
+  }
+
+  return configuredOllamaModel.trim() ? 'ollama' : 'unset';
+}
+
+export function deriveOnboardingPhase(input: FirstRunOnboardingInput): FirstRunOnboardingPhase {
+  const providerChoice = inferProviderChoiceFromExistingState(
+    input.providerChoice,
+    input.configuredOllamaModel,
+  );
+
+  if (providerChoice === 'anthropic') {
+    return 'resolved';
+  }
+
+  if (providerChoice === 'ollama') {
+    if (input.configuredOllamaModel.trim()) {
+      return 'resolved';
+    }
+
+    return input.ollamaModels.length > 0 ? 'free-ready' : 'free-needs-model';
+  }
+
+  return 'fork';
+}
+
+export function isChatGated(
+  providerChoice: ProviderChoice,
+  configuredOllamaModel: string,
+): boolean {
+  const resolvedChoice = inferProviderChoiceFromExistingState(providerChoice, configuredOllamaModel);
+  if (resolvedChoice === 'unset') {
+    return true;
+  }
+
+  return resolvedChoice === 'ollama' && !configuredOllamaModel.trim();
+}
+
+export function ollamaOnboardingActionLabel(
+  recommendedModel: string,
+  configuredOllamaModel: string,
+): string {
+  const model = recommendedModel.trim();
+  if (!model) {
+    return 'Detect Models';
+  }
+
+  return model === configuredOllamaModel.trim()
+    ? `Already Using ${model}`
+    : `Use ${model}`;
+}


### PR DESCRIPTION
## Summary
- add the `providerChoice` config field and persist it in the extension settings payload
- add a pure `firstRunOnboarding` state module for provider parsing, upgrader inference, onboarding phase derivation, chat gating, and future button labels
- check in the `openspec` proposal/design/spec/tasks packet for #141 and mark the completed foundation tasks

## Verification
- `npm test`
- `npm run build`
- `make test-pre-push`

Contributes to #141.
