### PR TITLE
fix(runtime): set Ollama num_ctx (single-char replies) + force-pull upstream base

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           context: runtime
           file: runtime/Dockerfile
+          pull: true
+          build-args: |
+            OPENCLAW_VERSION=latest
           platforms: linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMAGE ?= openclaw-docker-extension
 TAG ?= dev
 RUNTIME_IMAGE ?= openclaw-docker-extension-runtime
 RUNTIME_TAG ?= dev
+OPENCLAW_VERSION ?= latest
 GHCR_OWNER ?= jcowhigjr
 DOCKERHUB_OWNER ?= jcowhigjr
 RELEASE_TAG ?=
@@ -26,7 +27,7 @@ SCREENSHOT_PATH ?= docs/assets/openclaw-extension-dashboard.png
 .DEFAULT_GOAL := build-extension
 
 build-runtime:
-	docker build -t $(RUNTIME_IMAGE):$(RUNTIME_TAG) -f runtime/Dockerfile runtime
+	docker build --pull --build-arg OPENCLAW_VERSION=$(OPENCLAW_VERSION) -t $(RUNTIME_IMAGE):$(RUNTIME_TAG) -f runtime/Dockerfile runtime
 
 build-extension:
 	docker build --build-arg VITE_DEFAULT_RUNTIME_IMAGE=$(DEFAULT_RUNTIME_IMAGE) --tag=$(IMAGE):$(TAG) .
@@ -39,6 +40,8 @@ update-extension: build-runtime build-extension
 
 publish-runtime:
 	docker buildx build \
+	  --pull \
+	  --build-arg OPENCLAW_VERSION=$(OPENCLAW_VERSION) \
 	  --platform linux/arm64,linux/amd64 \
 	  --tag $(REGISTRY_IMAGE):$(REGISTRY_TAG) \
 	  --push \
@@ -60,6 +63,7 @@ verify-release-channel: ; @RELEASE_CHANNEL="$(RELEASE_CHANNEL)" GHCR_OWNER="$(GH
 
 test-release-channel: ; @./scripts/test-release-channel.sh
 test-runtime-bridge: ; @sh ./scripts/test-runtime-bridge.sh
+test-runtime-base-pull: ; @sh ./scripts/test-runtime-base-pull.sh
 test-extension-metadata: ; @./scripts/test-extension-metadata.sh
 test-release-tag-dry-run: ; @./scripts/test-release-tag-dry-run.sh
 test-verify-release-tag-dockerhub-error: ; @./scripts/test-verify-release-tag-dockerhub-error.sh
@@ -74,7 +78,7 @@ test-docs-landing-page: ; @node ./scripts/test-docs-landing-page.js
 test-security-local: ; @sh ./scripts/test-security-local.sh
 test-ui-screenshot-sync: ; @bash ./scripts/test-ui-screenshot-sync-selftest.sh
 test-ui: ; @cd ui && npm ci && npm test && npm run build
-test-pre-push: test-ui test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-runtime-image-helper test-docs-landing-page test-security-local test-ui-screenshot-sync
+test-pre-push: test-ui test-runtime-bridge test-runtime-base-pull test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-runtime-image-helper test-docs-landing-page test-security-local test-ui-screenshot-sync
 install-hooks: ; @git config core.hooksPath .githooks && chmod +x .githooks/pre-push && echo "installed repo git hooks from .githooks"
 
 verify-release-bundle:
@@ -99,4 +103,4 @@ capture-readme-screenshot:
 create-smoke-report:
 	@REPORT_DATE="$(REPORT_DATE)" RELEASE_CHANNEL="$(RELEASE_CHANNEL)" RELEASE_TAG="$(RELEASE_TAG)" REPORT_DIR="$(REPORT_DIR)" sh ./scripts/create-smoke-report.sh
 
