### PR TITLE
docs: sync roadmap status to v0.3.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,14 @@ This repo is a small, maintained product surface, not an open-ended experiment. 
 ## Current Roadmap
 
 - Treat issue [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12) as the source of truth for roadmap and decision gates.
-- MVP is complete enough to share: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, host Ollama setup, execution mode UX, repo metadata, `.env` documentation, readiness checks, build validation, and a real Docker Desktop stable-channel smoke pass for `v0.3.4`.
+- Current live status as of 2026-06-26: latest release is `v0.3.6`; GHCR `stable` was promoted to `v0.3.6`; pinned GHCR and Docker Hub `0.3.6` install validation was recorded in #86; the latest committed real Docker Desktop stable-channel smoke packet remains `v0.3.4`.
+- MVP is complete enough to share: GHCR/channel install path, update/restart flow, localhost Control UI bootstrap, token retry UX, first-run provider fork and chat gating, host Ollama setup, execution mode UX, repo metadata, `.env` documentation, readiness checks, build validation, and committed Docker Desktop stable-channel smoke evidence.
 - Default post-MVP posture is pause unless outside traction appears or a release/distribution gate fails and needs a small reproducible fix.
-- Remaining roadmap work is long-term hardening:
-  1. [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65) longer-term security, hardening, supply-chain, and network migration epic.
+- Active gates and follow-ups are:
+  1. [#86](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/86) Docker Marketplace submission governance gate; repo-side release verification is not the blocker for `v0.3.6`.
+  2. [#156](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/156)-[#160](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/160) local-model performance/supportability follow-ups; treat them as post-MVP, not a reason to restart broad feature work.
+  3. [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65) longer-term security, hardening, supply-chain, and network migration epic.
+- [#161](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/pull/161) merged on 2026-06-26 as a docs-only OpenSpec hardware-profile design package; do not reopen that planning lane unless working a specific follow-up issue.
 - Native migration after a successful Docker Desktop trial is documented in `docs/native-migration-investigation.md`; keep it manual/documentation-only unless real user demand justifies reopening implementation work.
 - Treat [#2](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/2) and [#13](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/13) as historical execution-mode context, not active implementation tracks.
 - Do not start new feature branches from stale priority notes. Re-check #12, open issues, and the latest merged PRs first.

--- a/README.md
+++ b/README.md
@@ -374,15 +374,15 @@ Safe extension-level diagnostics are limited to project-specific state: containe
 
 The roadmap source of truth is [issue #12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12). Keep this section aligned with that issue.
 
-Current status: the MVP is complete enough to share. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary. A real Docker Desktop stable-channel smoke pass for `v0.3.4` is captured in [docs/exploratory/2026-05-22-stable-channel-smoke/](docs/exploratory/2026-05-22-stable-channel-smoke/).
+Current status as of 2026-06-26: the MVP is complete enough to share. The latest release is `v0.3.6`, GHCR `stable` was promoted to `v0.3.6`, and the pinned GHCR/Docker Hub `0.3.6` install path is recorded in #86. The release/channel image path exists, the extension can update its runtime image, the localhost Control UI launch path bootstraps the gateway token, first-run provider setup is gated before chat, host Ollama setup is available, execution mode changes restart OpenClaw to reload cached exec approvals, and the README documents the current provider-auth, `.env`, host-Ollama offline-first behavior, and host-posture boundary. The latest committed real Docker Desktop stable-channel UI smoke packet remains `v0.3.4` in [docs/exploratory/2026-05-22-stable-channel-smoke/](docs/exploratory/2026-05-22-stable-channel-smoke/).
 
 Native migration after a successful Docker Desktop trial is documented as a manual investigation path in [docs/native-migration-investigation.md](docs/native-migration-investigation.md). Do not build native migration automation until real user demand and upstream OpenClaw portable-state guidance justify it.
 
 The repo should now move in this order:
 
 1. Pause unless outside users, upstream, or release/distribution friction provide evidence that more work is worth doing.
-2. Keep the release/channel image path and public landing page current when a real release or verification failure needs attention.
-3. Treat host Ollama as the supported offline-first local model path after initial setup.
+2. Keep #86 as the active Marketplace submission governance gate; do not treat it as a repo-side implementation blocker unless submission validation exposes a reproducible failure.
+3. Treat host Ollama as the supported offline-first local model path after initial setup; #156-#160 are post-MVP supportability follow-ups, and #161 now records the merged OpenSpec design package.
 4. Defer bundled local inference runtime work and native migration automation unless real user traction justifies them.
 
 The developer-only local update path remains `make update-extension`. The release-image path is the preferred end-user path; local builds remain useful for development and validation.

--- a/docs/submission-readiness.md
+++ b/docs/submission-readiness.md
@@ -24,14 +24,18 @@ Use this path for a 5-10 minute functional review on macOS with Docker Desktop.
 The extension is not listed in the Docker Extensions Marketplace yet, so this
 review path uses the GHCR stable channel.
 
-Current validated release/install tag: `v0.3.5`.
+Current validated release/install tag: `v0.3.6`.
 Latest committed manual stable-channel smoke packet: `v0.3.4` at
 `docs/exploratory/2026-05-22-stable-channel-smoke/`.
+The `v0.3.6` release verification recorded in #86 confirms pinned GHCR and
+Docker Hub install validation plus GHCR `stable` channel parity. The manual
+stable-channel Docker Desktop UI smoke packet has not been refreshed since
+`v0.3.4`.
 
 If you want a timestamped evidence packet before starting, run:
 
 ```bash
-make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.5
+make create-smoke-report RELEASE_CHANNEL=stable RELEASE_TAG=v0.3.6
 ```
 
 That scaffolds a report under `docs/exploratory/` with the preflight commands,
@@ -68,7 +72,7 @@ Maintainer release-channel validation:
 
 ```bash
 make verify-channel-install RELEASE_CHANNEL=stable
-make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.5
+make verify-channel-install RELEASE_CHANNEL=stable EXPECTED_RELEASE_TAG=v0.3.6
 ```
 
 Use `DRY_RUN=1` when you want to validate command construction without mutating Docker Desktop.
@@ -100,12 +104,15 @@ Use `DRY_RUN=1` when you want to validate command construction without mutating 
 
 Open issues at submission time:
 
+- [#86](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/86): Docker Marketplace submission governance gate for the current `docker.io/jcowhigjr/openclaw-docker-desktop-extension:0.3.6` submission image.
 - [#65](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/65): long-term security, hardening, supply-chain, and network migration epic.
+- [#156](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/156): large-prompt Ollama chats can hit OpenClaw's 120s LLM idle-timeout watchdog.
+- [#157](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/157)-[#160](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/160): post-MVP local-model performance and supportability proposals.
 - [#12](https://github.com/jcowhigjr/openclaw-docker-desktop-extension/issues/12): roadmap and decision gates tracker.
 
 Native migration after a Docker Desktop trial is documented as a manual investigation path in [native-migration-investigation.md](native-migration-investigation.md).
 
-These are not blockers for an external review of the current Docker Desktop extension path.
+These are not blockers for an external review of the current Docker Desktop extension path unless the review specifically requires Docker Marketplace listing, a refreshed manual stable-channel UI smoke packet, or large-prompt local Ollama reliability.
 
 ## Suggested Reviewer Questions
 


### PR DESCRIPTION
## Summary
- sync AGENTS roadmap guidance to the current v0.3.6 release and post-MVP posture
- refresh the README roadmap section so it matches issue #12 and the current #86 governance gate
- update the submission-readiness packet to the validated v0.3.6 install path while preserving the last committed manual stable-channel smoke packet reference

## Verification
- make test-docs-landing-page
- make test-pre-push

Contributes to #12.