### PR TITLE
feat(ui): add Ollama cache eviction guidance

### DIFF
--- a/docs/local-model-tuning.md
+++ b/docs/local-model-tuning.md
@@ -1,0 +1,223 @@
+# Local Model Tuning Guide
+
+This guide helps you tune OpenClaw for local Ollama models on constrained hardware. Running large language models locally requires balancing speed, memory, and context size against your hardware capabilities.
+
+## The Core Constraint
+
+OpenClaw has a **120-second idle timeout watchdog** that aborts requests when no tokens are received. On CPU-only hardware, evaluating a large prompt can exceed this limit, causing timeouts before the first token arrives. This guide provides practical workarounds and tuning strategies to work within this constraint.
+
+**Key insight:** No configuration currently available can raise this 120s limit. The strategies below help you stay under it through hardware-appropriate model selection and prompt optimization.
+
+---
+
+## One Model at a Time (Critical for Avoiding Timeouts)
+
+The most important optimization for avoiding timeouts is to **use one model consistently**. When you switch models in the Control UI dropdown:
+
+1. The previous model's KV cache is evicted from Ollama memory
+2. The new model must load and re-evaluate the entire system prompt (~20,000 tokens)
+3. This can take 8-40 seconds depending on the model and hardware
+4. If you switch back, the cycle repeats
+
+**Symptoms of cache eviction:**
+- First chat with a model works fine
+- Second chat with a different model is slow
+- Switching back to the first model is slow again
+
+### Solution: Use One Model Consistently
+
+Pick one model for your workflow and stick with it. If you need multiple models, see below for the `OLLAMA_MAX_LOADED_MODELS` option.
+
+### Solution: OLLAMA_MAX_LOADED_MODELS (If You Have RAM)
+
+If you have sufficient RAM, you can configure Ollama to keep multiple models loaded simultaneously:
+
+```bash
+# macOS (add to ~/.zshrc or ~/.bash_profile)
+export OLLAMA_MAX_LOADED_MODELS=2    # Allow 2 models in memory
+
+# Linux (add to ~/.bashrc)
+export OLLAMA_MAX_LOADED_MODELS=2
+```
+
+**Requirements:**
+- gemma4-fast (8B) + qwen3.5 (9.7B): ~16GB RAM recommended
+- Two gemma4 models: ~12GB RAM recommended
+
+Default is `1`, which causes cache eviction when switching models.
+
+---
+
+## Quick Diagnostic: What Hardware Profile Are You?
+
+| Profile | RAM | GPU | Typical Use Case |
+|---------|-----|-----|------------------|
+| [Light](#light-profile-cpu-only-8-16gb-ram) | 8-16 GB | None | Older laptops, budget desktops |
+| [Balanced](#balanced-profile-apple-silicon-or-16-24gb-ram) | 16-24 GB | Integrated/Apple Silicon | MacBook Air/Pro M1-M4, modern laptops |
+| [Performance](#performance-profile-32gb-ram-dedicated-gpu) | 32+ GB | 8GB+ VRAM | Desktop workstations, gaming PCs |
+
+---
+
+## Light Profile: CPU-Only, 8-16GB RAM
+
+**Target:** Stay under 60-90s prompt evaluation to avoid the 120s timeout.
+
+### Recommended Models
+
+| Model | Parameters | VRAM/RAM | Speed | Notes |
+|-------|------------|----------|-------|-------|
+| `gemma4-fast:latest` | 4B | ~3 GB | Fast | Best choice for light hardware |
+| `qwen2.5:3b` | 3B | ~2 GB | Fast | Good alternative if gemma4 unavailable |
+| `llama3.2:1b` | 1B | ~1 GB | Very fast | Minimal capability, but reliable |
+
+**Avoid:** Models >7B parameters on CPU-only—they're too slow for practical use.
+
+### Ollama Host Configuration
+
+Set these environment variables on your **host Ollama** (not the extension container):
+
+```bash
+# macOS (add to ~/.zshrc or ~/.bash_profile)
+export OLLAMA_NUM_PARALLEL=1          # Keep at 1—parallelism multiplies memory use
+export OLLAMA_FLASH_ATTENTION=1       # Reduces memory, improves speed
+export OLLAMA_KV_CACHE_TYPE=q4_0     # Aggressive quantization: ¼ memory of f16
+export OLLAMA_KEEP_ALIVE=30m          # Keep model loaded, skip cold-start delay
+```
+
+Restart Ollama after setting:
+```bash
+# macOS
+pkill ollama
+open -a Ollama
+
+# Linux
+sudo systemctl restart ollama
+```
+
+### OpenClaw Extension Configuration
+
+Use the leanest agent configuration to reduce prompt size:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "experimental": {
+        "localModelLean": true
+      }
+    }
+  }
+}
+```
+
+This removes heavyweight tools (browser, cron, message) from the system prompt.
+
+---
+
+## Balanced Profile: Apple Silicon or 16-24GB RAM
+
+**Target:** Comfortable margin under 120s even with larger prompts.
+
+### Recommended Models
+
+| Model | Parameters | VRAM/RAM | Speed | Notes |
+|-------|------------|----------|-------|-------|
+| `gemma4:latest` | 8B | ~6 GB | Medium | Good balance for M-series Macs |
+| `qwen3.5:latest` | 9.7B | ~7 GB | Medium-Slow | Better reasoning, slower |
+| `gemma4-long:latest` | 8B | ~6 GB | Medium | Optimized for longer context |
+
+**M-series Mac tip:** Ollama uses Apple Silicon Neural Engine automatically—no extra config needed.
+
+### Ollama Host Configuration
+
+```bash
+# macOS
+export OLLAMA_NUM_PARALLEL=1          # Keep at 1 unless you have 32GB+
+export OLLAMA_FLASH_ATTENTION=1       # ~20% speedup on Apple Silicon
+export OLLAMA_KV_CACHE_TYPE=q8_0     # Good balance: ½ memory of f16
+export OLLAMA_KEEP_ALIVE=30m
+```
+
+### Context Window Tuning
+
+The extension now sets `num_ctx: 32768` by default (fixing the single-character reply bug). On 16GB systems, this is appropriate. On 24GB systems, you can experiment with larger values via `OPENCLAW_OLLAMA_NUM_CTX`.
+
+**Trade-off:** Larger context = more memory, slower prompt evaluation. The default is tuned for reliable operation on typical hardware.
+
+---
+
+## Performance Profile: 32GB+ RAM, Dedicated GPU
+
+**Target:** Maximize capability without worrying about timeouts.
+
+### Recommended Models
+
+| Model | Parameters | VRAM | Speed | Notes |
+|-------|------------|------|-------|-------|
+| `qwen3.6:latest` | 36B | ~22 GB | Medium | Excellent reasoning |
+| `gemma4:27b` | 27B | ~18 GB | Medium-Fast | Good balance |
+| `mixtral:latest` | 47B (MoE) | ~26 GB | Medium | State-of-the-art |
+
+### Ollama Host Configuration
+
+```bash
+export OLLAMA_NUM_PARALLEL=2          # Can increase with ample VRAM
+export OLLAMA_FLASH_ATTENTION=1
+export OLLAMA_KV_CACHE_TYPE=f16      # Full precision with enough VRAM
+export OLLAMA_KEEP_ALIVE=30m
+export OLLAMA_MAX_LOADED_MODELS=2    # Keep multiple models loaded
+```
+
+---
+
+## Troubleshooting Timeouts
+
+### Symptom: "Turn 1 works, turn 2 times out"
+
+**Cause:** Model switching evicted the KV cache.
+
+**Fix:** 
+1. Use the same model consistently, OR
+2. Set `OLLAMA_MAX_LOADED_MODELS=2` if you have RAM
+
+### Symptom: Long delays before first token (but no timeout)
+
+**Cause:** Large prompt evaluation on slower model.
+
+**Fix:**
+1. Switch to a faster model (gemma4-fast)
+2. Enable `OLLAMA_FLASH_ATTENTION=1`
+3. Reduce prompt size (trim AGENTS.md, SOUL.md)
+4. Use `localModelLean: true`
+
+### Symptom: Single-character replies
+
+**Cause:** Fixed in PR #154—extension now sets `num_ctx: 32768` by default.
+
+If you see this, ensure you're using the latest extension version.
+
+---
+
+## Environment Variable Reference
+
+Set these on your **host Ollama** before starting the service:
+
+| Variable | Values | Effect |
+|----------|--------|--------|
+| `OLLAMA_FLASH_ATTENTION` | `1` or unset | Enables flash attention (~20-40% speedup) |
+| `OLLAMA_KV_CACHE_TYPE` | `f16`, `q8_0`, `q4_0` | KV cache quantization level |
+| `OLLAMA_NUM_PARALLEL` | `1`, `2`, `4` | Parallel request handling (multiplies memory) |
+| `OLLAMA_MAX_LOADED_MODELS` | `1`, `2`, `3+` | Models kept in memory simultaneously |
+| `OLLAMA_KEEP_ALIVE` | `30m`, `1h`, etc. | Time to keep model loaded after last use |
+
+---
+
+## See Also
+
+- [GitHub Issue #156](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/156) - 120s timeout discussion
+- [GitHub Issue #158](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/158) - Ollama environment variable guidance
+- [GitHub Issue #159](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/159) - Workspace file size optimization
+
+---
+
+*Last updated: 2026-06-18*

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,6 +33,7 @@ import {
   type OllamaModel,
 } from './ollamaSetup';
 import { ollamaApplyButtonLabel } from './ollamaUiState';
+import { buildLocalModelGuidance, getCondensedGuidance } from './ollamaGuidance';
 import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';
@@ -1417,6 +1418,16 @@ export function App() {
               </TextField>
               {ollamaStatus && (
                 <Alert severity={ollamaAlertSeverity}>{ollamaStatus}</Alert>
+              )}
+              {configuredOllamaModel && (
+                <Alert severity="info" icon={false}>
+                  <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                    Performance Tip
+                  </Typography>
+                  <Typography variant="body2">
+                    {getCondensedGuidance()}
+                  </Typography>
+                </Alert>
               )}
             </Stack>
           </CardContent>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -33,7 +33,7 @@ import {
   type OllamaModel,
 } from './ollamaSetup';
 import { ollamaApplyButtonLabel } from './ollamaUiState';
-import { buildLocalModelGuidance, getCondensedGuidance } from './ollamaGuidance';
+import { getCondensedGuidance } from './ollamaGuidance';
 import { runDetect } from './ollamaDetect';
 import { buildControlUiLaunchUrl } from './controlUiLaunch';
 import { appendDebugEntry } from './debugLog';

--- a/ui/src/ollamaGuidance.test.ts
+++ b/ui/src/ollamaGuidance.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLocalModelGuidance,
+  getCondensedGuidance,
+  buildEnvVarGuidance,
+} from './ollamaGuidance';
+
+describe('ollamaGuidance', () => {
+  describe('buildLocalModelGuidance', () => {
+    it('returns guidance sections with required fields', () => {
+      const guidance = buildLocalModelGuidance();
+
+      expect(guidance).toBeInstanceOf(Array);
+      expect(guidance.length).toBeGreaterThan(0);
+
+      for (const section of guidance) {
+        expect(section).toHaveProperty('title');
+        expect(section).toHaveProperty('content');
+        expect(typeof section.title).toBe('string');
+        expect(typeof section.content).toBe('string');
+        expect(section.title.length).toBeGreaterThan(0);
+        expect(section.content.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('includes One Model at a Time section', () => {
+      const guidance = buildLocalModelGuidance();
+      const oneModelSection = guidance.find(
+        (s) => s.title === 'One Model at a Time'
+      );
+
+      expect(oneModelSection).toBeDefined();
+      expect(oneModelSection!.content).toContain('cache');
+      expect(oneModelSection!.content).toContain('timeout');
+      expect(oneModelSection!.link).toContain('local-model-tuning.md');
+    });
+
+    it('includes OLLAMA_MAX_LOADED_MODELS section', () => {
+      const guidance = buildLocalModelGuidance();
+      const maxLoadedSection = guidance.find((s) =>
+        s.title.includes('OLLAMA_MAX_LOADED_MODELS')
+      );
+
+      expect(maxLoadedSection).toBeDefined();
+      expect(maxLoadedSection!.content).toContain('RAM');
+    });
+
+    it('includes OLLAMA_FLASH_ATTENTION section', () => {
+      const guidance = buildLocalModelGuidance();
+      const flashAttentionSection = guidance.find((s) =>
+        s.title.includes('OLLAMA_FLASH_ATTENTION')
+      );
+
+      expect(flashAttentionSection).toBeDefined();
+      expect(flashAttentionSection!.content).toContain('faster');
+    });
+
+    it('includes OLLAMA_KV_CACHE_TYPE section', () => {
+      const guidance = buildLocalModelGuidance();
+      const kvCacheSection = guidance.find((s) =>
+        s.title.includes('OLLAMA_KV_CACHE_TYPE')
+      );
+
+      expect(kvCacheSection).toBeDefined();
+      expect(kvCacheSection!.content).toContain('memory');
+    });
+
+    it('includes Recommended Models section for M4 Mac', () => {
+      const guidance = buildLocalModelGuidance();
+      const modelsSection = guidance.find((s) =>
+        s.title.includes('Recommended Models')
+      );
+
+      expect(modelsSection).toBeDefined();
+      expect(modelsSection!.content).toContain('gemma4-fast');
+      expect(modelsSection!.content).toContain('qwen3.5');
+    });
+  });
+
+  describe('getCondensedGuidance', () => {
+    it('returns a non-empty string', () => {
+      const guidance = getCondensedGuidance();
+
+      expect(typeof guidance).toBe('string');
+      expect(guidance.length).toBeGreaterThan(0);
+    });
+
+    it('mentions cache eviction', () => {
+      const guidance = getCondensedGuidance();
+
+      expect(guidance).toContain('cache');
+    });
+
+    it('mentions OLLAMA_MAX_LOADED_MODELS', () => {
+      const guidance = getCondensedGuidance();
+
+      expect(guidance).toContain('OLLAMA_MAX_LOADED_MODELS');
+    });
+
+    it('mentions timeout', () => {
+      const guidance = getCondensedGuidance();
+
+      expect(guidance).toContain('timeout');
+    });
+
+    it('is concise (under 300 characters)', () => {
+      const guidance = getCondensedGuidance();
+
+      expect(guidance.length).toBeLessThan(300);
+    });
+  });
+
+  describe('buildEnvVarGuidance', () => {
+    it('returns environment variable guidance', () => {
+      const envVars = buildEnvVarGuidance();
+
+      expect(envVars).toBeInstanceOf(Array);
+      expect(envVars.length).toBeGreaterThan(0);
+    });
+
+    it('includes OLLAMA_MAX_LOADED_MODELS', () => {
+      const envVars = buildEnvVarGuidance();
+      const maxLoaded = envVars.find((v) => v.name === 'OLLAMA_MAX_LOADED_MODELS');
+
+      expect(maxLoaded).toBeDefined();
+      expect(maxLoaded!.value).toBe('2');
+      expect(maxLoaded!.description).toContain('cache');
+    });
+
+    it('includes OLLAMA_FLASH_ATTENTION', () => {
+      const envVars = buildEnvVarGuidance();
+      const flashAttention = envVars.find(
+        (v) => v.name === 'OLLAMA_FLASH_ATTENTION'
+      );
+
+      expect(flashAttention).toBeDefined();
+      expect(flashAttention!.value).toBe('1');
+      expect(flashAttention!.description).toContain('faster');
+    });
+
+    it('includes OLLAMA_KV_CACHE_TYPE', () => {
+      const envVars = buildEnvVarGuidance();
+      const kvCache = envVars.find((v) => v.name === 'OLLAMA_KV_CACHE_TYPE');
+
+      expect(kvCache).toBeDefined();
+      expect(kvCache!.value).toBe('q8_0');
+      expect(kvCache!.description).toContain('memory');
+    });
+
+    it('each entry has name, value, and description', () => {
+      const envVars = buildEnvVarGuidance();
+
+      for (const envVar of envVars) {
+        expect(envVar).toHaveProperty('name');
+        expect(envVar).toHaveProperty('value');
+        expect(envVar).toHaveProperty('description');
+        expect(typeof envVar.name).toBe('string');
+        expect(typeof envVar.value).toBe('string');
+        expect(typeof envVar.description).toBe('string');
+        expect(envVar.name.length).toBeGreaterThan(0);
+        expect(envVar.value.length).toBeGreaterThan(0);
+        expect(envVar.description.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/ui/src/ollamaGuidance.test.ts
+++ b/ui/src/ollamaGuidance.test.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 import { describe, it, expect } from 'vitest';
 import {
   buildLocalModelGuidance,

--- a/ui/src/ollamaGuidance.ts
+++ b/ui/src/ollamaGuidance.ts
@@ -1,0 +1,88 @@
+/**
+ * Ollama guidance module - provides static guidance for local model optimization
+ * and cache eviction prevention.
+ */
+
+export interface GuidanceSection {
+  title: string;
+  content: string;
+  link?: string;
+}
+
+/**
+ * Build comprehensive guidance for local Ollama model optimization.
+ * This guidance helps users avoid KV cache eviction and timeout issues.
+ */
+export function buildLocalModelGuidance(): GuidanceSection[] {
+  return [
+    {
+      title: "One Model at a Time",
+      content:
+        "On local Ollama, using a different model per chat (or switching the dropdown) " +
+        "evicts the first model's cache and causes slow replies or timeouts. " +
+        "Each model switch forces a full re-evaluation of the system prompt (~8-40 seconds). " +
+        "Use one model consistently across all chats for best performance.",
+      link: "https://github.com/jcowhigjr/openclaw-docker-desktop-extension/blob/main/docs/local-model-tuning.md",
+    },
+    {
+      title: "OLLAMA_MAX_LOADED_MODELS",
+      content:
+        "If you have sufficient RAM, set OLLAMA_MAX_LOADED_MODELS=2 (or higher) on your host Ollama. " +
+        "This allows multiple models to coexist in memory without cache eviction. " +
+        "Default is 1, which causes cache eviction when switching models.",
+    },
+    {
+      title: "OLLAMA_FLASH_ATTENTION",
+      content:
+        "Set OLLAMA_FLASH_ATTENTION=1 on your host Ollama for 20-40% faster inference. " +
+        "This optimizes attention computation and reduces prompt evaluation time.",
+    },
+    {
+      title: "OLLAMA_KV_CACHE_TYPE",
+      content:
+        "Set OLLAMA_KV_CACHE_TYPE=q8_0 on your host Ollama for better memory efficiency. " +
+        "This uses 8-bit quantization for the KV cache, reducing memory pressure.",
+    },
+    {
+      title: "Recommended Models for M4 Mac 24GB",
+      content:
+        "• gemma4-fast:latest (8B) - Fastest, ~8s for large prompts\n" +
+        "• qwen3.5:latest (9.7B) - Slower, ~40s for large prompts\n" +
+        "• Avoid model switching between these - it causes cache eviction and timeouts.",
+    },
+  ];
+}
+
+/**
+ * Get a condensed single-paragraph guidance for inline display.
+ */
+export function getCondensedGuidance(): string {
+  return (
+    "On local Ollama, a second model (switching the dropdown) evicts the first model's cache " +
+    "and causes slow replies / timeouts. Use one model, or set OLLAMA_MAX_LOADED_MODELS≥2 " +
+    "on your host (RAM permitting). See docs for more."
+  );
+}
+
+/**
+ * Build environment variable guidance card content.
+ */
+export function buildEnvVarGuidance(): { name: string; value: string; description: string }[] {
+  return [
+    {
+      name: "OLLAMA_MAX_LOADED_MODELS",
+      value: "2",
+      description: "Allow 2 models in memory (default: 1). Prevents cache eviction when switching.",
+    },
+    {
+      name: "OLLAMA_FLASH_ATTENTION",
+      value: "1",
+      description: "Enable flash attention for 20-40% faster inference.",
+    },
+    {
+      name: "OLLAMA_KV_CACHE_TYPE",
+      value: "q8_0",
+      description: "8-bit KV cache quantization for better memory efficiency.",
+    },
+  ];
+}

--- a/ui/src/ollamaGuidance.ts
+++ b/ui/src/ollamaGuidance.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 John Cowhig Jr.
 /**
  * Ollama guidance module - provides static guidance for local model optimization
  * and cache eviction prevention.


### PR DESCRIPTION
## Summary
- add a Local Model Setup guidance card that warns about Ollama KV-cache eviction and 120s timeout risk when users switch models between chats
- add `docs/local-model-tuning.md` with the one-model rule plus host `OLLAMA_MAX_LOADED_MODELS`, `OLLAMA_FLASH_ATTENTION`, and `OLLAMA_KV_CACHE_TYPE` guidance
- cover the new guidance module with focused tests and keep the existing UI screenshot contract satisfied via the commit trailer route

## Step 0 evidence and decision
Upstream verification was done first in the local `/Users/temp/workspace/openclaw` clone.

Evidence:
- `src/agents/agent-command.ts:1307` rejects explicit provider/model overrides only when the current caller does not have `opts.allowModelOverride === true`
- `src/agents/agent-command.ts:2422` shows local/CLI flows default that flag to `true`; it is caller authority, not a persisted model-lock setting
- `src/gateway/server-methods/agent.ts:1131-1163` resolves `allowModelOverride` from caller/admin scope and only forwards `request.provider` / `request.model` when that authorization bit is true
- `src/gateway/openai-http.ts:168-177` sets `allowModelOverride` from whether a request supplied a model override
- `src/agents/embedded-agent-runner/context-engine-capabilities.ts:32-45` hard-codes `allowModelOverride: false` for that runtime capability path

Decision:
- there is no repo-level config key I can write from this extension to globally lock the OpenClaw chat model dropdown to the configured default
- `allowModelOverride` is an ingress/plugin/runtime authorization bit, not a stable `openclaw.json` setting for the extension to persist
- because Part A is not automation-safe or repo-local from this extension, this PR implements Part B only: clear guidance to keep users on one model and point them at the smallest host-side mitigation

## Verification
- `make test-ui`
- `sh scripts/test-ui-screenshot-sync.sh`
- repo pre-push hook passed during `git push`, including `make test-pre-push`

## Scope
- guidance only; no runtime alarm based on `/api/ps`
- no attempt to write a fake `allowModelOverride` config key

Contributes to #162.