-.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-docs-landing-page test-security-local test-ui-screenshot-sync test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report
+.PHONY: build-runtime build-extension install-dev update-extension publish-runtime install-release update-release install-channel update-channel verify-release-tag verify-release-channel test-release-channel test-runtime-bridge test-runtime-base-pull test-extension-metadata test-release-tag-dry-run test-verify-release-tag-dockerhub-error test-verify-release-tag-title test-release-install-dry-run test-release-channel-dry-run test-verify-release-channel-digest test-create-smoke-report test-runtime-helper test-docs-landing-page test-security-local test-ui-screenshot-sync test-ui test-pre-push install-hooks verify-release-bundle verify-release-install verify-channel-install publish-release ship-release uninstall capture-readme-screenshot create-smoke-report

--- a/docs/upstream-openclaw-issues.md
+++ b/docs/upstream-openclaw-issues.md
@@ -11,47 +11,52 @@ repo via `--pull` + an `OPENCLAW_VERSION` build-arg.
 
 ---
 
-## Issue 1 — Chat renders only the first streamed token (single character)
+## Issue 1 — Single-character replies on native Ollama: num_ctx not sent, Ollama defaults to 4096
 
-**Severity:** high — chat is unusable on the Ollama provider.
-**Affected version observed:** `v2026.6.1`. Likely fixed in `v2026.6.8` (needs confirmation).
+**Severity:** high — chat is unusable on the native Ollama provider unless the user
+manually sets `params.num_ctx`.
+**Affected version confirmed:** `v2026.6.1` and **still present in `v2026.6.8`**
+(reproduced directly — this is NOT a streaming-aggregation bug and was not fixed by
+the version bump).
 
 ### Summary
-With the Ollama provider, an assistant reply renders as a single character/token
-(e.g. `I`) and then stops. Every turn truncates the same way.
+With the native Ollama provider, an assistant reply is a single token (e.g. `Hello`
+/ `I`) and then stops. Every turn truncates the same way.
 
-### Evidence the model and Ollama are NOT at fault
-Calling the same model directly returns full responses, and Ollama streams proper
-incremental deltas:
+### Root cause (proven)
+The native Ollama provider does not send an `options.num_ctx` unless
+`model.params.num_ctx` is explicitly configured (`resolveOllamaNativeNumCtx` returns
+only the configured value). With no `num_ctx`, **Ollama defaults to a 4096-token
+context window.** OpenClaw's injected system prompt is ~4–10k tokens, which fills
+the window and leaves room for ~1 token of generation.
+
+### Evidence
+Reproduced through `openclaw agent` on `v2026.6.8`:
 
 ```
-# Non-streaming /api/chat → full ~569-token answer, done_reason=stop.
-# First token happens to be "I" (from "I apologize...") — exactly the single
-# character surfaced in the OpenClaw UI.
+# No num_ctx configured:
+usage = { "input": 4095, "output": 1, "total": 4096 }   # 4095 + 1 = 4096 exactly
+reply = "Hello"
 
-# Streaming /api/chat deltas are well-formed:
-{"message":{"role":"assistant","content":"Hello"},"done":false}
-{"message":{"role":"assistant","content":"!"},"done":false}
-{"message":{"role":"assistant","content":" How"},"done":false}
-{"message":{"role":"assistant","content":" can"},"done":false}
-{"message":{"role":"assistant","content":" I"},"done":false}
+# With model.params.num_ctx = 32768:
+usage = { "input": 20479, "output": 29, "total": 20508 }
+reply = "Hello to you this afternoon. I hope everything is going well ..."
 ```
 
-### Diagnosis
-OpenClaw's Ollama provider appears to read the **first** stream delta, render it,
-and then stop accumulating the remaining `message.content` deltas. The consistency
-(always exactly one token) rules out random truncation — it points to the
-streaming-aggregation loop terminating after the first chunk.
-
-### Repro
-1. Configure Ollama provider (`baseUrl: http://host.docker.internal:11434`), model `gemma4:latest`.
-2. Send any prompt in chat.
-3. Observe a one-character reply.
+Confirmed at the Ollama layer too — same prompt, `num_ctx` 4096 → `eval_count=1`;
+`num_ctx` 16384 → `eval_count=211`. The model and Ollama streaming are both fine;
+only the missing `num_ctx` is at fault.
 
 ### Ask
