### PR TITLE
docs(openspec): add hardware profile design package

### DIFF
--- a/docs/local-model-tuning.md
+++ b/docs/local-model-tuning.md
@@ -1,0 +1,461 @@
+# Local Model Tuning Guide
+
+This guide helps you tune OpenClaw for local Ollama models on constrained hardware. Running large language models locally requires balancing speed, memory, and context size against your hardware capabilities.
+
+## The Core Constraint
+
+OpenClaw has a **120-second idle timeout watchdog** that aborts requests when no tokens are received. On CPU-only hardware, evaluating a large prompt can exceed this limit, causing timeouts before the first token arrives. This guide provides practical workarounds and tuning strategies to work within this constraint.
+
+**Key insight:** No configuration currently available can raise this 120s limit. The strategies below help you stay under it through hardware-appropriate model selection and prompt optimization.
+
+---
+
+## Quick Diagnostic: What Hardware Profile Are You?
+
+| Profile | RAM | GPU | Typical Use Case |
+|---------|-----|-----|------------------|
+| [Light](#light-profile-cpu-only-8-16gb-ram) | 8-16 GB | None | Older laptops, budget desktops |
+| [Balanced](#balanced-profile-apple-silicon-or-16-24gb-ram) | 16-24 GB | Integrated/Apple Silicon | MacBook Air/Pro M1-M4, modern laptops |
+| [Performance](#performance-profile-32gb-ram-dedicated-gpu) | 32+ GB | 8GB+ VRAM | Desktop workstations, gaming PCs |
+
+---
+
+## Light Profile: CPU-Only, 8-16GB RAM
+
+**Target:** Stay under 60-90s prompt evaluation to avoid the 120s timeout.
+
+### Recommended Models
+
+| Model | Parameters | VRAM/RAM | Speed | Notes |
+|-------|------------|----------|-------|-------|
+| `gemma4-fast:latest` | 4B | ~3 GB | Fast | Best choice for light hardware |
+| `qwen2.5:3b` | 3B | ~2 GB | Fast | Good alternative if gemma4 unavailable |
+| `llama3.2:1b` | 1B | ~1 GB | Very fast | Minimal capability, but reliable |
+
+**Avoid:** Models >7B parameters on CPU-only—they're too slow for practical use.
+
+### Ollama Host Configuration
+
+Set these environment variables on your **host Ollama** (not the extension container):
+
+```bash
+# macOS (add to ~/.zshrc or ~/.bash_profile)
+export OLLAMA_NUM_PARALLEL=1          # Keep at 1—parallelism multiplies memory use
+export OLLAMA_FLASH_ATTENTION=1       # Reduces memory, improves speed
+export OLLAMA_KV_CACHE_TYPE=q4_0     # Aggressive quantization: ¼ memory of f16
+export OLLAMA_KEEP_ALIVE=30m          # Keep model loaded, skip cold-start delay
+```
+
+Restart Ollama after setting:
+```bash
+# macOS
+killall ollama
+ollama serve
+```
+
+### OpenClaw Configuration
+
+After applying your Ollama model through the extension, edit your OpenClaw config to reduce prompt pressure:
+
+**Option 1: Minimal (most reliable)**
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4-fast:latest",
+            "params": {
+              "num_ctx": 8192
+            },
+            "compat": {
+              "supportsTools": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**Option 2: Balanced (try this first)**
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      },
+      "compaction": {
+        "reserveTokens": 4096,
+        "reserveTokensFloor": 0,
+        "keepRecentTokens": 6000
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4-fast:latest",
+            "params": {
+              "num_ctx": 12288
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### What These Settings Do
+
+| Setting | Effect |
+|---------|--------|
+| `localModelLean: true` | Removes `browser`, `cron`, `message` tools from prompt—smaller tool schema |
+| `supportsTools: false` | Disables all tool calls—smallest possible prompt |
+| `num_ctx: 8192` | Smaller context window = faster prompt eval, less memory |
+| `reserveTokens: 4096` | Compacts session earlier, keeping prompt smaller |
+| `OLLAMA_KV_CACHE_TYPE=q4_0` | 75% memory reduction in KV cache |
+
+### Trim Workspace Files
+
+OpenClaw injects workspace files into every prompt. Large files slow down prompt evaluation:
+
+```bash
+# Check sizes
+ls -lh ~/.openclaw/workspace/
+
+# Trim or remove large files
+truncate -s 0 ~/.openclaw/workspace/AGENTS.md  # Keep file, empty contents
+rm ~/.openclaw/workspace/SOUL.md               # Remove if not needed
+```
+
+---
+
+## Balanced Profile: Apple Silicon or 16-24GB RAM
+
+**Target:** 30-60s prompt evaluation with moderate context.
+
+### Recommended Models
+
+| Model | Parameters | Unified Memory | Notes |
+|-------|------------|----------------|-------|
+| `gemma4:latest` | 9B | ~6 GB | Good balance on Apple Silicon |
+| `llama3.2:latest` | 8B | ~5 GB | Fast, capable |
+| `qwen3.5:latest` | 9.7B | ~6 GB | Larger context, slower eval |
+
+### Ollama Host Configuration
+
+```bash
+# macOS
+export OLLAMA_NUM_PARALLEL=1
+export OLLAMA_FLASH_ATTENTION=1
+export OLLAMA_KV_CACHE_TYPE=q8_0      # Balanced: ½ memory of f16
+export OLLAMA_KEEP_ALIVE=30m
+```
+
+For Apple Silicon specifically, ensure GPU layers are used:
+```bash
+ollama ps  # Verify model shows GPU offload
+```
+
+If running CPU-only on Apple Silicon (slow), treat as Light Profile.
+
+### OpenClaw Configuration
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      },
+      "compaction": {
+        "reserveTokens": 8192,
+        "keepRecentTokens": 12000
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4:latest",
+            "params": {
+              "num_ctx": 16384
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Managing Context on Medium Hardware
+
+With 16K context, you're approaching the danger zone for CPU prompt eval. Strategies:
+
+1. **Monitor context usage:** Watch the token counter in Control UI
+2. **Manual compaction:** Type `/compact` proactively before context gets large
+3. **Shorter messages:** Break long requests into smaller chunks
+4. **Use Tool Search:** Let OpenClaw discover tools rather than listing them all
+
+---
+
+## Performance Profile: 32GB+ RAM, Dedicated GPU
+
+**Target:** GPU handles prompt eval in <10s; 120s timeout not a constraint.
+
+### Recommended Models
+
+| Model | Parameters | VRAM | Notes |
+|-------|------------|------|-------|
+| `gemma4:latest` | 9B | ~6 GB | Fast on GPU |
+| `llama3.1:latest` | 8B | ~5 GB | Good capabilities |
+| `qwen3.5:latest` | 9.7B | ~6 GB | Largest context |
+| `llama3.1:70b` | 70B | ~40 GB | Requires significant VRAM |
+
+### Ollama Host Configuration
+
+```bash
+export OLLAMA_NUM_PARALLEL=1          # Increase to 2-4 if VRAM allows
+export OLLAMA_FLASH_ATTENTION=1
+export OLLAMA_KV_CACHE_TYPE=f16       # Full precision—VRAM available
+export OLLAMA_KEEP_ALIVE=30m
+```
+
+### OpenClaw Configuration
+
+Full capabilities—no special constraints needed:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "compaction": {
+        "reserveTokens": 16384
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4:latest",
+            "params": {
+              "num_ctx": 32768
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+---
+
+## Configuration Reference
+
+### OpenClaw Config Paths
+
+Edit via Control UI or directly in `~/.openclaw/openclaw.json`:
+
+| Path | Type | Default | Effect |
+|------|------|---------|--------|
+| `agents.defaults.experimental.localModelLean` | boolean | false | Removes heavy tools (browser, cron, message) |
+| `models.providers.ollama.models[].compat.supportsTools` | boolean | true | Disables all tool calls if false |
+| `models.providers.ollama.models[].params.num_ctx` | number | 32768 (extension default) | Context window size for Ollama |
+| `agents.defaults.compaction.reserveTokens` | number | 20000 | Trigger compaction when within this many tokens of context limit |
+| `agents.defaults.compaction.reserveTokensFloor` | number | 20000 | Minimum reserve (set to 0 to disable floor) |
+| `agents.defaults.compaction.keepRecentTokens` | number | — | Tokens to preserve during compaction |
+
+### Extension Environment Variables
+
+Set when building/running the extension runtime:
+
+| Variable | Effect |
+|----------|--------|
+| `OPENCLAW_OLLAMA_NUM_CTX` | Override default context window (default: 32768) |
+
+### Ollama Host Environment Variables
+
+Set on your host Ollama process:
+
+| Variable | Default | Options | Effect |
+|----------|---------|---------|--------|
+| `OLLAMA_NUM_PARALLEL` | 1 | 1-N | Parallel requests (multiplies memory use) |
+| `OLLAMA_FLASH_ATTENTION` | 0 | 0, 1 | Reduces memory, improves speed |
+| `OLLAMA_KV_CACHE_TYPE` | f16 | f16, q8_0, q4_0, q5_0, q5_1 | KV cache quantization |
+| `OLLAMA_KEEP_ALIVE` | 5m | duration, -1 | How long to keep model loaded |
+| `OLLAMA_CONTEXT_LENGTH` | model default | 2048, 4096, etc. | Override default context |
+
+---
+
+## Troubleshooting
+
+### Symptom: "LLM idle timeout (120s)" errors
+
+**Causes and fixes:**
+
+1. **Prompt too large for hardware**
+   - Reduce `num_ctx` in config
+   - Enable `localModelLean: true`
+   - Try `supportsTools: false`
+   - Trim workspace files (AGENTS.md, SOUL.md)
+
+2. **Model too large for CPU**
+   - Switch to smaller model (gemma4-fast, qwen2.5:3b)
+   - Add GPU if possible (10-20x speedup)
+
+3. **Cold-start latency**
+   - Set `OLLAMA_KEEP_ALIVE=30m` or `-1`
+   - The extension's "warm up model" feature also helps
+
+### Symptom: Single-character replies
+
+**Cause:** Ollama default context (4096) filled by system prompt.
+
+**Fix:** Extension already sets `num_ctx: 32768` by default. If you overrode it, check:
+```bash
+# Verify context size
+curl http://localhost:11434/api/show -d '{"name": "gemma4:latest"}'
+```
+
+### Symptom: Out of memory errors
+
+**Fixes:**
+
+1. Reduce `num_ctx`
+2. Set `OLLAMA_KV_CACHE_TYPE=q4_0`
+3. Reduce `OLLAMA_NUM_PARALLEL` to 1
+4. Use smaller model
+5. Close other applications
+
+### Symptom: Slow response every turn
+
+**Cause:** Full prompt re-evaluation (no KV cache prefix sharing).
+
+**Partial fixes:**
+- Enable `OLLAMA_FLASH_ATTENTION=1`
+- Reduce context window
+- Compaction helps keep prompt smaller
+- Use faster model
+
+---
+
+## Decision Flowchart
+
+```
+Start with model detection in extension
+         │
+         ▼
+    Model selected
+         │
+         ▼
+   First chat works?
+   ┌─────────────┐
+   │             │
+   ▼             ▼
+  Yes           No (timeout/error)
+   │             │
+   │             ▼
+   │    Enable localModelLean: true
+   │    Set num_ctx to 8192
+   │             │
+   │             ▼
+   │    Still failing?
+   │    ┌─────────────┐
+   │    │             │
+   │    ▼             ▼
+   │   Yes            No
+   │    │             │
+   │    ▼             ▼
+   │  SupportsTools:   Working
+   │  false           configuration
+   │    │
+   │    ▼
+   │  Still failing?
+   │    │
+   │    ▼
+   │  Switch to smaller
+   │  model (gemma4-fast,
+   │  qwen2.5:3b)
+   │
+   ▼
+Monitor context usage
+Type /compact when
+approaching limit
+```
+
+---
+
+## Advanced: Editing Config Directly
+
+The extension writes Ollama configuration to the OpenClaw volume. You can edit directly:
+
+```bash
+# Find the container
+docker ps | grep openclaw
+
+# Enter container
+docker exec -it <container_id> sh
+
+# Edit config
+cat ~/.openclaw/openclaw.json
+vi ~/.openclaw/openclaw.json
+
+# Restart OpenClaw (via extension UI) to apply changes
+```
+
+Or on the host with the volume:
+```bash
+# Locate volume
+docker volume ls | grep openclaw
+
+# Mount and edit (macOS: volume is inside Docker Desktop VM)
+# Use docker run to mount and edit:
+docker run --rm -it \
+  -v openclaw-docker-extension-home:/home/node \
+  alpine sh
+vi /home/node/.openclaw/openclaw.json
+```
+
+---
+
+## Summary Table: Recommended Settings by Hardware
+
+| Setting | Light (8-16GB, CPU) | Balanced (16-24GB, Apple Silicon) | Performance (32GB+, GPU) |
+|---------|---------------------|----------------------------------|--------------------------|
+| **Model** | gemma4-fast, qwen2.5:3b | gemma4, llama3.2 | gemma4, llama3.1, larger |
+| **num_ctx** | 8192 | 16384 | 32768 |
+| **localModelLean** | true | true (test false) | false |
+| **supportsTools** | false (if needed) | true | true |
+| **reserveTokens** | 4096 | 8192 | 16384 |
+| **OLLAMA_KV_CACHE_TYPE** | q4_0 | q8_0 | f16 |
+| **OLLAMA_FLASH_ATTENTION** | 1 | 1 | 1 |
+| **OLLAMA_NUM_PARALLEL** | 1 | 1 | 1-4 |
+
+---
+
+## See Also
+
+- [Ollama FAQ](https://docs.ollama.com/faq) — Ollama-specific tuning
+- [OpenClaw Local Models](https://docs.openclaw.ai/gateway/local-models) — Official OpenClaw guidance
+- [OpenClaw Compaction](https://docs.openclaw.ai/concepts/compaction) — Session management
+- [README.md](../README.md) — Extension setup and basic usage

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,168 @@
+# OpenSpec: Hardware Profile System for Local Models
+
+This directory contains the specification, design, and implementation planning for the Hardware Profile System—a set of extension features to optimize OpenClaw for local Ollama models on constrained hardware, with primary focus on M4 Macs with 24GB RAM.
+
+## Background
+
+OpenClaw has a hardcoded 120-second idle timeout watchdog that cannot be changed through configuration. On CPU-only or memory-constrained hardware, evaluating large prompts can exceed this limit, causing timeouts before the first token arrives.
+
+This system provides **practical workarounds** by helping users:
+1. Select appropriate models for their hardware
+2. Apply optimal configurations automatically
+3. Understand performance trade-offs upfront
+4. Tune their setup to stay under the timeout limit
+
+**Key insight**: No upstream fix is required. These are extension-side improvements.
+
+---
+
+## Deliverables
+
+### 1. GitHub Issues (Ready to File)
+
+| Issue | Title | Priority | Effort |
+|-------|-------|----------|--------|
+| [#157](issues/157-hardware-profile-detection-ui.md) | Hardware Profile Detection and UI | P1 | Medium |
+| [#158](issues/158-ollama-env-var-passthrough.md) | Ollama Environment Variable Passthrough | P1 | Small |
+| [#159](issues/159-workspace-file-size-guard.md) | Workspace File Size Guard | P2 | Medium |
+| [#160](issues/160-model-selection-ui-improvements.md) | Model Selection UI with Performance Indicators | P1 | Large |
+
+### 2. Specification Documents
+
+| Document | Purpose |
+|----------|---------|
+| [specs/hardware-profile-system.md](specs/hardware-profile-system.md) | Complete system specification with M4 24GB research |
+| [ui/hardware-profile-ui-design.md](ui/hardware-profile-ui-design.md) | Detailed UI wireframes and interaction flows |
+| [tech/hardware-profile-implementation.md](tech/hardware-profile-implementation.md) | Technical architecture and implementation guide |
+
+### 3. Verification & Testing
+
+| Document | Purpose |
+|----------|---------|
+| [verification/m4-24gb-manual-verification.md](verification/m4-24gb-manual-verification.md) | Manual test plan for M4 24GB hardware |
+
+### 4. Supporting Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [../docs/local-model-tuning.md](../docs/local-model-tuning.md) | User-facing tuning guide (already created) |
+
+---
+
+## Key Research Findings for M4 Mac 24GB
+
+### Optimal Models (from benchmarks)
+
+| Model | Parameters | RAM | Speed | Risk Level | Best For |
+|-------|------------|-----|-------|------------|----------|
+| **gemma4-fast** | 4B | ~3GB | 35-45 tok/s | 🟢 Very Low | Fast tasks |
+| **qwen2.5:3b** | 3B | ~2GB | 40-50 tok/s | 🟢 Very Low | Quick chat |
+| **qwen3:8b** | 8B | ~5GB | 28-35 tok/s | 🟢 Low | Coding |
+| **llama3.2** | 8B | ~5GB | 24-28 tok/s | 🟢 Low | General |
+| **gemma4** | 9B | ~6GB | 20-25 tok/s | 🟡 Medium | Balance |
+| **qwen3.5** | 9.7B | ~6GB | 15-20 tok/s | 🟡 Medium | Quality |
+| **qwen3:14b** | 14B | ~9GB | 10-16 tok/s | 🔴 High | Strong reasoning |
+
+### Critical Optimizations
+
+1. **OLLAMA_FLASH_ATTENTION=1**: 10-30% speedup, less memory
+2. **OLLAMA_KV_CACHE_TYPE=q8_0**: 50% memory reduction vs f16
+3. **localModelLean: true**: Removes browser/cron/message tools
+4. **num_ctx: 16384**: Balanced context vs speed for 24GB
+5. **Trim workspace files**: Every 10KB ≈ 10-15s eval time
+
+### Configuration for M4 24GB
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": { "localModelLean": true },
+      "compaction": { "reserveTokens": 8192 }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [{
+          "id": "gemma4:latest",
+          "params": { "num_ctx": 16384 }
+        }]
+      }
+    }
+  }
+}
+```
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Foundation (Issues #157, #158)
+- Hardware detection service
+- Model metadata database
+- Hardware banner component
+- Ollama env var guidance UI
+
+### Phase 2: Selection (Issue #160)
+- Model selector with performance indicators
+- Risk calculation and warnings
+- Safe settings modal
+- One-click config application
+
+### Phase 3: Optimization (Issue #159)
+- Workspace file size checking
+- Size guard UI component
+- Settings panel integration
+- Diagnostics tools
+
+### Phase 4: Polish
+- Manual verification on M4 24GB
+- Performance benchmark validation
+- UI/UX refinement
+- Documentation updates
+
+---
+
+## Quick Reference: File Locations
+
+```
+openspec/
+├── README.md                                    # This file
+├── issues/
+│   ├── 157-hardware-profile-detection-ui.md     # Issue spec
+│   ├── 158-ollama-env-var-passthrough.md        # Issue spec
+│   ├── 159-workspace-file-size-guard.md         # Issue spec
+│   └── 160-model-selection-ui-improvements.md   # Issue spec
+├── specs/
+│   └── hardware-profile-system.md               # System spec
+├── ui/
+│   └── hardware-profile-ui-design.md            # UI design
+├── tech/
+│   └── hardware-profile-implementation.md       # Tech design
+└── verification/
+    └── m4-24gb-manual-verification.md           # Test plan
+```
+
+---
+
+## Next Steps
+
+1. **Review and file GitHub issues**: Start with #157 and #158 (foundational)
+2. **Manual verification**: Run the M4 24GB test plan on actual hardware
+3. **Begin Phase 1 implementation**: Hardware detection and UI banner
+4. **Iterate based on verification results**: Adjust performance estimates as needed
+
+## Success Criteria
+
+- [ ] M4 24GB users can complete setup without timeout errors
+- [ ] Recommended models appropriate for detected hardware
+- [ ] UI warnings prevent selection of high-risk models
+- [ ] Safe settings apply correct configuration in one click
+- [ ] Workspace file warnings appear at appropriate thresholds
+
+---
+
+**Created**: 2026-01-XX  
+**Target Release**: v0.4.0  
+**Primary Hardware Target**: M4 Mac with 24GB RAM

--- a/openspec/issues/157-hardware-profile-detection-ui.md
+++ b/openspec/issues/157-hardware-profile-detection-ui.md
@@ -1,0 +1,78 @@
+# Issue #157: Hardware Profile Detection and UI
+
+## Summary
+Add automatic hardware detection and profile-based configuration recommendations to help users tune OpenClaw for their specific Mac hardware (M4 24GB and other configurations).
+
+## Background
+Users with M4 Macs and 24GB RAM (like the maintainer) need optimal local model configurations. Currently they must manually discover and apply tuning from the local-model-tuning.md guide. This feature would detect hardware capabilities and suggest/appply optimal settings automatically.
+
+## Acceptance Criteria
+
+### A/C 1: Hardware Detection
+- [ ] Detect macOS hardware (Apple Silicon generation: M1/M2/M3/M4/Pro/Max)
+- [ ] Detect total system RAM
+- [ ] Detect GPU availability and VRAM/unified memory
+- [ ] Store detected profile in extension config
+- [ ] Show detected profile in UI (read-only informational display)
+
+### A/C 2: Model Recommendations
+- [ ] Based on detected profile, recommend specific Ollama models:
+  - Light (8-16GB, CPU): `gemma4-fast`, `qwen2.5:3b`
+  - Balanced (16-24GB, Apple Silicon): `gemma4`, `qwen3:8b`, `llama3.2`
+  - Performance (32GB+, GPU): Any available model
+- [ ] Show recommendation before model selection
+- [ ] Explain why each model is recommended (speed/quality trade-off)
+- [ ] Allow user to override recommendation
+
+### A/C 3: Context Size Warnings
+- [ ] When selecting models >9B parameters on CPU-only: show warning about 120s timeout risk
+- [ ] When selecting large context (32768) on light hardware: suggest smaller context
+- [ ] Provide one-click "Apply safe settings" button
+
+### A/C 4: Configuration Presets
+- [ ] Apply hardware-appropriate OpenClaw config:
+  - `localModelLean: true` for Light/Balanced profiles
+  - Optimized `num_ctx` based on RAM (8192 light, 16384 balanced, 32768 performance)
+  - `compaction.reserveTokens` appropriate for profile
+- [ ] Pass Ollama environment variables if running containerized Ollama:
+  - `OLLAMA_FLASH_ATTENTION=1` for all Apple Silicon
+  - `OLLAMA_KV_CACHE_TYPE` based on profile (q4_0 light, q8_0 balanced, f16 performance)
+
+## Technical Notes
+
+### Detection Approach
+```typescript
+// Use Docker Desktop SDK to detect host capabilities
+// Option 1: Read system_profiler via exec into a lightweight container
+// Option 2: Use navigator.hardwareConcurrency + userAgent in UI (less accurate)
+// Option 3: Detect via Ollama API after connection (memory-based inference)
+```
+
+### Profile Schema
+```typescript
+type HardwareProfile = {
+  platform: 'macos' | 'linux' | 'windows';
+  chip: 'intel' | 'm1' | 'm2' | 'm3' | 'm4' | 'm4-pro' | 'm4-max' | 'unknown';
+  totalRamGB: number;
+  hasGpu: boolean;
+  unifiedMemory: boolean; // Apple Silicon
+  recommendedProfile: 'light' | 'balanced' | 'performance';
+};
+```
+
+### Configuration Mapping
+| Profile | Recommended Models | num_ctx | localModelLean | OLLAMA_KV_CACHE_TYPE |
+|---------|-------------------|---------|----------------|---------------------|
+| light | gemma4-fast, qwen2.5:3b | 8192 | true | q4_0 |
+| balanced | gemma4, qwen3:8b, llama3.2 | 16384 | true | q8_0 |
+| performance | Any | 32768 | false | f16 |
+
+## Out of Scope
+- Auto-detection of Linux/Windows hardware details (macOS focus for this extension)
+- Automatic model downloading (recommend only)
+- Real-time performance monitoring
+- Dynamic profile switching after initial setup
+
+## Related Documentation
+- docs/local-model-tuning.md
+- Issue #156 (120s timeout context)

--- a/openspec/issues/158-ollama-env-var-passthrough.md
+++ b/openspec/issues/158-ollama-env-var-passthrough.md
@@ -1,0 +1,87 @@
+# Issue #158: Ollama Environment Variable Passthrough
+
+## Summary
+Pass performance-tuning environment variables to the runtime container when running Ollama in containerized mode, or document host Ollama optimization for users.
+
+## Background
+The extension currently configures `num_ctx` via `OPENCLAW_OLLAMA_NUM_CTX`. However, critical Ollama performance variables (`OLLAMA_FLASH_ATTENTION`, `OLLAMA_KV_CACHE_TYPE`, `OLLAMA_NUM_PARALLEL`) must be set on the Ollama host process. For users running containerized Ollama (future feature), these should be passed through. For host Ollama users, we should provide documentation and UI guidance.
+
+## Acceptance Criteria
+
+### A/C 1: Container Launch Environment Variables
+- [ ] When creating the OpenClaw runtime container, pass through relevant env vars if set in Docker Desktop environment
+- [ ] Document which Ollama env vars affect performance
+- [ ] Allow override via extension settings UI
+
+### A/C 2: UI for Ollama Host Optimization
+- [ ] Detect if Ollama is running on host vs in container
+- [ ] Show warning if host Ollama lacks performance optimizations
+- [ ] Provide copy-paste commands for setting Ollama env vars on macOS
+- [ ] One-click "Copy Ollama optimization commands" button
+
+### A/C 3: Recommended Settings by Hardware
+- [ ] Automatically suggest optimal OLLAMA_KV_CACHE_TYPE based on detected hardware
+- [ ] Show in UI: "For your M4 Mac with 24GB RAM, we recommend: OLLAMA_KV_CACHE_TYPE=q8_0"
+- [ ] Link to local-model-tuning.md for full details
+
+## Configuration Variables to Support
+
+| Variable | Default | Light | Balanced | Performance |
+|----------|---------|-------|----------|-------------|
+| OLLAMA_FLASH_ATTENTION | 0 | 1 | 1 | 1 |
+| OLLAMA_KV_CACHE_TYPE | f16 | q4_0 | q8_0 | f16 |
+| OLLAMA_NUM_PARALLEL | 4 | 1 | 1 | 1-2 |
+| OLLAMA_KEEP_ALIVE | 5m | 30m | 30m | 30m |
+
+## Technical Implementation
+
+### Option A: Pass to Container (if containerized Ollama)
+```typescript
+// In buildRuntimeRunArgs, add -e flags for Ollama vars
+return [
+  '-d',
+  '--name', options.containerName,
+  '-e', 'OLLAMA_FLASH_ATTENTION=1',
+  '-e', 'OLLAMA_KV_CACHE_TYPE=q8_0',
+  // ... rest of args
+];
+```
+
+### Option B: Host Ollama UI Guidance (immediate implementation)
+- Detect Ollama location via API endpoint analysis
+- Show contextual guidance in Ollama setup flow
+- Provide shell commands for user's detected shell (zsh/bash)
+
+## UI Mockup
+
+```
+┌─────────────────────────────────────────┐
+│  Ollama Performance Optimization        │
+├─────────────────────────────────────────┤
+│                                         │
+│  Detected: Ollama running on host       │
+│  Hardware: M4 Mac, 24GB RAM             │
+│                                         │
+│  Recommended settings for your Mac:     │
+│  ┌─────────────────────────────────┐   │
+│  │ export OLLAMA_FLASH_ATTENTION=1 │   │
+│  │ export OLLAMA_KV_CACHE_TYPE=q8_0│   │
+│  │ export OLLAMA_KEEP_ALIVE=30m    │   │
+│  └─────────────────────────────────┘   │
+│                                         │
+│  [Copy Commands]  [Learn More]          │
+│                                         │
+│  ⚠️ Without these, large prompts may    │
+│     timeout after 120 seconds           │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+## Out of Scope
+- Actually modifying user's shell profile (provide commands only)
+- Windows/Linux Ollama service configuration (macOS primary)
+- Containerized Ollama deployment (future feature)
+
+## Related
+- Issue #157 (Hardware Profile Detection)
+- docs/local-model-tuning.md

--- a/openspec/issues/159-workspace-file-size-guard.md
+++ b/openspec/issues/159-workspace-file-size-guard.md
@@ -1,0 +1,108 @@
+# Issue #159: Workspace File Size Guard and Optimization Hints
+
+## Summary
+Warn users when OpenClaw workspace files (AGENTS.md, SOUL.md, etc.) grow large enough to significantly slow down prompt evaluation on local models.
+
+## Background
+OpenClaw injects workspace files (AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md) into every prompt. Large files cause slower prompt evaluation, especially problematic on CPU-only hardware where we're already near the 120s timeout limit. The default AGENTS.md template is ~7KB and can grow significantly with user additions.
+
+## Acceptance Criteria
+
+### A/C 1: File Size Detection
+- [ ] After Ollama setup completes, check workspace file sizes in the OpenClaw volume
+- [ ] Calculate total injected context size from workspace files
+- [ ] Store size metrics in extension state
+
+### A/C 2: Size Warnings
+- [ ] Show warning when any single file > 10,000 characters
+- [ ] Show warning when total workspace context > 20,000 characters
+- [ ] Display warning in Ollama setup completion flow and in settings
+
+### A/C 3: Optimization Guidance
+- [ ] Provide specific, actionable recommendations:
+   - "AGENTS.md is 15KB. Consider moving long skill documentation to skill-specific files."
+   - "SOUL.md is 8KB. This may add 2-3s to every prompt eval on your hardware."
+- [ ] One-click "View workspace files" button (open Control UI to workspace)
+- [ ] Link to local-model-tuning.md for trimming guidance
+
+### A/C 4: Lean Mode Suggestion
+- [ ] If workspace files are large AND hardware profile is light/balanced: suggest enabling `localModelLean: true`
+- [ ] Explain trade-off: "Lean mode removes browser/cron/message tools to compensate for large workspace context"
+- [ ] One-click enable in UI
+
+## Size Thresholds
+
+| Metric | Warning Level | Critical Level |
+|--------|--------------|----------------|
+| Single file | 10,000 chars | 20,000 chars |
+| Total workspace | 20,000 chars | 40,000 chars |
+| AGENTS.md specifically | 8,000 chars | 15,000 chars |
+
+## Time Impact Estimates (for UI display)
+
+Based on research at ~127 tok/s CPU prompt eval:
+- 10KB text ≈ 2,500 tokens ≈ ~20s additional prompt eval time
+- 20KB text ≈ 5,000 tokens ≈ ~40s additional prompt eval time
+
+These estimates help users understand the impact on the 120s timeout budget.
+
+## UI Mockup
+
+```
+┌─────────────────────────────────────────┐
+│  Workspace File Size Check                │
+├─────────────────────────────────────────┤
+│                                         │
+│  ⚠️ Large workspace files detected       │
+│                                         │
+│  File sizes:                            │
+│  • AGENTS.md    15,400 chars  ▲ Large    │
+│  • SOUL.md       8,200 chars  ▲ Large    │
+│  • TOOLS.md      2,100 chars  ✓ OK       │
+│  • USER.md         800 chars  ✓ OK       │
+│                                         │
+│  Total: ~26K chars ≈ ~50s prompt eval    │
+│                                         │
+│  [Trim AGENTS.md] [Enable Lean Mode]    │
+│  [View in Control UI] [Dismiss]           │
+│                                         │
+│  Tip: Move skill docs to skill files.   │
+│  See local-model-tuning.md for details. │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+## Technical Implementation
+
+### Size Check Command
+```typescript
+// Execute in container to check file sizes
+const sizeCheckArgs = [
+  'sh', '-c',
+  'cd /home/node/.openclaw/workspace && wc -c AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md 2>/dev/null || echo "0 AGENTS.md"'
+];
+```
+
+### Storage in Extension State
+```typescript
+type WorkspaceSizeState = {
+  checkedAt: string; // ISO timestamp
+  files: {
+    path: string;
+    bytes: number;
+    status: 'ok' | 'warning' | 'critical';
+  }[];
+  totalBytes: number;
+  totalStatus: 'ok' | 'warning' | 'critical';
+};
+```
+
+## Out of Scope
+- Automatically truncating files (user decision required)
+- Periodic background checks (check at setup/apply time only)
+- Checking memory/ directory contents (not injected every turn)
+
+## Related
+- Issue #157 (Hardware Profile Detection - for size impact context)
+- docs/local-model-tuning.md
+- OpenClaw docs on workspace files

--- a/openspec/issues/160-model-selection-ui-improvements.md
+++ b/openspec/issues/160-model-selection-ui-improvements.md
@@ -1,0 +1,137 @@
+# Issue #160: Model Selection UI with Performance Indicators
+
+## Summary
+Improve the Ollama model selection UI to show performance indicators, estimated tokens/second, and timeout risk levels based on detected hardware.
+
+## Background
+Users currently select Ollama models without understanding the performance implications for their specific hardware. A 9.7B model like `qwen3.5` runs at ~10-16 tok/s on M4 24GB (usable) but would be dangerously slow on CPU-only 8GB RAM (likely to timeout). The UI should surface this information at selection time.
+
+## Acceptance Criteria
+
+### A/C 1: Model Performance Metadata
+- [ ] Maintain internal database of model parameters and performance characteristics:
+  - Parameter count (3B, 4B, 7B, 8B, 9B, 14B, etc.)
+  - Typical RAM usage at Q4_K_M quantization
+  - Expected tokens/second on different hardware profiles
+- [ ] Show parameter count and estimated RAM usage in model list
+
+### A/C 2: Hardware-Specific Speed Estimates
+- [ ] For detected hardware profile, show estimated performance:
+  - "On your M4 Mac (24GB): ~15-20 tok/s"
+  - "Estimated prompt eval: ~30-40s for typical chat"
+- [ ] Show different estimate if running CPU-only vs GPU-accelerated
+
+### A/C 3: Timeout Risk Indicator
+- [ ] Show visual risk indicator for each model:
+  - 🟢 Low risk: Models <7B on any hardware
+  - 🟡 Medium risk: Models 7-10B on Apple Silicon
+  - 🔴 High risk: Models >10B or any model on CPU-only
+- [ ] Show specific warning for models that may hit 120s timeout:
+  "⚠️ With your hardware, large prompts on this model may exceed OpenClaw's 120s timeout limit."
+
+### A/C 4: Recommended Model Highlighting
+- [ ] Highlight recommended models for detected hardware:
+  - Light: Show "Recommended" badge on gemma4-fast, qwen2.5:3b
+  - Balanced: Show "Recommended" on gemma4, qwen3:8b, llama3.2
+- [ ] Sort recommended models to top of list
+- [ ] Show "Best for your Mac" callout
+
+### A/C 5: One-Click Safe Configuration
+- [ ] When user selects a model, offer "Apply with safe settings":
+  - Sets appropriate `num_ctx` for hardware
+  - Enables `localModelLean` if recommended
+  - Configures compaction settings
+- [ ] Confirm before applying: "This will also enable lean mode and set context to 16K for best performance."
+
+## Model Performance Database (Initial)
+
+| Model | Params | RAM (Q4) | M4 24GB tok/s | CPU-Only tok/s | Risk on M4 24GB | Risk on CPU |
+|-------|--------|----------|---------------|----------------|-----------------|-------------|
+| gemma4-fast | 4B | ~3GB | 35-45 | 20-25 | 🟢 Low | 🟡 Medium |
+| qwen2.5:3b | 3B | ~2GB | 40-50 | 25-30 | 🟢 Low | 🟢 Low |
+| llama3.2 | 8B | ~5GB | 24-28 | 12-15 | 🟢 Low | 🟡 Medium |
+| gemma4 | 9B | ~6GB | 20-25 | 10-12 | 🟡 Medium | 🔴 High |
+| qwen3.5 | 9.7B | ~6GB | 15-20 | 8-10 | 🟡 Medium | 🔴 High |
+| qwen3:14b | 14B | ~9GB | 10-16 | 5-7 | 🟡 Medium | 🔴 High |
+| llama3.1:70b | 70B | ~40GB | N/A (OOM) | N/A | 🔴 N/A | 🔴 N/A |
+
+## UI Mockup
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Select Ollama Model                                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                               │
+│  Detected: M4 Mac, 24GB RAM                                  │
+│                                                               │
+│  ⭐ Recommended for your Mac                                  │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ 🥇 gemma4         9B  ~6GB   ~22 tok/s  🟢 Low risk │    │
+│  │ 🥈 llama3.2       8B  ~5GB   ~26 tok/s  🟢 Low risk │    │
+│  │ 🥉 qwen3:8b       8B  ~5GB   ~30 tok/s  🟢 Low risk │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                                                               │
+│  Other available models:                                      │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │ gemma4-fast       4B  ~3GB   ~40 tok/s  🟢 Low risk │    │
+│  │ qwen3.5           9.7B ~6GB   ~18 tok/s  🟡 Medium   │    │
+│  │ ⚠️ qwen3:14b     14B  ~9GB   ~13 tok/s  🟡 Medium   │    │
+│  │     Large prompts may exceed 120s timeout             │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                                                               │
+│  Selected: qwen3.5                                          │
+│  [Apply with Safe Settings]  [Advanced...]                    │
+│                                                               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Technical Implementation
+
+### Model Metadata Type
+```typescript
+type ModelMetadata = {
+  id: string;
+  name: string;
+  parameters: number; // in billions
+  ramUsageGB: number; // Q4_K_M quantization estimate
+  performance: {
+    'm4-24gb': { tokPerSecond: [number, number]; notes?: string };
+    'cpu-light': { tokPerSecond: [number, number]; notes?: string };
+    'cpu-balanced': { tokPerSecond: [number, number]; notes?: string };
+  };
+  riskProfile: {
+    'm4-24gb': 'low' | 'medium' | 'high';
+    'cpu-light': 'low' | 'medium' | 'high';
+    'cpu-balanced': 'low' | 'medium' | 'high';
+  };
+};
+```
+
+### Dynamic Risk Calculation
+```typescript
+function calculateRisk(
+  model: ModelMetadata,
+  hardwareProfile: HardwareProfile,
+  estimatedPromptTokens: number // user's typical prompt size
+): 'low' | 'medium' | 'high' {
+  // Calculate estimated prompt eval time
+  const perf = model.performance[hardwareProfile.id];
+  const evalTimeSeconds = estimatedPromptTokens / perf.tokPerSecond[0];
+  
+  // Risk if approaching 120s timeout
+  if (evalTimeSeconds > 90) return 'high';
+  if (evalTimeSeconds > 60) return 'medium';
+  return 'low';
+}
+```
+
+## Out of Scope
+- Automatic model downloading (still manual)
+- Real-time benchmarking on user's machine
+- Predicting exact token counts for specific prompts
+- Non-Ollama local providers (LM Studio, etc.)
+
+## Related
+- Issue #157 (Hardware Profile Detection)
+- Issue #158 (Ollama Env Var Passthrough)
+- docs/local-model-tuning.md

--- a/openspec/specs/hardware-profile-system.md
+++ b/openspec/specs/hardware-profile-system.md
@@ -1,0 +1,407 @@
+# Hardware Profile System Specification
+
+## Overview
+A comprehensive system to detect, configure, and optimize OpenClaw for local models on different Mac hardware configurations, with specific focus on M4 Macs with 24GB RAM.
+
+## Goals
+1. **Automatic Detection**: Identify user's hardware capabilities (chip, RAM, GPU)
+2. **Smart Recommendations**: Suggest optimal models and configurations
+3. **Performance Warnings**: Alert users before they select models that may timeout
+4. **One-Click Optimization**: Apply tested configurations for specific hardware
+5. **Documentation**: Provide clear guidance for manual tuning
+
+## Target Hardware Profiles
+
+### Profile: Balanced (Primary Focus)
+**Target Hardware**: M4 Mac (base/Pro) with 24GB unified memory
+
+**Why This Matters**:
+- Base M4: 120 GB/s memory bandwidth
+- M4 Pro: 273 GB/s memory bandwidth
+- Unified memory allows efficient GPU offload
+- 24GB is the sweet spot for running 8-14B models comfortably
+
+**Research Findings for M4 24GB**:
+
+| Model | Params | RAM Used | Tokens/sec | Use Case |
+|-------|--------|----------|------------|----------|
+| **gemma4-fast** | 4B | ~3GB | 35-45 tok/s | Fast daily driver |
+| **qwen2.5:3b** | 3B | ~2GB | 40-50 tok/s | Ultra-fast responses |
+| **qwen3:8b** | 8B | ~5GB | 28-35 tok/s | Fast, capable |
+| **llama3.2** | 8B | ~5GB | 24-28 tok/s | General purpose |
+| **gemma4** | 9B | ~6GB | 20-25 tok/s | Best balance |
+| **qwen3.5** | 9.7B | ~6GB | 15-20 tok/s | Higher quality |
+| **qwen3:14b** | 14B | ~9GB | 10-16 tok/s | Slower, stronger |
+| **qwen3.5:27b** | 27B | ~16GB | 6-10 tok/s | Top quality, tight fit |
+
+**Key Insights from Research**:
+1. **MLX Backend**: Ollama 0.19+ uses Apple MLX framework → 1.7-3.4x faster than llama.cpp
+2. **Flash Attention**: `OLLAMA_FLASH_ATTENTION=1` reduces memory and improves speed
+3. **KV Cache Quantization**: `OLLAMA_KV_CACHE_TYPE=q8_0` uses ½ memory vs f16 with minimal quality loss
+4. **Prompt Eval vs Generation**: Prompt eval (first tokens) is slower than generation (subsequent tokens)
+5. **Context Matters**: 21K token prompt at 127 tok/s = 165s eval time (exceeds 120s timeout)
+
+### Profile: Light
+**Target Hardware**: 8-16GB RAM, CPU-only (older Macs, MacBook Air without GPU offload)
+
+**Constraints**:
+- Cannot run models >7B reliably
+- Must use aggressive KV cache quantization (q4_0)
+- Smaller context windows (8K instead of 16K)
+- Must use lean mode and tool disabling
+
+### Profile: Performance
+**Target Hardware**: 32GB+ RAM with dedicated GPU (M4 Max, Studio, or discrete GPU setups)
+
+**Capabilities**:
+- Can run larger models (up to 70B with quantization)
+- Full context windows (32K+)
+- All tools enabled
+- Higher parallelism possible
+
+## Configuration Recommendations by Profile
+
+### Balanced Profile (M4 24GB) - Detailed
+
+#### Recommended Primary Configuration
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      },
+      "compaction": {
+        "reserveTokens": 8192,
+        "keepRecentTokens": 12000
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4:latest",
+            "name": "Gemma 4",
+            "params": {
+              "num_ctx": 16384
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Ollama Host Environment
+```bash
+export OLLAMA_NUM_PARALLEL=1
+export OLLAMA_FLASH_ATTENTION=1
+export OLLAMA_KV_CACHE_TYPE=q8_0
+export OLLAMA_KEEP_ALIVE=30m
+```
+
+#### Workspace File Guidance
+- Keep AGENTS.md under 8,000 characters
+- SOUL.md under 5,000 characters
+- Total workspace context under 15,000 characters
+
+#### Model Selection Priority
+1. **Primary**: `gemma4` (9B) - best balance of speed and capability
+2. **Fast**: `gemma4-fast` (4B) - when speed matters most
+3. **Capable**: `qwen3:8b` - stronger reasoning at good speed
+4. **Heavy**: `qwen3:14b` - when quality trumps speed (expect ~30-40s prompt eval)
+
+### Light Profile
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      },
+      "compaction": {
+        "reserveTokens": 4096,
+        "reserveTokensFloor": 0,
+        "keepRecentTokens": 6000
+      }
+    }
+  },
+  "models": {
+    "providers": {
+      "ollama": {
+        "models": [
+          {
+            "id": "gemma4-fast:latest",
+            "params": {
+              "num_ctx": 8192
+            },
+            "compat": {
+              "supportsTools": false
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+## UI/UX Specification
+
+### Hardware Detection Flow
+
+```
+User opens extension
+       │
+       ▼
+  [Check if hardware detected]
+       │
+       ├─ No ──▶ [Run detection]
+       │            │
+       │            ▼
+       │       [Get system info via Docker SDK]
+       │            │
+       │            ▼
+       │       [Store: chip, RAM, hasGpu]
+       │            │
+       │            ▼
+       │       [Determine profile: light/balanced/performance]
+       │
+       ▼
+  [Show profile in UI]
+       │
+       ▼
+  [Recommend models]
+       │
+       ▼
+  [Warn about timeout risks]
+```
+
+### Model Selection UI States
+
+**State 1: Hardware Detected, No Model Selected**
+```
+┌────────────────────────────────────────────┐
+│  Your Mac: M4 with 24GB RAM                │
+│  Recommended for: Balanced profile          │
+│                                            │
+│  ⭐ Top picks for your Mac:                 │
+│  • Gemma 4 - Best balance (~22 tok/s)     │
+│  • Qwen3 8B - Fast & capable (~30 tok/s) │
+│  • Gemma 4 Fast - Maximum speed (~40 tok/s)│
+│                                            │
+│  [Select Model] [View All Options]         │
+└────────────────────────────────────────────┘
+```
+
+**State 2: Model Selected, Safe Settings Available**
+```
+┌────────────────────────────────────────────┐
+│  Selected: Qwen3.5 (9.7B parameters)        │
+│                                            │
+│  On your M4 (24GB):                        │
+│  • Estimated: ~18 tok/s                    │
+│  • Context: 16K tokens                     │
+│  • RAM usage: ~6GB                         │
+│                                            │
+│  ⚠️ Large prompts may take 30-45s to start  │
+│                                            │
+│  [Apply Safe Settings for M4]               │
+│  This will:                               │
+│  • Enable lean mode for smaller prompts    │
+│  • Set context to 16K                      │
+│  • Configure compaction                    │
+└────────────────────────────────────────────┘
+```
+
+**State 3: High Risk Model Selected**
+```
+┌────────────────────────────────────────────┐
+│  Selected: Qwen3 14B                        │
+│                                            │
+│  ⚠️ Timeout Risk on your hardware           │
+│                                            │
+│  This model:                               │
+│  • Uses ~9GB RAM                           │
+│  • Runs at ~13 tok/s on M4                 │
+│  • May exceed 120s timeout on large prompts │
+│                                            │
+│  Recommendations:                          │
+│  • Use smaller context (8K instead of 16K) │
+│  • Enable aggressive lean mode             │
+│  • Trim workspace files                     │
+│  • Or select a smaller model                │
+│                                            │
+│  [Apply Risk Mitigation] [Choose Different] │
+└────────────────────────────────────────────┘
+```
+
+## Technical Implementation
+
+### Hardware Detection API
+
+```typescript
+// src/services/hardwareDetection.ts
+
+interface HardwareProfile {
+  platform: 'macos' | 'linux' | 'windows';
+  chip: {
+    family: 'intel' | 'apple-silicon';
+    generation: 'm1' | 'm2' | 'm3' | 'm4' | 'm4-pro' | 'm4-max' | 'unknown';
+    hasGpu: boolean;
+    memoryBandwidthGBps: number | null; // 120 for base M4, 273 for M4 Pro, etc.
+  };
+  memory: {
+    totalGB: number;
+    unified: boolean; // true for Apple Silicon
+  };
+  recommendedProfile: 'light' | 'balanced' | 'performance';
+}
+
+async function detectHardware(): Promise<HardwareProfile> {
+  // Approach: Use Docker exec to run system_profiler on macOS
+  // Alternative: Parse userAgent in UI + memory estimate from performance API
+}
+```
+
+### Configuration Builder
+
+```typescript
+// src/services/configBuilder.ts
+
+interface ProfileConfig {
+  ollamaEnv: {
+    OLLAMA_FLASH_ATTENTION: '0' | '1';
+    OLLAMA_KV_CACHE_TYPE: 'f16' | 'q8_0' | 'q4_0';
+    OLLAMA_NUM_PARALLEL: string;
+    OLLAMA_KEEP_ALIVE: string;
+  };
+  openclawConfig: {
+    agents: {
+      defaults: {
+        experimental: { localModelLean: boolean };
+        compaction: {
+          reserveTokens?: number;
+          reserveTokensFloor?: number;
+          keepRecentTokens?: number;
+        };
+      };
+    };
+    models: {
+      providers: {
+        ollama: {
+          models: Array<{
+            id: string;
+            params: { num_ctx: number };
+            compat?: { supportsTools: boolean };
+          }>;
+        };
+      };
+    };
+  };
+}
+
+function buildConfigForProfile(profile: 'light' | 'balanced' | 'performance'): ProfileConfig {
+  // Return configuration object based on profile
+}
+```
+
+### Model Metadata Database
+
+```typescript
+// src/data/modelMetadata.ts
+
+export const MODEL_METADATA: Record<string, ModelMetadata> = {
+  'gemma4:latest': {
+    id: 'gemma4:latest',
+    name: 'Gemma 4',
+    parameters: 9,
+    ramUsageGB: 6,
+    performance: {
+      'm4-base': { tokPerSecond: [20, 25] },
+      'm4-pro': { tokPerSecond: [22, 28] },
+      'cpu-light': { tokPerSecond: [8, 10] },
+    },
+    recommendedProfiles: ['balanced', 'performance'],
+    contextWindow: 128000,
+    bestFor: 'General purpose, good balance of speed and quality',
+  },
+  'qwen3:8b': {
+    id: 'qwen3:8b',
+    name: 'Qwen 3 8B',
+    parameters: 8,
+    ramUsageGB: 5,
+    performance: {
+      'm4-base': { tokPerSecond: [28, 35] },
+      'm4-pro': { tokPerSecond: [30, 38] },
+      'cpu-light': { tokPerSecond: [12, 15] },
+    },
+    recommendedProfiles: ['balanced', 'performance'],
+    contextWindow: 32768,
+    bestFor: 'Fast responses with good reasoning',
+  },
+  // ... more models
+};
+```
+
+## Integration Points
+
+### With Ollama Setup Flow
+- Detect hardware at start of Ollama setup
+- Show recommendations before model selection
+- Apply safe settings on "Apply" action
+- Store detected profile in extension config
+
+### With Control UI
+- Pass hardware profile info via URL fragment or state
+- Show profile badge in Control UI header
+- Allow profile-based UI adaptations (e.g., warn about compaction)
+
+### With Runtime Container
+- Pass OLLAMA_* environment variables when launching container
+- Mount workspace volume with appropriate settings pre-configured
+
+## Testing Strategy
+
+### Manual Verification Matrix
+
+| Hardware | Profile | Model | Context | Expected Tok/s | Timeout Risk |
+|----------|---------|-------|---------|----------------|--------------|
+| M4 24GB | Balanced | gemma4 | 16K | 20-25 | Low |
+| M4 24GB | Balanced | qwen3:14b | 16K | 10-16 | Medium |
+| M4 24GB | Balanced | qwen3:14b | 32K | 10-16 | High |
+| M3 16GB | Light | gemma4-fast | 8K | 20-25 | Low |
+| M3 16GB | Light | gemma4 | 8K | 10-12 | Medium |
+| Intel 8GB | Light | qwen2.5:3b | 8K | 15-20 | Low |
+
+### Automated Tests
+- Unit tests for hardware detection logic
+- Unit tests for configuration builder
+- Integration tests for profile-based model filtering
+
+## Success Metrics
+
+1. **User Success Rate**: % of users who complete setup without timeout errors
+2. **Model Appropriateness**: % of users on balanced hardware selecting appropriate models
+3. **Configuration Adoption**: % of users who apply recommended settings
+4. **Timeout Reduction**: Decrease in "LLM idle timeout" errors in logs
+
+## Related Issues
+
+- Issue #157: Hardware Profile Detection and UI
+- Issue #158: Ollama Environment Variable Passthrough
+- Issue #159: Workspace File Size Guard
+- Issue #160: Model Selection UI with Performance Indicators
+- docs/local-model-tuning.md
+
+## Future Enhancements
+
+1. **Real-time Performance Monitoring**: Measure actual tok/s on user's machine
+2. **Adaptive Context Sizing**: Automatically adjust context based on measured performance
+3. **Community Benchmarks**: Crowdsource performance data from users
+4. **Non-Mac Support**: Extend detection to Windows/Linux (lower priority for this extension)
+5. **Model Update Notifications**: Alert when better models become available for user's hardware

--- a/openspec/tech/hardware-profile-implementation.md
+++ b/openspec/tech/hardware-profile-implementation.md
@@ -1,0 +1,410 @@
+# Hardware Profile System - Technical Implementation Design
+
+## Architecture Overview
+
+```
+Extension Frontend (React/TypeScript)
+├── HardwareProfileService          # Detection & profile logic
+├── ModelMetadataService             # Performance database
+├── RiskCalculator                   # Timeout risk assessment
+├── ProfileConfigBuilder             # Generate optimal config
+├── WorkspaceSizeService             # Check file sizes
+└── React Components
+    ├── HardwareProfileCard.tsx
+    ├── ModelSelector.tsx
+    ├── PerformanceIndicator.tsx
+    └── SafeSettingsModal.tsx
+
+Docker Desktop SDK
+├── Container exec for hw detection
+├── Volume inspection for workspace files
+└── Container launch with env vars
+```
+
+---
+
+## Core Types
+
+```typescript
+// src/types/hardware.ts
+
+export type HardwareProfile = 'light' | 'balanced' | 'performance';
+
+export interface DetectedHardware {
+  platform: 'macos' | 'linux' | 'windows';
+  chip: {
+    family: 'intel' | 'apple-silicon';
+    generation: 'm1' | 'm2' | 'm3' | 'm4' | 'm4-pro' | 'm4-max' | 'unknown';
+    hasGpu: boolean;
+    memoryBandwidthGBps: number | null;
+  };
+  memory: {
+    totalGB: number;
+    unified: boolean;
+  };
+  detectedAt: string;
+}
+
+export interface HardwareProfileConfig {
+  profile: HardwareProfile;
+  ollamaEnv: {
+    OLLAMA_FLASH_ATTENTION: '0' | '1';
+    OLLAMA_KV_CACHE_TYPE: 'f16' | 'q8_0' | 'q4_0';
+    OLLAMA_NUM_PARALLEL: string;
+    OLLAMA_KEEP_ALIVE: string;
+  };
+  openclawConfig: object;
+  recommendedModels: string[];
+  workspaceLimits: { maxFileSizeChars: number; maxTotalSizeChars: number };
+}
+
+export interface ModelMetadata {
+  id: string;
+  name: string;
+  parameters: number;
+  ramUsageGB: number;
+  performance: Record<string, { tokPerSecond: [number, number] }>;
+  riskProfile: Record<string, 'low' | 'medium' | 'high'>;
+  recommendedProfiles: HardwareProfile[];
+  contextWindow: number;
+}
+```
+
+---
+
+## Key Service Implementations
+
+### HardwareProfileService
+
+```typescript
+export class HardwareProfileService {
+  async detectHardware(): Promise<DetectedHardware> {
+    // Try browser hints first (fast)
+    const uaHints = this.detectFromUserAgent();
+    
+    // Fall back to Docker exec for detailed info
+    const dockerInfo = await this.detectFromDocker();
+    
+    return this.mergeDetections(uaHints, dockerInfo);
+  }
+  
+  determineProfile(hw: DetectedHardware): HardwareProfile {
+    if (hw.chip.family === 'apple-silicon') {
+      if (hw.memory.totalGB >= 32) return 'performance';
+      if (hw.memory.totalGB >= 16 && hw.chip.hasGpu) return 'balanced';
+    }
+    return 'light';
+  }
+}
+```
+
+### Profile Configurations
+
+```typescript
+export const PROFILE_CONFIGS: Record<HardwareProfile, HardwareProfileConfig> = {
+  balanced: {
+    profile: 'balanced',
+    ollamaEnv: {
+      OLLAMA_FLASH_ATTENTION: '1',
+      OLLAMA_KV_CACHE_TYPE: 'q8_0',
+      OLLAMA_NUM_PARALLEL: '1',
+      OLLAMA_KEEP_ALIVE: '30m',
+    },
+    openclawConfig: {
+      agents: {
+        defaults: {
+          experimental: { localModelLean: true },
+          compaction: { reserveTokens: 8192, keepRecentTokens: 12000 },
+        },
+      },
+      models: {
+        providers: {
+          ollama: {
+            models: [{
+              id: 'placeholder',
+              params: { num_ctx: 16384 },
+            }],
+          },
+        },
+      },
+    },
+    recommendedModels: [
+      'gemma4:latest',
+      'qwen3:8b',
+      'llama3.2:latest',
+      'gemma4-fast:latest',
+    ],
+    workspaceLimits: { maxFileSizeChars: 10000, maxTotalSizeChars: 20000 },
+  },
+  // ... light and performance profiles similar
+};
+```
+
+### Model Metadata (Key Models for M4 24GB)
+
+```typescript
+export const MODEL_METADATA: Record<string, ModelMetadata> = {
+  'gemma4:latest': {
+    id: 'gemma4:latest',
+    name: 'Gemma 4',
+    parameters: 9,
+    ramUsageGB: 6,
+    performance: {
+      'm4-base': { tokPerSecond: [20, 25] },
+      'balanced': { tokPerSecond: [15, 20] },
+      'light': { tokPerSecond: [8, 10] },
+    },
+    riskProfile: {
+      'm4-base': 'low',
+      'balanced': 'medium',
+      'light': 'high',
+    },
+    recommendedProfiles: ['balanced', 'performance'],
+    contextWindow: 128000,
+  },
+  // ... other models (qwen3:8b, llama3.2, qwen3:14b, gemma4-fast, etc.)
+};
+```
+
+### Risk Calculator
+
+```typescript
+export function calculateRisk(
+  modelId: string,
+  hardware: DetectedHardware,
+  workspaceSize?: WorkspaceSizeInfo,
+  estimatedPromptTokens = 15000
+): TimeoutRiskAssessment {
+  const model = MODEL_METADATA[modelId];
+  const profile = determineProfile(hardware);
+  const perf = model.performance[profile] || model.performance['balanced'];
+  
+  const promptEvalTime = estimatedPromptTokens / perf.tokPerSecond[0];
+  const workspaceOverhead = workspaceSize?.estimatedEvalTimeSeconds || 0;
+  const totalEvalTime = promptEvalTime + workspaceOverhead;
+  
+  let level: 'low' | 'medium' | 'high';
+  if (totalEvalTime > 90) level = 'high';
+  else if (totalEvalTime > 60) level = 'medium';
+  else level = 'low';
+  
+  return {
+    level,
+    estimatedPromptEvalSeconds: Math.round(totalEvalTime),
+    estimatedTokensPerSecond: Math.round(perf.tokPerSecond[0]),
+    riskFactors: buildRiskFactors(model, hardware, totalEvalTime),
+    mitigations: buildMitigations(model, profile, workspaceOverhead),
+  };
+}
+```
+
+---
+
+## Integration Points
+
+### 1. Ollama Setup Flow
+
+Modify `OllamaSetupService.ts`:
+
+```typescript
+async startSetupFlow(): Promise<void> {
+  // Detect hardware early
+  const { hardware, profile, config } = await this.hardwareService.getOptimalConfig();
+  this.state.hardware = hardware;
+  this.state.profile = profile;
+  
+  // Show hardware banner in UI
+  this.ui.showHardwareBanner(hardware, profile);
+  
+  // Continue with model selection...
+}
+
+async selectModel(modelId: string): Promise<void> {
+  const risk = calculateRisk(modelId, this.state.hardware);
+  this.state.selectedModelRisk = risk;
+  
+  // If high risk, show warning before applying
+  if (risk.level === 'high') {
+    await this.ui.showRiskWarning(risk);
+  }
+}
+```
+
+### 2. Config Application
+
+```typescript
+async applySafeSettings(modelId: string): Promise<void> {
+  const { profile, config } = await this.hardwareService.getOptimalConfig();
+  
+  // Merge profile config with selected model
+  const modelConfig = buildModelConfig(profile, modelId);
+  
+  // Apply to OpenClaw via existing ollamaSetup flow
+  await this.ollamaSetup.applyModelConfig(modelConfig);
+  
+  // Show Ollama env var guidance
+  this.ui.showOllamaEnvGuidance(config.ollamaEnv);
+}
+```
+
+### 3. Workspace Size Check
+
+```typescript
+async checkWorkspaceSizes(): Promise<WorkspaceSizeInfo> {
+  const result = await this.ddClient.docker.cli.exec('exec', [
+    'openclaw-docker-desktop-extension-runtime',
+    'sh', '-c',
+    'cd /home/node/.openclaw/workspace && wc -c AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md'
+  ]);
+  
+  return this.parseSizeOutput(result.stdout);
+}
+```
+
+---
+
+## UI Component Structure
+
+```typescript
+// HardwareProfileCard.tsx
+interface Props {
+  hardware: DetectedHardware;
+  profile: HardwareProfile;
+  onOptimize: () => void;
+  onChangeProfile: (profile: HardwareProfile) => void;
+}
+
+// ModelSelector.tsx
+interface Props {
+  hardware: DetectedHardware;
+  availableModels: string[];
+  onSelect: (modelId: string, risk: TimeoutRiskAssessment) => void;
+}
+
+// PerformanceIndicator.tsx
+interface Props {
+  modelId: string;
+  hardware: DetectedHardware;
+  showDetails?: boolean;
+}
+
+// SafeSettingsModal.tsx
+interface Props {
+  modelId: string;
+  risk: TimeoutRiskAssessment;
+  profileConfig: HardwareProfileConfig;
+  onApply: () => void;
+  onCustomize: () => void;
+  onSkip: () => void;
+}
+```
+
+---
+
+## State Management
+
+```typescript
+interface HardwareProfileState {
+  detected?: {
+    hardware: DetectedHardware;
+    profile: HardwareProfile;
+    config: HardwareProfileConfig;
+  };
+  selectedModel?: {
+    id: string;
+    risk: TimeoutRiskAssessment;
+  };
+  workspaceSize?: WorkspaceSizeInfo;
+  appliedSettings?: {
+    timestamp: string;
+    config: HardwareProfileConfig;
+  };
+}
+
+// Use React Context for global state
+const HardwareContext = createContext<{
+  state: HardwareProfileState;
+  detect: () => Promise<void>;
+  selectModel: (id: string) => Promise<void>;
+  applySettings: () => Promise<void>;
+}>();
+```
+
+---
+
+## File Structure
+
+```
+src/
+├── services/
+│   ├── hardware/
+│   │   ├── HardwareProfileService.ts
+│   │   ├── hardwareDetection.ts
+│   │   └── riskCalculator.ts
+│   ├── config/
+│   │   ├── ProfileConfigBuilder.ts
+│   │   └── OllamaConfigApplier.ts
+│   └── workspace/
+│       └── WorkspaceSizeService.ts
+├── components/
+│   ├── hardware/
+│   │   ├── HardwareProfileCard.tsx
+│   │   ├── ModelSelector.tsx
+│   │   ├── PerformanceIndicator.tsx
+│   │   └── SafeSettingsModal.tsx
+│   └── workspace/
+│       └── WorkspaceSizeGuard.tsx
+├── data/
+│   └── modelMetadata.ts
+├── types/
+│   └── hardware.ts
+├── hooks/
+│   └── useHardwareProfile.ts
+└── context/
+    └── HardwareContext.tsx
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Detection & Display (MVP)
+- Hardware detection via userAgent + Docker info
+- Hardware banner component
+- Model metadata database (6-8 key models)
+
+### Phase 2: Model Selection
+- Model selector with performance indicators
+- Risk calculation and display
+- Basic safe settings modal
+
+### Phase 3: Config Application
+- Profile config builder
+- Integration with ollamaSetup flow
+- Ollama env var guidance UI
+
+### Phase 4: Workspace & Diagnostics
+- Workspace size checking
+- File size guard component
+- Settings panel integration
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Hardware detection logic
+- Profile determination algorithm
+- Risk calculation edge cases
+- Config builder output validation
+
+### Integration Tests
+- Full setup flow with mocked Docker
+- Model selection → config application chain
+- State persistence across sessions
+
+### Manual Verification
+- Test on actual M4 24GB Mac
+- Verify all recommended models install and run
+- Confirm timeout risk estimates match reality
+- Validate workspace size calculations

--- a/openspec/ui/hardware-profile-ui-design.md
+++ b/openspec/ui/hardware-profile-ui-design.md
@@ -1,0 +1,471 @@
+# Hardware Profile System - UI Design Document
+
+## Design Principles
+
+1. **Transparent**: Show users what we detected and why we're recommending settings
+2. **Non-blocking**: Never prevent user from overriding recommendations
+3. **Educational**: Explain the "why" behind each suggestion
+4. **Progressive disclosure**: Start simple, allow deep dives
+
+---
+
+## Screen 1: Hardware Detection Banner
+
+### Purpose
+Immediately show users we understand their hardware and have tailored recommendations.
+
+### Placement
+Top of main extension panel, persistent once detected.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ┌─────────────────────────────────────────────────────────┐     │
+│  │ 🖥️  M4 Mac • 24GB RAM • Apple GPU                        │  ✓ │
+│  │ Balanced profile: Optimized for 8-14B models             │     │
+│  │ [Optimize Settings] [Change Profile] [ⓘ]                 │     │
+│  └─────────────────────────────────────────────────────────┘     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### States
+
+**Initial (Detecting):**
+```
+┌────────────────────────────────────────┐
+│ 🔍 Detecting your Mac hardware...      │
+└────────────────────────────────────────┘
+```
+
+**Detected:**
+```
+┌─────────────────────────────────────────────────────────┐
+│ 🖥️  M4 Pro • 24GB RAM • Apple GPU                        │
+│ Balanced profile: Optimized for 8-14B models          │
+│ [Optimize Settings] [ⓘ]                               │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Manual Override Active:**
+```
+┌─────────────────────────────────────────────────────────┐
+│ 🖥️  M4 Pro • 24GB RAM (Custom: Light profile)           │
+│ [Revert to Auto] [ⓘ]                                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Interaction
+- Clicking chip icon opens hardware details modal
+- "Optimize Settings" applies profile defaults
+- Info icon opens local-model-tuning.md
+
+---
+
+## Screen 2: Model Selection with Performance Indicators
+
+### Purpose
+Help users choose appropriate models for their hardware with clear performance expectations.
+
+### Placement
+Ollama setup flow, after connection test.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Select Ollama Model                                              │
+│                                                                   │
+│  🖥️  Using: M4 Mac, 24GB RAM                                     │
+│                                                                   │
+│  ─────────────────────────────────────────────────────────────   │
+│  ⭐ RECOMMENDED FOR YOUR MAC                                      │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 🔥 Gemma 4 (9B)         [Recommended]                      │  │
+│  │    ~22 tokens/sec • ~6GB RAM • Good balance               │  │
+│  │    ✓ Low timeout risk                                     │  │
+│  │    [Select]                                               │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  Qwen3 8B               [Recommended]                      │  │
+│  │    ~30 tokens/sec • ~5GB RAM • Fast responses           │  │
+│  │    ✓ Low timeout risk                                     │  │
+│  │    [Select]                                               │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  Gemma 4 Fast (4B)                                       │  │
+│  │    ~40 tokens/sec • ~3GB RAM • Maximum speed            │  │
+│  │    ✓ Low timeout risk                                     │  │
+│  │    [Select]                                               │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  ─────────────────────────────────────────────────────────────   │
+│  OTHER AVAILABLE MODELS                                           │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  Qwen3.5 (9.7B)                                          │  │
+│  │    ~18 tokens/sec • ~6GB RAM • Higher quality           │  │
+│  │    ⚠️ Medium timeout risk on large prompts               │  │
+│  │    [Select]                                               │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  Qwen3 14B              [Advanced]                       │  │
+│  │    ~13 tokens/sec • ~9GB RAM • Slower, stronger          │  │
+│  │    ⚠️ High timeout risk • May need lean mode             │  │
+│  │    [Select with Warnings]                                   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  [Show All Models...]                                             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Card Components
+
+Each model card shows:
+- **Model name** + parameter count
+- **Performance badge**: 🔥 Fast, ⚡ Balanced, 🐢 Slow
+- **Tokens/sec**: Estimated range
+- **RAM usage**: Approximate memory needed
+- **Risk indicator**: ✓ Low / ⚠️ Medium / 🚫 High timeout risk
+- **Description**: One-line use case
+- **Action button**: Select / Select with Warnings
+
+### Risk Calculation Display
+
+When user hovers on risk indicator:
+
+```
+┌─────────────────────────────────────┐
+│  ⚠️ Timeout Risk Explained          │
+│                                     │
+│  Estimated performance on your Mac: │
+│  • Prompt eval: 25-35s (typical)    │
+│  • Token generation: ~18 tok/s      │
+│                                     │
+│  Risk factors:                      │
+│  • Large prompts (>15K tokens)      │
+│  • Heavy tool usage                 │
+│  • Large workspace files            │
+│                                     │
+│  [Learn how to mitigate]           │
+└─────────────────────────────────────┘
+```
+
+---
+
+## Screen 3: Safe Settings Confirmation
+
+### Purpose
+Apply hardware-optimized configuration with user consent and transparency.
+
+### Placement
+After model selection, before applying to OpenClaw.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Apply Safe Settings for Qwen3.5?                               │
+│                                                                   │
+│  Based on your M4 Mac (24GB), we recommend:                     │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  ⚙️ Configuration Changes                                │  │
+│  │                                                           │  │
+│  │  OpenClaw Settings:                                      │  │
+│  │  • Enable lean mode (smaller prompts)        [✓]         │  │
+│  │  • Set context window to 16K tokens          [✓]         │  │
+│  │  • Configure early compaction                [✓]         │  │
+│  │                                                           │  │
+│  │  Ollama Host Settings (copy these):                      │  │
+│  │  • OLLAMA_FLASH_ATTENTION=1                            │  │
+│  │  • OLLAMA_KV_CACHE_TYPE=q8_0                           │  │
+│  │  • OLLAMA_KEEP_ALIVE=30m                               │  │
+│  │    [Copy Commands]                                       │  │
+│  │                                                           │  │
+│  │  Expected improvement:                                   │  │
+│  │  • Prompt eval: 40% faster                             │  │
+│  │  • Timeout risk: Low → Very Low                        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  [Apply Settings]  [Customize...]  [Skip - Use Defaults]        │
+│                                                                   │
+│  💡 Tip: You can change these later in Settings                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Customization Modal
+
+If user clicks "Customize...":
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Customize Configuration                                        │
+│                                                                   │
+│  Context Window                                                 │
+│  ● 8K (fastest)  ○ 16K (balanced)  ○ 32K (full)                 │
+│  Smaller = faster prompt evaluation                             │
+│                                                                   │
+│  Lean Mode                                                      │
+│  ☑ Enable lean mode (removes browser/cron/message tools)       │
+│  Reduces prompt size, helpful for timeout prevention           │
+│                                                                   │
+│  Tool Support                                                   │
+│  ☑ Enable full tool support (may increase prompt size)         │
+│                                                                   │
+│  Compaction                                                     │
+│  Trigger compaction when within: [8192] tokens of limit       │
+│                                                                   │
+│           [Cancel]  [Apply Custom]                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Screen 4: Workspace File Size Guard
+
+### Purpose
+Warn users when workspace files are large enough to impact performance.
+
+### Placement
+Shown during setup completion and in Settings > Diagnostics.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Workspace File Check                                             │
+│                                                                   │
+│  ⚠️ Large files may slow down prompt evaluation                │
+│                                                                   │
+│  Your workspace files:                                          │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ File              Size      Status   Impact                 │  │
+│  │ ─────────────────────────────────────────────────────────  │  │
+│  │ AGENTS.md         15.4 KB   ⚠️ Large  ~25s eval time        │  │
+│  │ SOUL.md           8.2 KB    ⚠️ Large  ~13s eval time        │  │
+│  │ TOOLS.md          2.1 KB    ✓ OK     ~3s eval time         │  │
+│  │ IDENTITY.md       0.8 KB    ✓ OK     ~1s eval time         │  │
+│  │ USER.md           0.4 KB    ✓ OK     ~1s eval time         │  │
+│  │ ─────────────────────────────────────────────────────────  │  │
+│  │ TOTAL             26.9 KB   ⚠️ High  ~43s added eval       │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  💡 This adds ~43 seconds to every prompt evaluation            │
+│     on your hardware (M4 24GB)                                   │
+│                                                                   │
+│  Quick fixes:                                                   │
+│  [Enable Lean Mode] [Open in Control UI] [Learn More]           │
+│                                                                   │
+│  [Dismiss]  [Don't Show Again]                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### File Actions Dropdown
+
+Each file row has actions:
+
+```
+┌────────────────────────┐
+│ Actions for AGENTS.md  │
+├────────────────────────┤
+│ View in Control UI     │
+│ ─────────────────────  │
+│ Open in editor         │
+│ Move to docs/ folder   │
+│ ─────────────────────  │
+│ Trim to 8K characters  │
+│ (creates backup)       │
+└────────────────────────┘
+```
+
+---
+
+## Screen 5: Ollama Host Optimization Guide
+
+### Purpose
+Help users configure their host Ollama for optimal performance.
+
+### Placement
+Shown after Ollama connection test if optimizations are available.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Optimize Your Ollama Host                                        │
+│                                                                   │
+│  🖥️  Detected: Ollama running on your Mac (host)                 │
+│                                                                   │
+│  Your hardware (M4, 24GB) can benefit from these settings:        │
+│                                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  Current vs Recommended                                  │  │
+│  │                                                           │  │
+│  │  OLLAMA_FLASH_ATTENTION    ❌ Not set  →  ✅ 1          │  │
+│  │  OLLAMA_KV_CACHE_TYPE      f16 (default) →  q8_0         │  │
+│  │  OLLAMA_NUM_PARALLEL       4 (default)   →  1            │  │
+│  │  OLLAMA_KEEP_ALIVE         5m (default)  →  30m        │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  Expected benefits:                                             │
+│  • 30% faster prompt evaluation                                  │
+│  • 50% less memory usage                                        │
+│  • Lower risk of 120s timeout                                   │
+│                                                                   │
+│  To apply, run these commands in Terminal:                      │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │  # Add to your ~/.zshrc or ~/.bash_profile                │  │
+│  │  export OLLAMA_FLASH_ATTENTION=1                          │  │
+│  │  export OLLAMA_KV_CACHE_TYPE=q8_0                          │  │
+│  │  export OLLAMA_NUM_PARALLEL=1                              │  │
+│  │  export OLLAMA_KEEP_ALIVE=30m                            │  │
+│  │                                                           │  │
+│  │  # Then restart Ollama                                    │  │
+│  │  killall ollama && ollama serve                          │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│  [Copy All Commands]  [Copy Export Lines Only]                  │
+│                                                                   │
+│  [I've Already Done This]  [Remind Me Later]  [Don't Ask Again] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Check Verification
+
+After user clicks "I've Already Done This":
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚙️ Verifying Ollama Settings...                                │
+│                                                                   │
+│  Testing with a small prompt...                                  │
+│  ✓ OLLAMA_FLASH_ATTENTION is active                            │
+│  ✓ Response time improved (was: 45s, now: 28s)                  │
+│                                                                   │
+│  [Done]                                                           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Screen 6: Settings Panel Integration
+
+### Purpose
+Allow users to view and adjust hardware profile settings.
+
+### Placement
+New "Hardware & Performance" section in Settings tab.
+
+### Design
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚙️ Settings                                                      │
+│                                                                   │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │ HARDWARE & PERFORMANCE                                      ││
+│  │                                                              ││
+│  │ Detected Profile                                            ││
+│  │ 🖥️  M4 Mac • 24GB RAM • Apple GPU                           ││
+│  │ Balanced (8-14B models recommended)                         ││
+│  │ [Change to Light] [Change to Performance]                   ││
+│  │                                                              ││
+│  │ ─────────────────────────────────────────────────────────    ││
+│  │                                                              ││
+│  │ Performance Settings                                         ││
+│  │                                                              ││
+│  │ Lean Mode           [Enabled ▼]                             ││
+│  │ Context Window      [16384 tokens ▼]                        ││
+│  │ Tool Support        [Full ▼]                                  ││
+│  │ Compaction Reserve  [8192 tokens ▼]                         ││
+│  │                                                              ││
+│  │ ─────────────────────────────────────────────────────────    ││
+│  │                                                              ││
+│  │ Diagnostics                                                  ││
+│  │ [Check Workspace File Sizes]                                ││
+│  │ [Test Current Performance]                                  ││
+│  │ [View Local Model Tuning Guide]                            ││
+│  │                                                              ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                                                                   │
+│  [Save Changes]  [Reset to Profile Defaults]                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Responsive Behavior
+
+### Narrow Panel (Docker Desktop default)
+
+```
+┌─────────────────────────────┐
+│ 🖥️ M4 • 24GB               │
+│ Balanced profile            │
+│ [Optimize] [ⓘ]             │
+└─────────────────────────────┘
+```
+
+```
+┌─────────────────────────────┐
+│ Select Model                │
+│                             │
+│ ⭐ Recommended:              │
+│ 🔥 Gemma 4 (9B)            │
+│ ~22 tok/s • ✓ Low risk     │
+│ [Select]                   │
+│                             │
+│  More models...             │
+└─────────────────────────────┘
+```
+
+### Wide Panel (User expanded)
+
+Full designs as shown above.
+
+---
+
+## Animation & Transitions
+
+### Hardware Detection
+
+1. **Scanning**: Pulse animation on chip icon (2s)
+2. **Success**: Checkmark fade in, profile slide down (300ms)
+3. **Error**: Shake animation, show manual selection
+
+### Model Cards
+
+1. **Hover**: Subtle lift (translateY -2px) + shadow increase
+2. **Select**: Border highlight + ripple effect
+3. **Risk reveal**: Yellow pulse on ⚠️ icon
+
+### Settings Applied
+
+1. **Success toast**: Slide in from bottom, auto-dismiss 5s
+2. **Config change**: Subtle fade on affected values
+
+---
+
+## Color Scheme
+
+| Element | Color | Usage |
+|---------|-------|-------|
+| Low risk | Green #22c55e | ✓ indicators |
+| Medium risk | Amber #f59e0b | ⚠️ warnings |
+| High risk | Red #ef4444 | 🚫 errors |
+| Recommended | Blue #3b82f6 | ⭐ badges |
+| Fast | Orange #f97316 | 🔥 indicators |
+| Info | Gray #6b7280 | Tooltips, secondary |
+
+---
+
+## Accessibility
+
+- All risk indicators have text equivalents (not just color)
+- Icons have aria-labels
+- Keyboard navigation for all interactive elements
+- Reduced motion support via `prefers-reduced-motion`

--- a/openspec/verification/m4-24gb-manual-verification.md
+++ b/openspec/verification/m4-24gb-manual-verification.md
@@ -1,0 +1,335 @@
+# Manual Verification Plan: M4 Mac 24GB
+
+## Test Environment
+
+**Target Hardware**: M4 Mac (base or Pro) with 24GB unified memory
+**OS**: macOS Sequoia 15.x
+**Ollama**: v0.19+ (MLX backend)
+**Extension**: Local dev build
+
+---
+
+## Prerequisites
+
+1. Ollama installed and running on host
+2. Extension installed from local dev build (`make install-dev`)
+3. All test models pulled: `ollama pull gemma4 qwen3:8b llama3.2 qwen3:14b gemma4-fast qwen2.5:3b`
+4. Ollama env vars set:
+   ```bash
+   export OLLAMA_FLASH_ATTENTION=1
+   export OLLAMA_KV_CACHE_TYPE=q8_0
+   export OLLAMA_NUM_PARALLEL=1
+   export OLLAMA_KEEP_ALIVE=30m
+   ```
+
+---
+
+## Test Matrix
+
+### Test 1: Model Performance Benchmarks
+
+**Goal**: Verify actual tokens/sec matches our estimates
+
+| Model | Expected tok/s | Actual tok/s | Status |
+|-------|----------------|--------------|--------|
+| gemma4-fast | 35-45 | | |
+| qwen2.5:3b | 40-50 | | |
+| qwen3:8b | 28-35 | | |
+| llama3.2 | 24-28 | | |
+| gemma4 | 20-25 | | |
+| qwen3.5 | 15-20 | | |
+| qwen3:14b | 10-16 | | |
+
+**Test Command**:
+```bash
+# Test generation speed
+curl http://localhost:11434/api/generate -d '{
+  "model": "gemma4",
+  "prompt": "Write a paragraph about machine learning.",
+  "stream": false
+}' | jq '.eval_rate'
+```
+
+**Pass Criteria**:
+- Actual tok/s within 20% of expected range
+- No OOM errors
+- Model loads successfully
+
+---
+
+### Test 2: Prompt Evaluation Timeout Risk
+
+**Goal**: Verify which models hit the 120s timeout with large prompts
+
+**Test Setup**:
+1. Configure OpenClaw with `num_ctx: 16384` (16K context)
+2. Create a large workspace file (simulate AGENTS.md at 15KB)
+3. Send a complex multi-turn conversation to build context
+4. Measure prompt eval time for each model
+
+**Measurement**:
+```bash
+# Use Ollama API to measure prompt eval
+curl http://localhost:11434/api/generate -d '{
+  "model": "MODEL_NAME",
+  "prompt": "PASTE_LARGE_PROMPT_HERE",
+  "stream": false
+}' | jq '.prompt_eval_count, .prompt_eval_duration'
+
+# Calculate: prompt_eval_count / (prompt_eval_duration / 1e9) = tok/s
+```
+
+**Timeout Risk Verification**:
+
+| Model | Context | Prompt Eval Time | Timeout? |
+|-------|---------|------------------|----------|
+| gemma4-fast | 8K | Expected: ~15s | |
+| gemma4-fast | 16K | Expected: ~30s | |
+| gemma4 | 8K | Expected: ~25s | |
+| gemma4 | 16K | Expected: ~50s | |
+| qwen3:14b | 8K | Expected: ~35s | |
+| qwen3:14b | 16K | Expected: ~70s | |
+
+**Pass Criteria**:
+- gemma4 at 16K: <90s (safe margin)
+- qwen3:14b at 16K: <100s (acceptable risk)
+- No actual timeouts in OpenClaw during 5-turn conversation
+
+---
+
+### Test 3: Workspace File Size Impact
+
+**Goal**: Quantify how workspace file size affects prompt eval time
+
+**Test Steps**:
+1. Start with minimal workspace (empty AGENTS.md)
+2. Measure baseline prompt eval time
+3. Add 10KB to AGENTS.md
+4. Measure prompt eval time
+5. Add another 10KB (20KB total)
+6. Measure again
+
+**Expected Impact**:
+| Workspace Size | Added Eval Time |
+|----------------|-----------------|
+| 10KB | ~10-15s |
+| 20KB | ~20-30s |
+
+**Pass Criteria**:
+- Each 10KB adds roughly 10-15s to eval time
+- UI warnings appear at correct thresholds
+
+---
+
+### Test 4: Configuration Effectiveness
+
+**Goal**: Verify each configuration change has expected effect
+
+**Test A: Lean Mode**
+1. Disable lean mode, measure prompt eval
+2. Enable lean mode, measure again
+3. Verify faster eval with lean mode
+
+**Test B: Context Size**
+1. Test with num_ctx: 32768
+2. Test with num_ctx: 16384
+3. Test with num_ctx: 8192
+4. Verify smaller context = faster eval
+
+**Test C: KV Cache Type**
+1. Test with OLLAMA_KV_CACHE_TYPE=f16
+2. Test with q8_0
+3. Test with q4_0 (if available)
+4. Verify memory usage and speed differences
+
+**Pass Criteria**:
+- Lean mode: 10-20% faster
+- Half context size: ~40% faster
+- q8_0 vs f16: similar speed, less memory
+
+---
+
+### Test 5: Full Extension Flow
+
+**Goal**: End-to-end verification of hardware profile features
+
+**Flow 1: First-time Setup**
+1. Reset extension state
+2. Open extension
+3. Verify hardware detection shows "M4 Mac • 24GB • Balanced"
+4. Select gemma4
+5. Verify safe settings modal appears
+6. Apply settings
+7. Verify config applied correctly
+
+**Flow 2: Model with Risk Warning**
+1. Go to settings
+2. Select qwen3:14b
+3. Verify high risk warning appears
+4. Verify mitigation suggestions shown
+5. Apply with mitigations
+6. Verify lean mode enabled and context reduced
+
+**Flow 3: Workspace Size Check**
+1. Create large AGENTS.md (20KB)
+2. Restart extension
+3. Verify size warning appears
+4. Verify "trim" or "enable lean mode" actions work
+
+**Pass Criteria**:
+- All UI flows work without errors
+- Configurations apply correctly
+- Warnings appear at appropriate times
+
+---
+
+## Measurement Tools
+
+### 1. Ollama API Timing Script
+
+```bash
+#!/bin/bash
+# benchmark-model.sh
+
+MODEL=$1
+PROMPT="Write a detailed explanation of how neural networks work, including architecture, training process, and common applications. Be thorough and use examples."
+
+echo "Benchmarking $MODEL..."
+
+RESULT=$(curl -s http://localhost:11434/api/generate -d "{
+  \"model\": \"$MODEL\",
+  \"prompt\": \"$PROMPT\",
+  \"stream\": false
+}")
+
+PROMPT_EVAL_COUNT=$(echo $RESULT | jq '.prompt_eval_count')
+PROMPT_EVAL_DURATION=$(echo $RESULT | jq '.prompt_eval_duration')
+EVAL_COUNT=$(echo $RESULT | jq '.eval_count')
+EVAL_DURATION=$(echo $RESULT | jq '.eval_duration')
+
+# Convert nanoseconds to seconds
+PROMPT_EVAL_SECS=$(echo "scale=3; $PROMPT_EVAL_DURATION / 1000000000" | bc)
+EVAL_SECS=$(echo "scale=3; $EVAL_DURATION / 1000000000" | bc)
+
+# Calculate rates
+PROMPT_RATE=$(echo "scale=1; $PROMPT_EVAL_COUNT / $PROMPT_EVAL_SECS" | bc)
+GEN_RATE=$(echo "scale=1; $EVAL_COUNT / $EVAL_SECS" | bc)
+
+echo "Prompt eval: $PROMPT_EVAL_COUNT tokens in ${PROMPT_EVAL_SECS}s = ${PROMPT_RATE} tok/s"
+echo "Generation: $EVAL_COUNT tokens in ${EVAL_SECS}s = ${GEN_RATE} tok/s"
+```
+
+### 2. Workspace File Size Check
+
+```bash
+#!/bin/bash
+# check-workspace.sh
+
+CONTAINER="openclaw-docker-desktop-extension-runtime"
+
+docker exec $CONTAINER sh -c '
+  cd /home/node/.openclaw/workspace &&
+  echo "=== Workspace File Sizes ===" &&
+  wc -c AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md 2>/dev/null &&
+  echo "=== Total ===" &&
+  cat AGENTS.md SOUL.md TOOLS.md IDENTITY.md USER.md 2>/dev/null | wc -c
+'
+```
+
+### 3. OpenClaw Config Verification
+
+```bash
+#!/bin/bash
+# verify-config.sh
+
+CONTAINER="openclaw-docker-desktop-extension-runtime"
+
+echo "=== OpenClaw Config ==="
+docker exec $CONTAINER cat /home/node/.openclaw/openclaw.json | jq .
+
+echo ""
+echo "=== Ollama Model Config ==="
+docker exec $CONTAINER cat /home/node/.openclaw/openclaw.json | jq '.models.providers.ollama.models[0]'
+```
+
+---
+
+## Expected Results Summary
+
+### M4 Mac 24GB - Balanced Profile
+
+**Recommended Models**:
+1. **gemma4** - Primary recommendation
+   - Speed: ~22 tok/s
+   - Prompt eval: ~25-35s at 16K context
+   - Risk: Low to Medium
+   
+2. **qwen3:8b** - Fast alternative
+   - Speed: ~30 tok/s
+   - Prompt eval: ~20-25s at 16K context
+   - Risk: Low
+
+3. **gemma4-fast** - Maximum speed
+   - Speed: ~40 tok/s
+   - Prompt eval: ~15-20s at 16K context
+   - Risk: Very Low
+
+**Configuration**:
+- num_ctx: 16384
+- localModelLean: true
+- OLLAMA_KV_CACHE_TYPE: q8_0
+- OLLAMA_FLASH_ATTENTION: 1
+
+**Timeout Risk Models**:
+- qwen3:14b at 16K context: ~60-70s eval (medium risk)
+- qwen3.5 at 16K context: ~50-60s eval (medium risk)
+
+---
+
+## Success Criteria
+
+### Absolute Requirements
+- [ ] gemma4 at 16K context: <90s prompt eval
+- [ ] gemma4-fast at 16K context: <60s prompt eval
+- [ ] No timeouts during normal 5-turn conversation
+- [ ] Extension hardware detection works
+- [ ] Model recommendations appropriate for hardware
+
+### Nice-to-Have
+- [ ] qwen3:14b at 16K context: <100s eval (borderline but usable)
+- [ ] Lean mode provides measurable improvement
+- [ ] UI warnings prevent user from selecting inappropriate models
+
+---
+
+## Issue Tracking
+
+Use this section during testing to record actual vs expected:
+
+| Test | Expected | Actual | Status | Notes |
+|------|----------|--------|--------|-------|
+| gemma4 tok/s | 20-25 | | | |
+| gemma4 eval 16K | ~35s | | | |
+| qwen3:14b eval 16K | ~70s | | | |
+| Lean mode improvement | 10-20% | | | |
+| Hardware detection | M4 24GB | | | |
+
+---
+
+## Sign-Off
+
+**Tester**: _________________
+**Date**: _________________
+**Hardware**: _________________
+**Ollama Version**: _________________
+
+**Overall Result**: [ ] PASS [ ] FAIL
+
+**Blocking Issues**:
+- [ ] None
+- [ ] Issue 1: _________________
+- [ ] Issue 2: _________________
+
+**Notes**:
+_________________________________
+_________________________________


### PR DESCRIPTION
## Summary

Adds the OpenSpec design package for the hardware-profile / local-model-performance work. **Docs-only** — no runtime, UI, or build changes in the PR diff.

Rebased/merged onto current `main` on 2026-06-26 to clear the merge conflict. The conflict in `docs/local-model-tuning.md` was resolved in favor of current `main`, because `main` already contains the newer local-model tuning guide and #162 cache-eviction guidance.

## Contents

- `openspec/specs/hardware-profile-system.md`
- `openspec/ui/hardware-profile-ui-design.md`
- `openspec/tech/hardware-profile-implementation.md`
- `openspec/verification/m4-24gb-manual-verification.md`
- `openspec/issues/157-160*.md` — the four GitHub issues already filed as #157-#160
- `openspec/README.md`

## Related

- Documents design direction for #157, #158, #159, #160.
- #156 remains the hard blocker for genuine large-prompt local Ollama reliability; sequence it alongside #157/#158, not after them.

## Verification

- `make test-pre-push`

## Review note

Pure documentation/spec. No screenshot impact.
