### PR TITLE
fix(ui): unbreak Apply-and-Restart (drop sqlite auth step) + warm up Ollama model

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -28,6 +28,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getDDClient, isDemoMode } from './dockerDesktopClient';
 import {
   buildOllamaTagsFetchArgs,
+  buildOllamaWarmupArgs,
   chooseRecommendedOllamaModel,
   type OllamaModel,
 } from './ollamaSetup';
@@ -594,28 +595,52 @@ export function App() {
     }
   }, [appendDebug, ddClient, findContainer, refresh]);
 
-  const restart = useCallback(async () => {
-    setBusy(true);
-    setError('');
-    try {
-      await traceAction('container.restart', async ({ step }) => {
-        const container = await findContainer();
-        if (container) {
-          await ddClient.docker.cli.exec('restart', [container.id]);
-          step('docker_restart', 'ok');
-          await runAndPoll(step);
-        } else {
-          step('container_missing', 'warning');
-          await createOrStart();
-        }
-      });
-    } catch (err) {
-      const text = formatUnknownError(err);
-      setError(text);
-    } finally {
-      setBusy(false);
-    }
-  }, [createOrStart, ddClient, findContainer, runAndPoll]);
+  // Best-effort: preload an Ollama model into memory so the user's first
+  // message after a (re)start doesn't pay the cold-load cost (which otherwise
+  // surfaces as "LLM request timed out"). Fire-and-forget — it never blocks or
+  // fails the calling flow, and is a no-op for a blank model.
+  const warmUpOllamaModel = useCallback(
+    (containerId: string, model: string) => {
+      const args = buildOllamaWarmupArgs(model);
+      if (args.length === 0) {
+        return;
+      }
+      void ddClient.docker.cli
+        .exec('exec', [containerId, ...args])
+        .then(() => appendDebug(`warmed up Ollama model ${model.trim()}`))
+        .catch((err) => appendDebug(`ollama warmup skipped: ${formatUnknownError(err)}`));
+    },
+    [appendDebug, ddClient],
+  );
+
+  const restart = useCallback(
+    async (warmupModel?: string) => {
+      setBusy(true);
+      setError('');
+      try {
+        await traceAction('container.restart', async ({ step }) => {
+          const container = await findContainer();
+          if (container) {
+            await ddClient.docker.cli.exec('restart', [container.id]);
+            step('docker_restart', 'ok');
+            await runAndPoll(step);
+            const modelToWarm =
+              warmupModel ?? (config.providerChoice === 'ollama' ? configuredOllamaModel : '');
+            warmUpOllamaModel(container.id, modelToWarm);
+          } else {
+            step('container_missing', 'warning');
+            await createOrStart();
+          }
+        });
+      } catch (err) {
+        const text = formatUnknownError(err);
+        setError(text);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [config.providerChoice, configuredOllamaModel, createOrStart, ddClient, findContainer, runAndPoll, warmUpOllamaModel],
+  );
 
   const remove = useCallback(async () => {
     setBusy(true);
@@ -826,7 +851,7 @@ export function App() {
       // restart — making "Apply and Restart" neither apply cleanly nor restart.
       appendDebug(`OpenClaw default model set to ollama/${model}`);
       setOllamaStatus(`Configured OpenClaw to use Ollama model ${model}. Restarting OpenClaw...`);
-      await restart();
+      await restart(model);
       setConfiguredOllamaModel(model);
       persistConfig({ ...config, providerChoice: 'ollama' });
       setOllamaStatus(`Restart complete. OpenClaw is using ${model}.`);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -817,20 +817,13 @@ export function App() {
         container.id,
         ...buildRuntimeHelperArgs('ollama-auth-profiles-write'),
       ]);
-      await ddClient.docker.cli.exec('exec', [
-        container.id,
-        'node',
-        'openclaw.mjs',
-        'models',
-        'auth',
-        'order',
-        'set',
-        '--agent',
-        'main',
-        '--provider',
-        'ollama',
-        'ollama:manual',
-      ]);
+      // Auth resolution is entirely file-based: ollama-config-write sets
+      // openclaw.json auth.profiles/order and ollama-auth-profiles-write seeds
+      // each agent's auth-profiles.json, both loaded on the restart below. The
+      // previous `models auth order set` CLI call here targeted a separate
+      // sqlite auth-state store that these writes never populate, so it always
+      // failed ("Auth profile ollama:manual not found") and aborted before the
+      // restart — making "Apply and Restart" neither apply cleanly nor restart.
       appendDebug(`OpenClaw default model set to ollama/${model}`);
       setOllamaStatus(`Configured OpenClaw to use Ollama model ${model}. Restarting OpenClaw...`);
       await restart();

--- a/ui/src/ollamaSetup.test.ts
+++ b/ui/src/ollamaSetup.test.ts
@@ -8,6 +8,7 @@ import {
   buildOllamaAuthProfilesStore,
   buildOllamaProviderPatch,
   buildOllamaTagsFetchArgs,
+  buildOllamaWarmupArgs,
   chooseRecommendedOllamaModel,
   isConfigPathMissing,
   mergeOllamaProviderConfig,
@@ -128,6 +129,29 @@ describe('ollamaSetup helpers', () => {
       '5',
       'http://host.docker.internal:11434/api/tags',
     ]);
+  });
+
+  it('builds Docker SDK-safe argv that preloads a model into host Ollama', () => {
+    expect(buildOllamaWarmupArgs('gemma4-fast:latest')).toEqual([
+      'curl',
+      '-fsS',
+      '--max-time',
+      '120',
+      '-X',
+      'POST',
+      '-H',
+      'Content-Type: application/json',
+      '-d',
+      '{"model":"gemma4-fast:latest","keep_alive":"30m"}',
+      'http://host.docker.internal:11434/api/generate',
+    ]);
+  });
+
+  it('trims the model name when building warmup argv and rejects empty', () => {
+    expect(buildOllamaWarmupArgs('  qwen3.5:latest  ')[9]).toBe(
+      '{"model":"qwen3.5:latest","keep_alive":"30m"}',
+    );
+    expect(buildOllamaWarmupArgs('   ')).toEqual([]);
   });
 
   it('prefers a practical installed local model over the first Ollama result', () => {

--- a/ui/src/ollamaSetup.ts
+++ b/ui/src/ollamaSetup.ts
@@ -137,6 +137,34 @@ export function buildOllamaTagsFetchArgs(): string[] {
   ];
 }
 
+// Build Docker SDK-safe argv that preloads a model into host Ollama. A POST to
+// /api/generate with no prompt and a keep_alive triggers Ollama's documented
+// model-preload: it loads the model into memory and returns immediately. Firing
+// this after a restart means the user's first real message does not pay the
+// cold-load cost (which otherwise shows up as an "LLM request timed out").
+// Returns [] for a blank model so callers can skip the warmup safely.
+export function buildOllamaWarmupArgs(model: string): string[] {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const body = JSON.stringify({ model: trimmed, keep_alive: '30m' });
+  return [
+    'curl',
+    '-fsS',
+    '--max-time',
+    '120',
+    '-X',
+    'POST',
+    '-H',
+    'Content-Type: application/json',
+    '-d',
+    body,
+    `${DEFAULT_OLLAMA_BASE_URL}/api/generate`,
+  ];
+}
+
 export function chooseRecommendedOllamaModel(models: OllamaModel[]): string {
   const installed = new Set(models.map((model) => model.name));
   for (const candidate of RECOMMENDED_MODEL_ORDER) {


### PR DESCRIPTION
## Summary

Follow-up to #154 (squash-merged before these two commits landed). Both are required for the Ollama local-model flow to be usable end-to-end.

### 1. Drop the broken `models auth order set` step from the apply flow
`applyOllamaSetup` ran `openclaw models auth order set`, which targets a **sqlite** auth-state store that the extension's **file-based** writes (`openclaw.json` auth.profiles/order + per-agent `auth-profiles.json`) never populate. It always failed with *"Auth profile ollama:manual not found"*, and the thrown error **aborted the flow before `restart()`** — so "Apply and Restart" neither applied cleanly nor restarted, and users had to click Restart separately. Auth resolution is file-based (per the `propagate-ollama-auth-to-all-agents` design), so the call was redundant as well as broken. Removing it makes "Apply and Restart" do exactly that in one click.

### 2. Warm up the Ollama model after restart
The readiness poll (`checkReady` → `/healthz`) confirms the **gateway** is up but does not cover Ollama's per-model **cold load**, so the first message after a restart could fail with *"LLM request timed out."* Added a best-effort, fire-and-forget preload after restart: a POST to Ollama `/api/generate` with no prompt and `keep_alive=30m` (Ollama's documented model-preload). `applyOllamaSetup` warms the just-applied model; the standalone Restart warms the configured model. Never blocks or fails the restart.

## Test artifacts
```
$ npm test    →  Test Files 24 passed (24) | Tests 98 passed (98)   (+2 new warmup tests)
$ npm run build → tsc + vite build OK
```

### Live, end-to-end verification (OpenClaw 2026.6.8, host Ollama)
- Apply flow without the order-set step: no auth error, gateway ready, agent replied "ready".
- Warm-up: unloaded model → ran the exact warmup command → Ollama returned `done_reason: "load"`, model resident with 30-min keep_alive. The ~13s cold load now happens in the background after readiness, not on the first message.
- Confirmed in the real Control UI: full chat responses on both `main` and `heartbeat` agents (`gemma4-fast:latest`, `qwen3.5:latest`).

## Request for adversarial review
1. `buildOllamaWarmupArgs` — JSON body construction and the 120s curl timeout; confirm fire-and-forget can't leak an unhandled rejection.
2. `restart(warmupModel?)` — the `config.providerChoice === 'ollama'` guard and stale-closure safety for `configuredOllamaModel`.
3. Removing the order-set call — confirm no path depends on the sqlite auth-order store.

## Known follow-up (not addressed here)
Some messages still intermittently time out / need a resend (visible as the ×2/×3 send badges) — appears to be internal Ollama connection/timeout behavior under load, distinct from the single-character bug. Tracked separately.