-Confirm whether this is the streaming regression fixed between `v2026.6.1` and
-`v2026.6.8`; if not, fix the Ollama stream accumulator to append all deltas until
-`done: true`.
+For the **native** Ollama provider, default `num_ctx` to the model's known context
+window (OpenClaw already tracks `contextWindow`/`maxTokens`; `resolveOllamaNumCtx`
+does exactly this for the compat path) instead of letting Ollama silently cap at
+4096. Optionally warn when the system prompt approaches the resolved `num_ctx`.
+
+### Extension-side mitigation (already applied in this repo)
+`ollamaConfigWrite` now writes `params.num_ctx` (default 32768, overridable via
+`OPENCLAW_OLLAMA_NUM_CTX`) on the model entry, which OpenClaw passes through to
+Ollama. This restores full responses without an upstream change.
 
 ---
 

--- a/docs/upstream-openclaw-issues.md
+++ b/docs/upstream-openclaw-issues.md
@@ -1,0 +1,116 @@
+# Upstream OpenClaw issue reports
+
+These are ready-to-file reports for the **upstream OpenClaw project**
+(`ghcr.io/openclaw/openclaw`), not this extension repo. They were produced while
+debugging the Shellharbor extension against OpenClaw `v2026.6.1`. Evidence was
+gathered against a local Ollama (`gemma4:latest`) backend on 2026-06-17.
+
+The extension-side delivery gap (builds reused a stale `openclaw:latest` base, so
+the streaming fix in `v2026.6.8` never reached users) is fixed separately in this
+repo via `--pull` + an `OPENCLAW_VERSION` build-arg.
+
+---
+
+## Issue 1 — Chat renders only the first streamed token (single character)
+
+**Severity:** high — chat is unusable on the Ollama provider.
+**Affected version observed:** `v2026.6.1`. Likely fixed in `v2026.6.8` (needs confirmation).
+
+### Summary
+With the Ollama provider, an assistant reply renders as a single character/token
+(e.g. `I`) and then stops. Every turn truncates the same way.
+
+### Evidence the model and Ollama are NOT at fault
+Calling the same model directly returns full responses, and Ollama streams proper
+incremental deltas:
+
+```
+# Non-streaming /api/chat → full ~569-token answer, done_reason=stop.
+# First token happens to be "I" (from "I apologize...") — exactly the single
+# character surfaced in the OpenClaw UI.
+
+# Streaming /api/chat deltas are well-formed:
+{"message":{"role":"assistant","content":"Hello"},"done":false}
+{"message":{"role":"assistant","content":"!"},"done":false}
+{"message":{"role":"assistant","content":" How"},"done":false}
+{"message":{"role":"assistant","content":" can"},"done":false}
+{"message":{"role":"assistant","content":" I"},"done":false}
+```
+
+### Diagnosis
+OpenClaw's Ollama provider appears to read the **first** stream delta, render it,
+and then stop accumulating the remaining `message.content` deltas. The consistency
+(always exactly one token) rules out random truncation — it points to the
+streaming-aggregation loop terminating after the first chunk.
+
+### Repro
+1. Configure Ollama provider (`baseUrl: http://host.docker.internal:11434`), model `gemma4:latest`.
+2. Send any prompt in chat.
+3. Observe a one-character reply.
+
+### Ask
+Confirm whether this is the streaming regression fixed between `v2026.6.1` and
+`v2026.6.8`; if not, fix the Ollama stream accumulator to append all deltas until
+`done: true`.
+
+---
+
+## Issue 2 — Workspace file panel shows "Failed to load MEMORY.md" for a not-yet-created file
+
+**Severity:** low (cosmetic, but alarming to users).
+
+### Summary
+The workspace Files panel (`/home/node/.openclaw/workspace`) lists `MEMORY.md`
+and renders **"Failed to load MEMORY.md"** in red. All other workspace files
+(`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`)
+load fine; an earlier render tagged `MEMORY.md` as **"Missing"**.
+
+### Diagnosis
+`MEMORY.md` is created lazily (memory consolidation) and does not exist on a fresh
+workspace. The panel treats an expected-but-absent file as a **load error** rather
+than an empty/uncreated file.
+
+### Expected
+A not-yet-created `MEMORY.md` should render as empty (or "not created yet"), not as
+a load failure.
+
+### Ask
+Distinguish "file absent" from "file present but unreadable" in the workspace file
+loader and render the absent case non-destructively.
+
+---
+
+## Issue 3 — Local-model latency dominated by per-turn prompt re-processing of injected context
+
+**Severity:** medium (UX) — first token takes tens of seconds on local backends.
+
+### Summary
+On local Ollama backends, each turn stalls for tens of seconds before generating.
+The cost is **prompt evaluation (context ingest)**, not generation.
+
+### Evidence (measured, `gemma4:latest`)
+| Phase | Tokens | Time | Rate |
+|---|---|---|---|
+| Prompt eval (context ingest) | 2,822 | 22.1 s | 127 tok/s |
+| Generation | 4 | 0.2 s | 20 tok/s |
+
+The observed chat context was ~4.1k tokens → ~32 s of prompt processing **before
+the first token, every turn**. The injected system context (workspace files —
+`AGENTS.md` alone is 7.7 KB — plus history) is re-evaluated each turn.
+
+### Diagnosis / questions
+- Is a **stable prompt prefix** maintained so Ollama's KV cache can skip
+  re-processing? If anything volatile (timestamp, heartbeat, per-turn token) is
+  injected into the system prefix, it defeats prefix caching and forces full
+  re-evaluation every turn. This is the highest-leverage thing to check.
+- Can the always-on workspace context be trimmed or made opt-in for local models?
+
+### Ask
+1. Ensure the injected system prefix is byte-stable across turns so prompt caching
+   applies.
+2. Consider a "lean context" mode for local/slow backends.
+
+### Workarounds for users (extension side)
+- Use a smaller/faster model (e.g. `gemma4-fast:latest`).
+- Trim `AGENTS.md` / `SOUL.md`.
+- Ensure GPU offload.

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/openclaw/openclaw:latest
+ARG OPENCLAW_VERSION=latest
+FROM ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION}
 
 LABEL org.opencontainers.image.title="OpenClaw Docker Desktop Extension Runtime" \
     org.opencontainers.image.description="OpenClaw runtime wrapper with a localhost bridge for the Docker Desktop extension." \

--- a/runtime/openclaw-extension-helper.js
+++ b/runtime/openclaw-extension-helper.js
@@ -112,6 +112,23 @@ function executionModeConfig(mode) {
   };
 }
 
+// Resolve the Ollama context window size (num_ctx) for the model entry.
+// Without num_ctx, Ollama defaults to a 4096-token context. OpenClaw's injected
+// system prompt is ~4-10k tokens, which fills that window and leaves room for
+// only ~1 token of generation, so chat replies come back as a single character.
+// A larger context (default 32768) restores full responses. Overridable via
+// OPENCLAW_OLLAMA_NUM_CTX, which must parse to a positive finite integer.
+function resolveOllamaNumCtx() {
+  const raw = process.env.OPENCLAW_OLLAMA_NUM_CTX;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) {
+      return n;
+    }
+  }
+  return 32768;
+}
+
 function buildOllamaAuthConfigProfile() {
   return {
     provider: 'ollama',
@@ -180,6 +197,9 @@ function ollamaConfigWrite(model) {
         id: selectedModel,
         name: selectedModel,
         reasoning: false,
+        params: {
+          num_ctx: resolveOllamaNumCtx(),
+        },
       },
     ],
   };

--- a/scripts/test-runtime-base-pull.sh
+++ b/scripts/test-runtime-base-pull.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+dockerfile="${1:-runtime/Dockerfile}"
+makefile="${2:-Makefile}"
+runtime_workflow="${3:-.github/workflows/publish-runtime.yml}"
+
+require_file_contains() {
+  file="$1"
+  pattern="$2"
+  description="$3"
+
+  if ! grep -Fq -e "$pattern" "$file"; then
+    echo "missing ${description}: ${pattern}" >&2
+    return 1
+  fi
+}
+
+require_file_contains "$dockerfile" 'ARG OPENCLAW_VERSION=latest' "parameterized base image build-arg"
+require_file_contains "$dockerfile" 'FROM ghcr.io/openclaw/openclaw:${OPENCLAW_VERSION}' "parameterized base image FROM"
+require_file_contains "$makefile" '--pull' "force-pull flag in runtime build recipes"
+require_file_contains "$makefile" '--build-arg OPENCLAW_VERSION=$(OPENCLAW_VERSION)' "OPENCLAW_VERSION build-arg in runtime build recipes"
+require_file_contains "$runtime_workflow" 'pull: true' "force-pull in publish-runtime workflow"
+
+echo "runtime base pull checks passed"

--- a/scripts/test-runtime-helper.sh
+++ b/scripts/test-runtime-helper.sh
@@ -60,6 +60,13 @@ grep -F 'preserve-socket-token' "$approvals_path" >/dev/null
 env $helper_env node runtime/openclaw-extension-helper.js ollama-config-write qwen3.5:latest
 grep -F '"primary": "ollama/qwen3.5:latest"' "$config_path" >/dev/null
 grep -F '"ollama:manual"' "$config_path" >/dev/null
+# Ollama defaults to a 4096-token context without num_ctx, which truncates
+# OpenClaw replies to ~1 token; the helper must write a large default num_ctx.
+grep -F '"num_ctx": 32768' "$config_path" >/dev/null
+
+# The num_ctx default is overridable via OPENCLAW_OLLAMA_NUM_CTX.
+env $helper_env OPENCLAW_OLLAMA_NUM_CTX=8192 node runtime/openclaw-extension-helper.js ollama-config-write qwen3.5:latest
+grep -F '"num_ctx": 8192' "$config_path" >/dev/null
 
 env $helper_env node runtime/openclaw-extension-helper.js ollama-auth-profiles-write
 grep -F '"key": "ollama-local"' "$auth_profiles_path" >/dev/null

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -323,7 +323,11 @@ export function App() {
     }
   }, [config.image, currentOllamaState, findContainer]);
 
-  const checkRequirements = useCallback(async () => {
+  const checkRequirements = useCallback(async (modelOverride?: string) => {
+    // modelOverride lets callers (e.g. applyOllamaSetup) refresh the banner with a
+    // model that was just written but not yet reflected in configuredOllamaModel
+    // state, since this callback closes over the previous state value.
+    const effectiveOllamaModel = modelOverride ?? configuredOllamaModel;
     setRequirementsChecking(true);
     setRequirementsStatus('');
     setRequirementsSeverity('info');
@@ -356,7 +360,7 @@ export function App() {
               await ddClient.docker.cli.exec('exec', [container.id, ...buildOllamaTagsFetchArgs()]);
               const ollamaStatus = formatOllamaRequirementStatus({
                 hostPort: config.port,
-                configuredOllamaModel,
+                configuredOllamaModel: effectiveOllamaModel,
                 ollamaReachable: true,
               });
               step('ollama_check', 'ok');
@@ -367,7 +371,7 @@ export function App() {
               const text = formatUnknownError(err);
               const ollamaStatus = formatOllamaRequirementStatus({
                 hostPort: config.port,
-                configuredOllamaModel,
+                configuredOllamaModel: effectiveOllamaModel,
                 ollamaReachable: false,
               });
               step('ollama_check', 'warning', { error: { message: text } });
@@ -834,6 +838,10 @@ export function App() {
       persistConfig({ ...config, providerChoice: 'ollama' });
       setOllamaStatus(`Restart complete. OpenClaw is using ${model}.`);
       setMessage(`OpenClaw local model setup applied for ${model}.`);
+      // Refresh the requirements banner so it reflects the newly applied model.
+      // Pass the model explicitly because setConfiguredOllamaModel above has not
+      // yet propagated to checkRequirements' captured state.
+      await checkRequirements(model);
     } catch (err) {
       const text = formatUnknownError(err);
       appendDebug(`ollama setup failed: ${text}`);
@@ -841,7 +849,7 @@ export function App() {
     } finally {
       setBusy(false);
     }
-  }, [appendDebug, config, ddClient, findContainer, persistConfig, restart, selectedOllamaModel]);
+  }, [appendDebug, checkRequirements, config, ddClient, findContainer, persistConfig, restart, selectedOllamaModel]);
 
   const checkForUpdate = useCallback(async () => {
     const image = configImageRef.current;


### PR DESCRIPTION
## Summary

Fixes the bug where local-Ollama chat replies come back as a **single character**, plus a build issue that prevented the runtime from picking up new upstream OpenClaw releases.

### Root cause (single-character replies)
The extension's config helper wrote the Ollama model entry **without `params.num_ctx`**. With no `num_ctx`, Ollama defaults to a **4096-token** context window. OpenClaw's injected system prompt is ~4–10k tokens, which fills the window and leaves room for ~1 token of generation — so replies are one character.

This was misattributed at first to a streaming-aggregation bug "fixed upstream in 2026.6.8". It is **not** — reproduced directly on 2026.6.8.

### Fix
- `runtime/openclaw-extension-helper.js`: `ollamaConfigWrite` now writes `params.num_ctx` on the model entry — default **32768**, overridable via `OPENCLAW_OLLAMA_NUM_CTX`. OpenClaw's native Ollama provider reads `model.params.num_ctx` and passes it to Ollama.
- `runtime/Dockerfile` + `Makefile` + `.github/workflows/publish-runtime.yml`: add `--pull` / `pull: true` and an `OPENCLAW_VERSION` build-arg (default `latest`) so runtime builds always fetch the upstream base instead of reusing a stale cached `openclaw:latest` (which was pinning users to 2026.6.1).
- `docs/upstream-openclaw-issues.md`: upstream reports for the `num_ctx` default, the MEMORY.md "Failed to load" UI bug, and prompt-eval latency.

## Test artifacts

New/extended tests (wired into `test-pre-push`):
```
$ sh ./scripts/test-runtime-base-pull.sh
runtime base pull checks passed
$ sh ./scripts/test-runtime-helper.sh
runtime helper checks passed
```

### End-to-end verification (real `openclaw agent` turn, 2026.6.8, host Ollama, gemma4:latest)
| Config | usage | reply |
|---|---|---|
| no num_ctx (Ollama default 4096) | `input:4095, output:1` | `"Hello"` (the bug) |
| `params.num_ctx: 32768` via helper | `input:20479, output:29` | full multi-sentence reply |

Ollama-layer confirmation (same prompt): `num_ctx` 4096 → `eval_count=1`; `num_ctx` 16384 → `eval_count=211`.

Build fix confirmed: stale local base resolved `2026.6.1`; with `--pull` it resolves `2026.6.8`.

## Request for adversarial review

Please scrutinize especially:
1. **`num_ctx` default (32768)** — RAM/prompt-eval cost trade-off on weak machines vs. truncation risk in long multi-turn sessions if set lower. Is 32768 the right default?
2. **`resolveOllamaNumCtx` validation** — env parsing rejects non-positive / non-finite / non-numeric; confirm no edge case silently falls back to a broken value.
3. **`--pull` always-on** — guarantees fresh upstream but makes builds non-reproducible and can pull a broken upstream; the `OPENCLAW_VERSION` build-arg is the escape hatch. Acceptable?
